### PR TITLE
fix(es): full support for shortcut properties

### DIFF
--- a/packages/es-schemas/src/async_search_delete.ts
+++ b/packages/es-schemas/src/async_search_delete.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/async_search_get.ts
+++ b/packages/es-schemas/src/async_search_get.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -158,6 +159,9 @@ export const SearchAggregationProfile = z.object({
   get children () { return SearchAggregationProfile.array().optional() }
 }).meta({ id: 'SearchAggregationProfile' })
 export type SearchAggregationProfile = z.infer<typeof SearchAggregationProfile>
+
+export const SearchBoundaryScanner = z.enum(['chars', 'sentence', 'word']).meta({ id: 'SearchBoundaryScanner' })
+export type SearchBoundaryScanner = z.infer<typeof SearchBoundaryScanner>
 
 export interface SearchCollectorShape {
   name: string
@@ -383,8 +387,3929 @@ export const SearchFetchProfile = z.object({
 }).meta({ id: 'SearchFetchProfile' })
 export type SearchFetchProfile = z.infer<typeof SearchFetchProfile>
 
+/** Path to field or array of paths. Some API's support wildcards in the path to select multiple fields. */
+export const Field = z.string().meta({ id: 'Field' })
+export type Field = z.infer<typeof Field>
+
+export const Name = z.string().meta({ id: 'Name' })
+export type Name = z.infer<typeof Name>
+
+/** A reference to a field with formatting instructions on how to return the value */
+export const QueryDslFieldAndFormat = z.object({
+  field: Field.describe('A wildcard pattern. The request returns values for field names matching this pattern.'),
+  format: z.string().describe('The format in which the values are returned.').optional(),
+  include_unmapped: z.boolean().optional()
+}).meta({ id: 'QueryDslFieldAndFormat' })
+export type QueryDslFieldAndFormat = z.infer<typeof QueryDslFieldAndFormat>
+
+export const SearchHighlighterType = z.union([z.enum(['plain', 'fvh', 'unified']), z.string()]).meta({ id: 'SearchHighlighterType' })
+export type SearchHighlighterType = z.infer<typeof SearchHighlighterType>
+
+export const SearchHighlighterFragmenter = z.enum(['simple', 'span']).meta({ id: 'SearchHighlighterFragmenter' })
+export type SearchHighlighterFragmenter = z.infer<typeof SearchHighlighterFragmenter>
+
+export const QueryDslQueryBase = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional()
+}).meta({ id: 'QueryDslQueryBase' })
+export type QueryDslQueryBase = z.infer<typeof QueryDslQueryBase>
+
+/** The minimum number of terms that should match as integer, percentage or range */
+export const MinimumShouldMatch = z.union([integer, z.string()]).meta({ id: 'MinimumShouldMatch' })
+export type MinimumShouldMatch = z.infer<typeof MinimumShouldMatch>
+
+export interface QueryDslBoolQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  filter?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+  minimum_should_match?: MinimumShouldMatch | undefined
+  must?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+  must_not?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+  should?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+}
+export const QueryDslBoolQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  get filter (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('The clause (query) must appear in matching documents. However, unlike `must`, the score of the query will be ignored.').optional() },
+  minimum_should_match: MinimumShouldMatch.describe('Specifies the number or percentage of `should` clauses returned documents must match.').optional(),
+  get must (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('The clause (query) must appear in matching documents and will contribute to the score.').optional() },
+  get must_not (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('The clause (query) must not appear in the matching documents. Because scoring is ignored, a score of `0` is returned for all documents.').optional() },
+  get should (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('The clause (query) should appear in the matching document.').optional() }
+}).meta({ id: 'QueryDslBoolQuery' })
+export type QueryDslBoolQuery = z.infer<typeof QueryDslBoolQuery>
+
+export interface QueryDslBoostingQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  negative_boost: double
+  negative: QueryDslQueryContainerShape
+  positive: QueryDslQueryContainerShape
+}
+export const QueryDslBoostingQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  negative_boost: double.describe('Floating point number between 0 and 1.0 used to decrease the relevance scores of documents matching the `negative` query.'),
+  get negative () { return QueryDslQueryContainer.describe('Query used to decrease the relevance score of matching documents.') },
+  get positive () { return QueryDslQueryContainer.describe('Any returned documents must match this query.') }
+}).meta({ id: 'QueryDslBoostingQuery' })
+export type QueryDslBoostingQuery = z.infer<typeof QueryDslBoostingQuery>
+
+export const QueryDslOperator = z.enum(['and', 'AND', 'or', 'OR']).meta({ id: 'QueryDslOperator' })
+export type QueryDslOperator = z.infer<typeof QueryDslOperator>
+
+export const QueryDslCommonTermsQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  analyzer: z.string().optional(),
+  cutoff_frequency: double.optional(),
+  high_freq_operator: QueryDslOperator.optional(),
+  low_freq_operator: QueryDslOperator.optional(),
+  minimum_should_match: MinimumShouldMatch.optional(),
+  query: z.string()
+}).meta({ id: 'QueryDslCommonTermsQuery' })
+export type QueryDslCommonTermsQuery = z.infer<typeof QueryDslCommonTermsQuery>
+
+export const QueryDslCombinedFieldsOperator = z.enum(['or', 'and']).meta({ id: 'QueryDslCombinedFieldsOperator' })
+export type QueryDslCombinedFieldsOperator = z.infer<typeof QueryDslCombinedFieldsOperator>
+
+export const QueryDslCombinedFieldsZeroTerms = z.enum(['none', 'all']).meta({ id: 'QueryDslCombinedFieldsZeroTerms' })
+export type QueryDslCombinedFieldsZeroTerms = z.infer<typeof QueryDslCombinedFieldsZeroTerms>
+
+export const QueryDslCombinedFieldsQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  fields: z.array(Field).describe('List of fields to search. Field wildcard patterns are allowed. Only `text` fields are supported, and they must all have the same search `analyzer`.'),
+  query: z.string().describe('Text to search for in the provided `fields`. The `combined_fields` query analyzes the provided text before performing a search.'),
+  auto_generate_synonyms_phrase_query: z.boolean().describe('If true, match phrase queries are automatically created for multi-term synonyms.').optional(),
+  operator: QueryDslCombinedFieldsOperator.describe('Boolean logic used to interpret text in the query value.').optional(),
+  minimum_should_match: MinimumShouldMatch.describe('Minimum number of clauses that must match for a document to be returned.').optional(),
+  zero_terms_query: QueryDslCombinedFieldsZeroTerms.describe('Indicates whether no documents are returned if the analyzer removes all tokens, such as when using a `stop` filter.').optional()
+}).meta({ id: 'QueryDslCombinedFieldsQuery' })
+export type QueryDslCombinedFieldsQuery = z.infer<typeof QueryDslCombinedFieldsQuery>
+
+export interface QueryDslConstantScoreQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  filter: QueryDslQueryContainerShape
+}
+export const QueryDslConstantScoreQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  get filter () { return QueryDslQueryContainer.describe('Filter query you wish to run. Any returned documents must match this query. Filter queries do not calculate relevance scores. To speed up performance, Elasticsearch automatically caches frequently used filter queries.') }
+}).meta({ id: 'QueryDslConstantScoreQuery' })
+export type QueryDslConstantScoreQuery = z.infer<typeof QueryDslConstantScoreQuery>
+
+export interface QueryDslDisMaxQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  queries: QueryDslQueryContainerShape[]
+  tie_breaker?: double | undefined
+}
+export const QueryDslDisMaxQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  get queries () { return QueryDslQueryContainer.array().describe('One or more query clauses. Returned documents must match one or more of these queries. If a document matches multiple queries, Elasticsearch uses the highest relevance score.') },
+  tie_breaker: double.describe('Floating point number between 0 and 1.0 used to increase the relevance scores of documents matching multiple query clauses.').optional()
+}).meta({ id: 'QueryDslDisMaxQuery' })
+export type QueryDslDisMaxQuery = z.infer<typeof QueryDslDisMaxQuery>
+
+export const QueryDslDistanceFeatureQueryBase = z.object({
+  ...QueryDslQueryBase.shape,
+  origin: z.any().describe('Date or point of origin used to calculate distances. If the `field` value is a `date` or `date_nanos` field, the `origin` value must be a date. Date Math, such as `now-1h`, is supported. If the field value is a `geo_point` field, the `origin` value must be a geopoint.'),
+  pivot: z.any().describe('Distance from the `origin` at which relevance scores receive half of the `boost` value. If the `field` value is a `date` or `date_nanos` field, the `pivot` value must be a time unit, such as `1h` or `10d`. If the `field` value is a `geo_point` field, the `pivot` value must be a distance unit, such as `1km` or `12m`.'),
+  field: Field.describe('Name of the field used to calculate distances. This field must meet the following criteria: be a `date`, `date_nanos` or `geo_point` field; have an `index` mapping parameter value of `true`, which is the default; have an `doc_values` mapping parameter value of `true`, which is the default.')
+}).meta({ id: 'QueryDslDistanceFeatureQueryBase' })
+export type QueryDslDistanceFeatureQueryBase = z.infer<typeof QueryDslDistanceFeatureQueryBase>
+
+export const QueryDslUntypedDistanceFeatureQuery = z.object({
+  ...QueryDslDistanceFeatureQueryBase.shape
+}).meta({ id: 'QueryDslUntypedDistanceFeatureQuery' })
+export type QueryDslUntypedDistanceFeatureQuery = z.infer<typeof QueryDslUntypedDistanceFeatureQuery>
+
+export const QueryDslGeoDistanceFeatureQuery = z.object({
+  ...QueryDslDistanceFeatureQueryBase.shape
+}).meta({ id: 'QueryDslGeoDistanceFeatureQuery' })
+export type QueryDslGeoDistanceFeatureQuery = z.infer<typeof QueryDslGeoDistanceFeatureQuery>
+
+export const QueryDslDateDistanceFeatureQuery = z.object({
+  ...QueryDslDistanceFeatureQueryBase.shape
+}).meta({ id: 'QueryDslDateDistanceFeatureQuery' })
+export type QueryDslDateDistanceFeatureQuery = z.infer<typeof QueryDslDateDistanceFeatureQuery>
+
+export const QueryDslDistanceFeatureQuery = z.union([QueryDslUntypedDistanceFeatureQuery, QueryDslGeoDistanceFeatureQuery, QueryDslDateDistanceFeatureQuery]).meta({ id: 'QueryDslDistanceFeatureQuery' })
+export type QueryDslDistanceFeatureQuery = z.infer<typeof QueryDslDistanceFeatureQuery>
+
+export const QueryDslExistsQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  field: Field.describe('Name of the field you wish to search.')
+}).meta({ id: 'QueryDslExistsQuery' })
+export type QueryDslExistsQuery = z.infer<typeof QueryDslExistsQuery>
+
+export const QueryDslFunctionBoostMode = z.enum(['multiply', 'replace', 'sum', 'avg', 'max', 'min']).meta({ id: 'QueryDslFunctionBoostMode' })
+export type QueryDslFunctionBoostMode = z.infer<typeof QueryDslFunctionBoostMode>
+
+export const QueryDslMultiValueMode = z.enum(['min', 'max', 'avg', 'sum']).meta({ id: 'QueryDslMultiValueMode' })
+export type QueryDslMultiValueMode = z.infer<typeof QueryDslMultiValueMode>
+
+export const QueryDslDecayFunctionBase = z.object({
+  multi_value_mode: QueryDslMultiValueMode.describe('Determines how the distance is calculated when a field used for computing the decay contains multiple values.').optional()
+}).meta({ id: 'QueryDslDecayFunctionBase' })
+export type QueryDslDecayFunctionBase = z.infer<typeof QueryDslDecayFunctionBase>
+
+export const QueryDslUntypedDecayFunction = z.object({
+  multi_value_mode: QueryDslMultiValueMode.describe('Determines how the distance is calculated when a field used for computing the decay contains multiple values.').optional()
+}).catchall(z.any()).meta({ id: 'QueryDslUntypedDecayFunction' })
+export type QueryDslUntypedDecayFunction = z.infer<typeof QueryDslUntypedDecayFunction>
+
+export const QueryDslDateDecayFunction = z.object({
+  multi_value_mode: QueryDslMultiValueMode.describe('Determines how the distance is calculated when a field used for computing the decay contains multiple values.').optional()
+}).catchall(z.any()).meta({ id: 'QueryDslDateDecayFunction' })
+export type QueryDslDateDecayFunction = z.infer<typeof QueryDslDateDecayFunction>
+
+export const QueryDslNumericDecayFunction = z.object({
+  multi_value_mode: QueryDslMultiValueMode.describe('Determines how the distance is calculated when a field used for computing the decay contains multiple values.').optional()
+}).catchall(z.any()).meta({ id: 'QueryDslNumericDecayFunction' })
+export type QueryDslNumericDecayFunction = z.infer<typeof QueryDslNumericDecayFunction>
+
+export const QueryDslGeoDecayFunction = z.object({
+  multi_value_mode: QueryDslMultiValueMode.describe('Determines how the distance is calculated when a field used for computing the decay contains multiple values.').optional()
+}).catchall(z.any()).meta({ id: 'QueryDslGeoDecayFunction' })
+export type QueryDslGeoDecayFunction = z.infer<typeof QueryDslGeoDecayFunction>
+
+export const QueryDslDecayFunction = z.union([QueryDslUntypedDecayFunction, QueryDslDateDecayFunction, QueryDslNumericDecayFunction, QueryDslGeoDecayFunction]).meta({ id: 'QueryDslDecayFunction' })
+export type QueryDslDecayFunction = z.infer<typeof QueryDslDecayFunction>
+
+export const QueryDslFieldValueFactorModifier = z.enum(['none', 'log', 'log1p', 'log2p', 'ln', 'ln1p', 'ln2p', 'square', 'sqrt', 'reciprocal']).meta({ id: 'QueryDslFieldValueFactorModifier' })
+export type QueryDslFieldValueFactorModifier = z.infer<typeof QueryDslFieldValueFactorModifier>
+
+export const QueryDslFieldValueFactorScoreFunction = z.object({
+  field: Field.describe('Field to be extracted from the document.'),
+  factor: double.describe('Optional factor to multiply the field value with.').optional(),
+  missing: double.describe('Value used if the document doesn’t have that field. The modifier and factor are still applied to it as though it were read from the document.').optional(),
+  modifier: QueryDslFieldValueFactorModifier.describe('Modifier to apply to the field value.').optional()
+}).meta({ id: 'QueryDslFieldValueFactorScoreFunction' })
+export type QueryDslFieldValueFactorScoreFunction = z.infer<typeof QueryDslFieldValueFactorScoreFunction>
+
+export const QueryDslRandomScoreFunction = z.object({
+  field: Field.optional(),
+  seed: z.union([long, z.string()]).optional()
+}).meta({ id: 'QueryDslRandomScoreFunction' })
+export type QueryDslRandomScoreFunction = z.infer<typeof QueryDslRandomScoreFunction>
+
+export const Metadata = z.record(z.string(), z.any()).meta({ id: 'Metadata' })
+export type Metadata = z.infer<typeof Metadata>
+
+export const AggregationsAggregation = z.object({
+}).meta({ id: 'AggregationsAggregation' })
+export type AggregationsAggregation = z.infer<typeof AggregationsAggregation>
+
+/** Base type for bucket aggregations. These aggregations also accept sub-aggregations. */
+export const AggregationsBucketAggregationBase = z.object({
+}).meta({ id: 'AggregationsBucketAggregationBase' })
+export type AggregationsBucketAggregationBase = z.infer<typeof AggregationsBucketAggregationBase>
+
+export interface AggregationsAdjacencyMatrixAggregationShape {
+  filters?: Record<string, QueryDslQueryContainerShape> | undefined
+  separator?: string | undefined
+}
+export const AggregationsAdjacencyMatrixAggregation = z.object({
+  get filters (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof QueryDslQueryContainer>> { return z.record(z.string(), QueryDslQueryContainer).describe('Filters used to create buckets. At least one filter is required.').optional() },
+  separator: z.string().describe('Separator used to concatenate filter names. Defaults to &.').optional()
+}).meta({ id: 'AggregationsAdjacencyMatrixAggregation' })
+export type AggregationsAdjacencyMatrixAggregation = z.infer<typeof AggregationsAdjacencyMatrixAggregation>
+
+export const AggregationsMinimumInterval = z.enum(['second', 'minute', 'hour', 'day', 'month', 'year']).meta({ id: 'AggregationsMinimumInterval' })
+export type AggregationsMinimumInterval = z.infer<typeof AggregationsMinimumInterval>
+
+export const EpochTime = z.any().meta({ id: 'EpochTime' })
+export type EpochTime = z.infer<typeof EpochTime>
+
+/**
+ * A date and time, either as a string whose format can depend on the context (defaulting to ISO 8601), or a
+ * number of milliseconds since the Epoch. Elasticsearch accepts both as input, but will generally output a string
+ * representation.
+ */
+export const DateTime = z.union([z.string(), EpochTime]).meta({ id: 'DateTime' })
+export type DateTime = z.infer<typeof DateTime>
+
+export const TimeZone = z.string().meta({ id: 'TimeZone' })
+export type TimeZone = z.infer<typeof TimeZone>
+
+export interface AggregationsAutoDateHistogramAggregationShape {
+  buckets?: integer | undefined
+  field?: Field | undefined
+  format?: string | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
+  missing?: DateTime | undefined
+  offset?: string | undefined
+  params?: Record<string, unknown> | undefined
+  script?: ScriptShape | undefined
+  time_zone?: TimeZone | undefined
+}
+export const AggregationsAutoDateHistogramAggregation = z.object({
+  buckets: integer.describe('The target number of buckets.').optional(),
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
+  params: z.record(z.string(), z.any()).optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  time_zone: TimeZone.describe('Time zone ID.').optional()
+}).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
+export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
+
+export const AggregationsMissing = z.union([z.string(), integer, double, z.boolean()]).meta({ id: 'AggregationsMissing' })
+export type AggregationsMissing = z.infer<typeof AggregationsMissing>
+
+export interface AggregationsMetricAggregationBaseShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+}
+export const AggregationsMetricAggregationBase = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() }
+}).meta({ id: 'AggregationsMetricAggregationBase' })
+export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
+
+export interface AggregationsFormatMetricAggregationBaseShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  format?: string | undefined
+}
+export const AggregationsFormatMetricAggregationBase = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  format: z.string().optional()
+}).meta({ id: 'AggregationsFormatMetricAggregationBase' })
+export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
+
+export interface AggregationsAverageAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  format?: string | undefined
+}
+export const AggregationsAverageAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  format: z.string().optional()
+}).meta({ id: 'AggregationsAverageAggregation' })
+export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
+
+/**
+ * Buckets path can be expressed in different ways, and an aggregation may accept some or all of these
+ * forms depending on its type. Please refer to each aggregation's documentation to know what buckets
+ * path forms they accept.
+ */
+export const AggregationsBucketsPath = z.union([z.string(), z.array(z.string()), z.record(z.string(), z.string())]).meta({ id: 'AggregationsBucketsPath' })
+export type AggregationsBucketsPath = z.infer<typeof AggregationsBucketsPath>
+
+export const AggregationsBucketPathAggregation = z.object({
+  buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional()
+}).meta({ id: 'AggregationsBucketPathAggregation' })
+export type AggregationsBucketPathAggregation = z.infer<typeof AggregationsBucketPathAggregation>
+
+export const AggregationsGapPolicy = z.enum(['skip', 'insert_zeros', 'keep_values']).meta({ id: 'AggregationsGapPolicy' })
+export type AggregationsGapPolicy = z.infer<typeof AggregationsGapPolicy>
+
+export const AggregationsPipelineAggregationBase = z.object({
+  ...AggregationsBucketPathAggregation.shape,
+  format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
+  gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional()
+}).meta({ id: 'AggregationsPipelineAggregationBase' })
+export type AggregationsPipelineAggregationBase = z.infer<typeof AggregationsPipelineAggregationBase>
+
+export const AggregationsAverageBucketAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape
+}).meta({ id: 'AggregationsAverageBucketAggregation' })
+export type AggregationsAverageBucketAggregation = z.infer<typeof AggregationsAverageBucketAggregation>
+
+export const AggregationsTDigestExecutionHint = z.enum(['default', 'high_accuracy']).meta({ id: 'AggregationsTDigestExecutionHint' })
+export type AggregationsTDigestExecutionHint = z.infer<typeof AggregationsTDigestExecutionHint>
+
+export interface AggregationsBoxplotAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  compression?: double | undefined
+  execution_hint?: AggregationsTDigestExecutionHint | undefined
+}
+export const AggregationsBoxplotAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
+  execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
+}).meta({ id: 'AggregationsBoxplotAggregation' })
+export type AggregationsBoxplotAggregation = z.infer<typeof AggregationsBoxplotAggregation>
+
+export interface AggregationsBucketScriptAggregationShape {
+  buckets_path?: AggregationsBucketsPath | undefined
+  format?: string | undefined
+  gap_policy?: AggregationsGapPolicy | undefined
+  script?: ScriptShape | undefined
+}
+export const AggregationsBucketScriptAggregation = z.object({
+  buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
+  format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
+  gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
+}).meta({ id: 'AggregationsBucketScriptAggregation' })
+export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
+
+export interface AggregationsBucketSelectorAggregationShape {
+  buckets_path?: AggregationsBucketsPath | undefined
+  format?: string | undefined
+  gap_policy?: AggregationsGapPolicy | undefined
+  script?: ScriptShape | undefined
+}
+export const AggregationsBucketSelectorAggregation = z.object({
+  buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
+  format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
+  gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
+}).meta({ id: 'AggregationsBucketSelectorAggregation' })
+export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
+
+export const SortOrder = z.enum(['asc', 'desc']).meta({ id: 'SortOrder' })
+export type SortOrder = z.infer<typeof SortOrder>
+
+export const ScoreSort = z.object({
+  order: SortOrder.optional()
+}).meta({ id: 'ScoreSort' })
+export type ScoreSort = z.infer<typeof ScoreSort>
+
+export const SortMode = z.enum(['min', 'max', 'sum', 'avg', 'median']).meta({ id: 'SortMode' })
+export type SortMode = z.infer<typeof SortMode>
+
+export const GeoDistanceType = z.enum(['arc', 'plane']).meta({ id: 'GeoDistanceType' })
+export type GeoDistanceType = z.infer<typeof GeoDistanceType>
+
+export const DistanceUnit = z.enum(['in', 'ft', 'yd', 'mi', 'nmi', 'km', 'm', 'cm', 'mm']).meta({ id: 'DistanceUnit' })
+export type DistanceUnit = z.infer<typeof DistanceUnit>
+
+export interface NestedSortValueShape {
+  filter?: QueryDslQueryContainerShape | undefined
+  max_children?: integer | undefined
+  nested?: NestedSortValueShape | undefined
+  path: Field
+}
+export const NestedSortValue = z.object({
+  get filter () { return QueryDslQueryContainer.optional() },
+  max_children: integer.optional(),
+  get nested () { return NestedSortValue.optional() },
+  path: Field
+}).meta({ id: 'NestedSortValue' })
+export type NestedSortValue = z.infer<typeof NestedSortValue>
+
+export interface GeoDistanceSortShape {
+  mode?: SortMode | undefined
+  distance_type?: GeoDistanceType | undefined
+  ignore_unmapped?: boolean | undefined
+  order?: SortOrder | undefined
+  unit?: DistanceUnit | undefined
+  nested?: NestedSortValueShape | undefined
+}
+export const GeoDistanceSort = z.looseObject({
+  mode: SortMode.optional(),
+  distance_type: GeoDistanceType.optional(),
+  ignore_unmapped: z.boolean().optional(),
+  order: SortOrder.optional(),
+  unit: DistanceUnit.optional(),
+  get nested () { return NestedSortValue.optional() }
+}).meta({ id: 'GeoDistanceSort' })
+export type GeoDistanceSort = z.infer<typeof GeoDistanceSort>
+
+export const ScriptSortType = z.enum(['string', 'number', 'version']).meta({ id: 'ScriptSortType' })
+export type ScriptSortType = z.infer<typeof ScriptSortType>
+
+export interface ScriptSortShape {
+  order?: SortOrder | undefined
+  script: ScriptShape
+  type?: ScriptSortType | undefined
+  mode?: SortMode | undefined
+  nested?: NestedSortValueShape | undefined
+}
+export const ScriptSort = z.object({
+  order: SortOrder.optional(),
+  get script () { return z.union([Script, ScriptSource]) },
+  type: ScriptSortType.optional(),
+  mode: SortMode.optional(),
+  get nested () { return NestedSortValue.optional() }
+}).meta({ id: 'ScriptSort' })
+export type ScriptSort = z.infer<typeof ScriptSort>
+
+export interface SortOptionsShape {
+  _score?: ScoreSort | undefined
+  _doc?: ScoreSort | undefined
+  _geo_distance?: GeoDistanceSortShape | undefined
+  _script?: ScriptSortShape | undefined
+}
+export const SortOptions = z.looseObject({
+  _score: ScoreSort.optional(),
+  _doc: ScoreSort.optional(),
+  get _geo_distance () { return GeoDistanceSort.optional() },
+  get _script () { return ScriptSort.optional() }
+}).meta({ id: 'SortOptions' })
+export type SortOptions = z.infer<typeof SortOptions>
+
+export type SortCombinationsShape = Field | SortOptionsShape
+export const SortCombinations: z.ZodType<SortCombinationsShape> = z.union([Field, z.lazy(() => SortOptions)]).meta({ id: 'SortCombinations' })
+export type SortCombinations = z.infer<typeof SortCombinations>
+
+export type SortShape = SortCombinationsShape | SortCombinationsShape[]
+export const Sort: z.ZodType<SortShape> = z.union([z.lazy(() => SortCombinations), z.array(z.lazy(() => SortCombinations))]).meta({ id: 'Sort' })
+export type Sort = z.infer<typeof Sort>
+
+export interface AggregationsBucketSortAggregationShape {
+  from?: integer | undefined
+  gap_policy?: AggregationsGapPolicy | undefined
+  size?: integer | undefined
+  sort?: SortShape | undefined
+}
+export const AggregationsBucketSortAggregation = z.object({
+  from: integer.describe('Buckets in positions prior to `from` will be truncated.').optional(),
+  gap_policy: AggregationsGapPolicy.describe('The policy to apply when gaps are found in the data.').optional(),
+  size: integer.describe('The number of buckets to return. Defaults to all buckets of the parent aggregation.').optional(),
+  get sort () { return Sort.describe('The list of fields to sort on.').optional() }
+}).meta({ id: 'AggregationsBucketSortAggregation' })
+export type AggregationsBucketSortAggregation = z.infer<typeof AggregationsBucketSortAggregation>
+
+/**
+ * A sibling pipeline aggregation which executes a two sample Kolmogorov–Smirnov test (referred
+ * to as a "K-S test" from now on) against a provided distribution, and the distribution implied
+ * by the documents counts in the configured sibling aggregation. Specifically, for some metric,
+ * assuming that the percentile intervals of the metric are known beforehand or have been computed
+ * by an aggregation, then one would use range aggregation for the sibling to compute the p-value
+ * of the distribution difference between the metric and the restriction of that metric to a subset
+ * of the documents. A natural use case is if the sibling aggregation range aggregation nested in a
+ * terms aggregation, in which case one compares the overall distribution of metric to its restriction
+ * to each term.
+ */
+export const AggregationsBucketKsAggregation = z.object({
+  ...AggregationsBucketPathAggregation.shape,
+  alternative: z.array(z.string()).describe('A list of string values indicating which K-S test alternative to calculate. The valid values are: "greater", "less", "two_sided". This parameter is key for determining the K-S statistic used when calculating the K-S test. Default value is all possible alternative hypotheses.').optional(),
+  fractions: z.array(double).describe('A list of doubles indicating the distribution of the samples with which to compare to the `buckets_path` results. In typical usage this is the overall proportion of documents in each bucket, which is compared with the actual document proportions in each bucket from the sibling aggregation counts. The default is to assume that overall documents are uniformly distributed on these buckets, which they would be if one used equal percentiles of a metric to define the bucket end points.').optional(),
+  sampling_method: z.string().describe('Indicates the sampling methodology when calculating the K-S test. Note, this is sampling of the returned values. This determines the cumulative distribution function (CDF) points used comparing the two samples. Default is `upper_tail`, which emphasizes the upper end of the CDF points. Valid options are: `upper_tail`, `uniform`, and `lower_tail`.').optional()
+}).meta({ id: 'AggregationsBucketKsAggregation' })
+export type AggregationsBucketKsAggregation = z.infer<typeof AggregationsBucketKsAggregation>
+
+export const AggregationsBucketCorrelationFunctionCountCorrelationIndicator = z.object({
+  doc_count: integer.describe('The total number of documents that initially created the expectations. It’s required to be greater than or equal to the sum of all values in the buckets_path as this is the originating superset of data to which the term values are correlated.'),
+  expectations: z.array(double).describe('An array of numbers with which to correlate the configured `bucket_path` values. The length of this value must always equal the number of buckets returned by the `bucket_path`.'),
+  fractions: z.array(double).describe('An array of fractions to use when averaging and calculating variance. This should be used if the pre-calculated data and the buckets_path have known gaps. The length of fractions, if provided, must equal expectations.').optional()
+}).meta({ id: 'AggregationsBucketCorrelationFunctionCountCorrelationIndicator' })
+export type AggregationsBucketCorrelationFunctionCountCorrelationIndicator = z.infer<typeof AggregationsBucketCorrelationFunctionCountCorrelationIndicator>
+
+export const AggregationsBucketCorrelationFunctionCountCorrelation = z.object({
+  indicator: AggregationsBucketCorrelationFunctionCountCorrelationIndicator.describe('The indicator with which to correlate the configured `bucket_path` values.')
+}).meta({ id: 'AggregationsBucketCorrelationFunctionCountCorrelation' })
+export type AggregationsBucketCorrelationFunctionCountCorrelation = z.infer<typeof AggregationsBucketCorrelationFunctionCountCorrelation>
+
+export const AggregationsBucketCorrelationFunction = z.object({
+  count_correlation: AggregationsBucketCorrelationFunctionCountCorrelation.describe('The configuration to calculate a count correlation. This function is designed for determining the correlation of a term value and a given metric.')
+}).meta({ id: 'AggregationsBucketCorrelationFunction' })
+export type AggregationsBucketCorrelationFunction = z.infer<typeof AggregationsBucketCorrelationFunction>
+
+/** A sibling pipeline aggregation which executes a correlation function on the configured sibling multi-bucket aggregation. */
+export const AggregationsBucketCorrelationAggregation = z.object({
+  ...AggregationsBucketPathAggregation.shape,
+  function: AggregationsBucketCorrelationFunction.describe('The correlation function to execute.')
+}).meta({ id: 'AggregationsBucketCorrelationAggregation' })
+export type AggregationsBucketCorrelationAggregation = z.infer<typeof AggregationsBucketCorrelationAggregation>
+
+export const AggregationsCardinalityExecutionMode = z.enum(['global_ordinals', 'segment_ordinals', 'direct', 'save_memory_heuristic', 'save_time_heuristic']).meta({ id: 'AggregationsCardinalityExecutionMode' })
+export type AggregationsCardinalityExecutionMode = z.infer<typeof AggregationsCardinalityExecutionMode>
+
+export interface AggregationsCardinalityAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  precision_threshold?: integer | undefined
+  rehash?: boolean | undefined
+  execution_hint?: AggregationsCardinalityExecutionMode | undefined
+}
+export const AggregationsCardinalityAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
+  rehash: z.boolean().optional(),
+  execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
+}).meta({ id: 'AggregationsCardinalityAggregation' })
+export type AggregationsCardinalityAggregation = z.infer<typeof AggregationsCardinalityAggregation>
+
+export interface AggregationsCartesianBoundsAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+}
+export const AggregationsCartesianBoundsAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() }
+}).meta({ id: 'AggregationsCartesianBoundsAggregation' })
+export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
+
+export interface AggregationsCartesianCentroidAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+}
+export const AggregationsCartesianCentroidAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() }
+}).meta({ id: 'AggregationsCartesianCentroidAggregation' })
+export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
+
+export const AggregationsCustomCategorizeTextAnalyzer = z.object({
+  char_filter: z.array(z.string()).optional(),
+  tokenizer: z.string().optional(),
+  filter: z.array(z.string()).optional()
+}).meta({ id: 'AggregationsCustomCategorizeTextAnalyzer' })
+export type AggregationsCustomCategorizeTextAnalyzer = z.infer<typeof AggregationsCustomCategorizeTextAnalyzer>
+
+export const AggregationsCategorizeTextAnalyzer = z.union([z.string(), AggregationsCustomCategorizeTextAnalyzer]).meta({ id: 'AggregationsCategorizeTextAnalyzer' })
+export type AggregationsCategorizeTextAnalyzer = z.infer<typeof AggregationsCategorizeTextAnalyzer>
+
+/**
+ * A multi-bucket aggregation that groups semi-structured text into buckets. Each text
+ * field is re-analyzed using a custom analyzer. The resulting tokens are then categorized
+ * creating buckets of similarly formatted text values. This aggregation works best with machine
+ * generated text like system logs. Only the first 100 analyzed tokens are used to categorize the text.
+ */
+export const AggregationsCategorizeTextAggregation = z.object({
+  field: Field.describe('The semi-structured text field to categorize.'),
+  max_unique_tokens: integer.describe('The maximum number of unique tokens at any position up to max_matched_tokens. Must be larger than 1. Smaller values use less memory and create fewer categories. Larger values will use more memory and create narrower categories. Max allowed value is 100.').optional(),
+  max_matched_tokens: integer.describe('The maximum number of token positions to match on before attempting to merge categories. Larger values will use more memory and create narrower categories. Max allowed value is 100.').optional(),
+  similarity_threshold: integer.describe('The minimum percentage of tokens that must match for text to be added to the category bucket. Must be between 1 and 100. The larger the value the narrower the categories. Larger values will increase memory usage and create narrower categories.').optional(),
+  categorization_filters: z.array(z.string()).describe('This property expects an array of regular expressions. The expressions are used to filter out matching sequences from the categorization field values. You can use this functionality to fine tune the categorization by excluding sequences from consideration when categories are defined. For example, you can exclude SQL statements that appear in your log files. This property cannot be used at the same time as categorization_analyzer. If you only want to define simple regular expression filters that are applied prior to tokenization, setting this property is the easiest method. If you also want to customize the tokenizer or post-tokenization filtering, use the categorization_analyzer property instead and include the filters as pattern_replace character filters.').optional(),
+  categorization_analyzer: AggregationsCategorizeTextAnalyzer.describe('The categorization analyzer specifies how the text is analyzed and tokenized before being categorized. The syntax is very similar to that used to define the analyzer in the analyze API. This property cannot be used at the same time as `categorization_filters`.').optional(),
+  shard_size: integer.describe('The number of categorization buckets to return from each shard before merging all the results.').optional(),
+  size: integer.describe('The number of buckets to return.').optional(),
+  min_doc_count: integer.describe('The minimum number of documents in a bucket to be returned to the results.').optional(),
+  shard_min_doc_count: integer.describe('The minimum number of documents in a bucket to be returned from the shard before merging.').optional()
+}).meta({ id: 'AggregationsCategorizeTextAggregation' })
+export type AggregationsCategorizeTextAggregation = z.infer<typeof AggregationsCategorizeTextAggregation>
+
+export const AggregationsChangePointAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape
+}).meta({ id: 'AggregationsChangePointAggregation' })
+export type AggregationsChangePointAggregation = z.infer<typeof AggregationsChangePointAggregation>
+
+export const RelationName = z.string().meta({ id: 'RelationName' })
+export type RelationName = z.infer<typeof RelationName>
+
+export const AggregationsChildrenAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  type: RelationName.describe('The child type that should be selected.').optional()
+}).meta({ id: 'AggregationsChildrenAggregation' })
+export type AggregationsChildrenAggregation = z.infer<typeof AggregationsChildrenAggregation>
+
+/** A field value. */
+export const FieldValue = z.union([long, double, z.string(), z.boolean(), z.null()]).meta({ id: 'FieldValue' })
+export type FieldValue = z.infer<typeof FieldValue>
+
+export const AggregationsCompositeAggregateKey = z.record(Field, FieldValue).meta({ id: 'AggregationsCompositeAggregateKey' })
+export type AggregationsCompositeAggregateKey = z.infer<typeof AggregationsCompositeAggregateKey>
+
+export const AggregationsMissingOrder = z.enum(['first', 'last', 'default']).meta({ id: 'AggregationsMissingOrder' })
+export type AggregationsMissingOrder = z.infer<typeof AggregationsMissingOrder>
+
+export const AggregationsValueType = z.enum(['string', 'long', 'double', 'number', 'date', 'date_nanos', 'ip', 'numeric', 'geo_point', 'boolean']).meta({ id: 'AggregationsValueType' })
+export type AggregationsValueType = z.infer<typeof AggregationsValueType>
+
+export interface AggregationsCompositeAggregationBaseShape {
+  field?: Field | undefined
+  missing_bucket?: boolean | undefined
+  missing_order?: AggregationsMissingOrder | undefined
+  script?: ScriptShape | undefined
+  value_type?: AggregationsValueType | undefined
+  order?: SortOrder | undefined
+}
+export const AggregationsCompositeAggregationBase = z.object({
+  field: Field.describe('Either `field` or `script` must be present').optional(),
+  missing_bucket: z.boolean().optional(),
+  missing_order: AggregationsMissingOrder.optional(),
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
+  value_type: AggregationsValueType.optional(),
+  order: SortOrder.optional()
+}).meta({ id: 'AggregationsCompositeAggregationBase' })
+export type AggregationsCompositeAggregationBase = z.infer<typeof AggregationsCompositeAggregationBase>
+
+export interface AggregationsCompositeTermsAggregationShape {
+  field?: Field | undefined
+  missing_bucket?: boolean | undefined
+  missing_order?: AggregationsMissingOrder | undefined
+  script?: ScriptShape | undefined
+  value_type?: AggregationsValueType | undefined
+  order?: SortOrder | undefined
+}
+export const AggregationsCompositeTermsAggregation = z.object({
+  field: Field.describe('Either `field` or `script` must be present').optional(),
+  missing_bucket: z.boolean().optional(),
+  missing_order: AggregationsMissingOrder.optional(),
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
+  value_type: AggregationsValueType.optional(),
+  order: SortOrder.optional()
+}).meta({ id: 'AggregationsCompositeTermsAggregation' })
+export type AggregationsCompositeTermsAggregation = z.infer<typeof AggregationsCompositeTermsAggregation>
+
+export interface AggregationsCompositeHistogramAggregationShape {
+  field?: Field | undefined
+  missing_bucket?: boolean | undefined
+  missing_order?: AggregationsMissingOrder | undefined
+  script?: ScriptShape | undefined
+  value_type?: AggregationsValueType | undefined
+  order?: SortOrder | undefined
+  interval: double
+}
+export const AggregationsCompositeHistogramAggregation = z.object({
+  field: Field.describe('Either `field` or `script` must be present').optional(),
+  missing_bucket: z.boolean().optional(),
+  missing_order: AggregationsMissingOrder.optional(),
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
+  value_type: AggregationsValueType.optional(),
+  order: SortOrder.optional(),
+  interval: double
+}).meta({ id: 'AggregationsCompositeHistogramAggregation' })
+export type AggregationsCompositeHistogramAggregation = z.infer<typeof AggregationsCompositeHistogramAggregation>
+
+/**
+ * A date histogram interval. Similar to `Duration` with additional units: `w` (week), `M` (month), `q` (quarter) and
+ * `y` (year)
+ */
+export const DurationLarge = z.string().meta({ id: 'DurationLarge' })
+export type DurationLarge = z.infer<typeof DurationLarge>
+
+export interface AggregationsCompositeDateHistogramAggregationShape {
+  field?: Field | undefined
+  missing_bucket?: boolean | undefined
+  missing_order?: AggregationsMissingOrder | undefined
+  script?: ScriptShape | undefined
+  value_type?: AggregationsValueType | undefined
+  order?: SortOrder | undefined
+  format?: string | undefined
+  calendar_interval?: DurationLarge | undefined
+  fixed_interval?: DurationLarge | undefined
+  offset?: Duration | undefined
+  time_zone?: TimeZone | undefined
+}
+export const AggregationsCompositeDateHistogramAggregation = z.object({
+  field: Field.describe('Either `field` or `script` must be present').optional(),
+  missing_bucket: z.boolean().optional(),
+  missing_order: AggregationsMissingOrder.optional(),
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
+  value_type: AggregationsValueType.optional(),
+  order: SortOrder.optional(),
+  format: z.string().optional(),
+  calendar_interval: DurationLarge.describe('Either `calendar_interval` or `fixed_interval` must be present').optional(),
+  fixed_interval: DurationLarge.describe('Either `calendar_interval` or `fixed_interval` must be present').optional(),
+  offset: Duration.optional(),
+  time_zone: TimeZone.optional()
+}).meta({ id: 'AggregationsCompositeDateHistogramAggregation' })
+export type AggregationsCompositeDateHistogramAggregation = z.infer<typeof AggregationsCompositeDateHistogramAggregation>
+
+export const CoordsGeoBounds = z.object({
+  top: double,
+  bottom: double,
+  left: double,
+  right: double
+}).meta({ id: 'CoordsGeoBounds' })
+export type CoordsGeoBounds = z.infer<typeof CoordsGeoBounds>
+
+export const TopLeftBottomRightGeoBounds = z.object({
+  top_left: GeoLocation,
+  bottom_right: GeoLocation
+}).meta({ id: 'TopLeftBottomRightGeoBounds' })
+export type TopLeftBottomRightGeoBounds = z.infer<typeof TopLeftBottomRightGeoBounds>
+
+export const TopRightBottomLeftGeoBounds = z.object({
+  top_right: GeoLocation,
+  bottom_left: GeoLocation
+}).meta({ id: 'TopRightBottomLeftGeoBounds' })
+export type TopRightBottomLeftGeoBounds = z.infer<typeof TopRightBottomLeftGeoBounds>
+
+export const WktGeoBounds = z.object({
+  wkt: z.string()
+}).meta({ id: 'WktGeoBounds' })
+export type WktGeoBounds = z.infer<typeof WktGeoBounds>
+
+/**
+ * A geo bounding box. It can be represented in various ways:
+ * - as 4 top/bottom/left/right coordinates
+ * - as 2 top_left / bottom_right points
+ * - as 2 top_right / bottom_left points
+ * - as a WKT bounding box
+ */
+export const GeoBounds = z.union([CoordsGeoBounds, TopLeftBottomRightGeoBounds, TopRightBottomLeftGeoBounds, WktGeoBounds]).meta({ id: 'GeoBounds' })
+export type GeoBounds = z.infer<typeof GeoBounds>
+
+export interface AggregationsCompositeGeoTileGridAggregationShape {
+  field?: Field | undefined
+  missing_bucket?: boolean | undefined
+  missing_order?: AggregationsMissingOrder | undefined
+  script?: ScriptShape | undefined
+  value_type?: AggregationsValueType | undefined
+  order?: SortOrder | undefined
+  precision?: integer | undefined
+  bounds?: GeoBounds | undefined
+}
+export const AggregationsCompositeGeoTileGridAggregation = z.object({
+  field: Field.describe('Either `field` or `script` must be present').optional(),
+  missing_bucket: z.boolean().optional(),
+  missing_order: AggregationsMissingOrder.optional(),
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
+  value_type: AggregationsValueType.optional(),
+  order: SortOrder.optional(),
+  precision: integer.optional(),
+  bounds: GeoBounds.optional()
+}).meta({ id: 'AggregationsCompositeGeoTileGridAggregation' })
+export type AggregationsCompositeGeoTileGridAggregation = z.infer<typeof AggregationsCompositeGeoTileGridAggregation>
+
+const AggregationsCompositeAggregationSourceExclusiveProps = z.union([z.object({ terms: z.lazy(() => AggregationsCompositeTermsAggregation) }), z.object({ histogram: z.lazy(() => AggregationsCompositeHistogramAggregation) }), z.object({ date_histogram: z.lazy(() => AggregationsCompositeDateHistogramAggregation) }), z.object({ geotile_grid: z.lazy(() => AggregationsCompositeGeoTileGridAggregation) })])
+
+export interface AggregationsCompositeAggregationSourceShape {
+  terms?: AggregationsCompositeTermsAggregation | undefined
+  histogram?: AggregationsCompositeHistogramAggregation | undefined
+  date_histogram?: AggregationsCompositeDateHistogramAggregation | undefined
+  geotile_grid?: AggregationsCompositeGeoTileGridAggregation | undefined
+}
+export const AggregationsCompositeAggregationSource: z.ZodType<AggregationsCompositeAggregationSourceShape> = AggregationsCompositeAggregationSourceExclusiveProps.meta({ id: 'AggregationsCompositeAggregationSource' })
+export type AggregationsCompositeAggregationSource = z.infer<typeof AggregationsCompositeAggregationSource>
+
+export interface AggregationsCompositeAggregationShape {
+  after?: AggregationsCompositeAggregateKey | undefined
+  size?: integer | undefined
+  sources?: Array<Record<string, AggregationsCompositeAggregationSourceShape>> | undefined
+}
+export const AggregationsCompositeAggregation = z.object({
+  after: AggregationsCompositeAggregateKey.describe('When paginating, use the `after_key` value returned in the previous response to retrieve the next page.').optional(),
+  size: integer.describe('The number of composite buckets that should be returned.').optional(),
+  get sources (): z.ZodOptional<z.ZodArray<z.ZodRecord<z.ZodString, typeof AggregationsCompositeAggregationSource>>> { return z.array(z.record(z.string(), AggregationsCompositeAggregationSource)).describe('The value sources used to build composite buckets. Keys are returned in the order of the `sources` definition.').optional() }
+}).meta({ id: 'AggregationsCompositeAggregation' })
+export type AggregationsCompositeAggregation = z.infer<typeof AggregationsCompositeAggregation>
+
+export const AggregationsCumulativeCardinalityAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape
+}).meta({ id: 'AggregationsCumulativeCardinalityAggregation' })
+export type AggregationsCumulativeCardinalityAggregation = z.infer<typeof AggregationsCumulativeCardinalityAggregation>
+
+export const AggregationsCumulativeSumAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape
+}).meta({ id: 'AggregationsCumulativeSumAggregation' })
+export type AggregationsCumulativeSumAggregation = z.infer<typeof AggregationsCumulativeSumAggregation>
+
+export const AggregationsCalendarInterval = z.enum(['second', '1s', 'minute', '1m', 'hour', '1h', 'day', '1d', 'week', '1w', 'month', '1M', 'quarter', '1q', 'year', '1y']).meta({ id: 'AggregationsCalendarInterval' })
+export type AggregationsCalendarInterval = z.infer<typeof AggregationsCalendarInterval>
+
+export const AggregationsExtendedBounds = z.object({
+  max: z.any().describe('Maximum value for the bound.').optional(),
+  min: z.any().describe('Minimum value for the bound.').optional()
+}).meta({ id: 'AggregationsExtendedBounds' })
+export type AggregationsExtendedBounds = z.infer<typeof AggregationsExtendedBounds>
+
+export const AggregationsAggregateOrder = z.union([z.record(Field, SortOrder), z.array(z.record(Field, SortOrder))]).meta({ id: 'AggregationsAggregateOrder' })
+export type AggregationsAggregateOrder = z.infer<typeof AggregationsAggregateOrder>
+
+export interface AggregationsDateHistogramAggregationShape {
+  calendar_interval?: AggregationsCalendarInterval | undefined
+  extended_bounds?: AggregationsExtendedBounds | undefined
+  hard_bounds?: AggregationsExtendedBounds | undefined
+  field?: Field | undefined
+  fixed_interval?: Duration | undefined
+  format?: string | undefined
+  interval?: Duration | undefined
+  min_doc_count?: integer | undefined
+  missing?: DateTime | undefined
+  offset?: Duration | undefined
+  order?: AggregationsAggregateOrder | undefined
+  params?: Record<string, unknown> | undefined
+  script?: ScriptShape | undefined
+  time_zone?: TimeZone | undefined
+  keyed?: boolean | undefined
+}
+export const AggregationsDateHistogramAggregation = z.object({
+  calendar_interval: AggregationsCalendarInterval.describe('Calendar-aware interval. Can be specified using the unit name, such as `month`, or as a single unit quantity, such as `1M`.').optional(),
+  extended_bounds: AggregationsExtendedBounds.describe('Enables extending the bounds of the histogram beyond the data itself.').optional(),
+  hard_bounds: AggregationsExtendedBounds.describe('Limits the histogram to specified bounds.').optional(),
+  field: Field.describe('The date field whose values are use to build a histogram.').optional(),
+  fixed_interval: Duration.describe('Fixed intervals: a fixed number of SI units and never deviate, regardless of where they fall on the calendar.').optional(),
+  format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
+  interval: Duration.optional(),
+  min_doc_count: integer.describe('Only returns buckets that have `min_doc_count` number of documents. By default, all buckets between the first bucket that matches documents and the last one are returned.').optional(),
+  missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
+  order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
+  params: z.record(z.string(), z.any()).optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
+  keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
+}).meta({ id: 'AggregationsDateHistogramAggregation' })
+export type AggregationsDateHistogramAggregation = z.infer<typeof AggregationsDateHistogramAggregation>
+
+export const DateMath = z.string().meta({ id: 'DateMath' })
+export type DateMath = z.infer<typeof DateMath>
+
+/**
+ * A date range limit, represented either as a DateMath expression or a number expressed
+ * according to the target field's precision.
+ */
+export const AggregationsFieldDateMath = z.union([DateMath, long]).meta({ id: 'AggregationsFieldDateMath' })
+export type AggregationsFieldDateMath = z.infer<typeof AggregationsFieldDateMath>
+
+export const AggregationsDateRangeExpression = z.object({
+  from: AggregationsFieldDateMath.describe('Start of the range (inclusive).').optional(),
+  key: z.string().describe('Custom key to return the range with.').optional(),
+  to: AggregationsFieldDateMath.describe('End of the range (exclusive).').optional()
+}).meta({ id: 'AggregationsDateRangeExpression' })
+export type AggregationsDateRangeExpression = z.infer<typeof AggregationsDateRangeExpression>
+
+export const AggregationsDateRangeAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  field: Field.describe('The date field whose values are use to build ranges.').optional(),
+  format: z.string().describe('The date format used to format `from` and `to` in the response.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  ranges: z.array(AggregationsDateRangeExpression).describe('Array of date ranges.').optional(),
+  time_zone: TimeZone.describe('Time zone used to convert dates from another time zone to UTC.').optional(),
+  keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and returns the ranges as a hash rather than an array.').optional()
+}).meta({ id: 'AggregationsDateRangeAggregation' })
+export type AggregationsDateRangeAggregation = z.infer<typeof AggregationsDateRangeAggregation>
+
+export const AggregationsDerivativeAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape
+}).meta({ id: 'AggregationsDerivativeAggregation' })
+export type AggregationsDerivativeAggregation = z.infer<typeof AggregationsDerivativeAggregation>
+
+export const AggregationsSamplerAggregationExecutionHint = z.enum(['map', 'global_ordinals', 'bytes_hash']).meta({ id: 'AggregationsSamplerAggregationExecutionHint' })
+export type AggregationsSamplerAggregationExecutionHint = z.infer<typeof AggregationsSamplerAggregationExecutionHint>
+
+export interface AggregationsDiversifiedSamplerAggregationShape {
+  execution_hint?: AggregationsSamplerAggregationExecutionHint | undefined
+  max_docs_per_value?: integer | undefined
+  script?: ScriptShape | undefined
+  shard_size?: integer | undefined
+  field?: Field | undefined
+}
+export const AggregationsDiversifiedSamplerAggregation = z.object({
+  execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
+  max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
+  field: Field.describe('The field used to provide values used for de-duplication.').optional()
+}).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
+export type AggregationsDiversifiedSamplerAggregation = z.infer<typeof AggregationsDiversifiedSamplerAggregation>
+
+export interface AggregationsExtendedStatsAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  format?: string | undefined
+  sigma?: double | undefined
+}
+export const AggregationsExtendedStatsAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  format: z.string().optional(),
+  sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
+}).meta({ id: 'AggregationsExtendedStatsAggregation' })
+export type AggregationsExtendedStatsAggregation = z.infer<typeof AggregationsExtendedStatsAggregation>
+
+export const AggregationsExtendedStatsBucketAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape,
+  sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
+}).meta({ id: 'AggregationsExtendedStatsBucketAggregation' })
+export type AggregationsExtendedStatsBucketAggregation = z.infer<typeof AggregationsExtendedStatsBucketAggregation>
+
+export const AggregationsTermsExclude = z.union([z.string(), z.array(z.string())]).meta({ id: 'AggregationsTermsExclude' })
+export type AggregationsTermsExclude = z.infer<typeof AggregationsTermsExclude>
+
+export const AggregationsTermsPartition = z.object({
+  num_partitions: long.describe('The number of partitions.'),
+  partition: long.describe('The partition number for this request.')
+}).meta({ id: 'AggregationsTermsPartition' })
+export type AggregationsTermsPartition = z.infer<typeof AggregationsTermsPartition>
+
+export const AggregationsTermsInclude = z.union([z.string(), z.array(z.string()), AggregationsTermsPartition]).meta({ id: 'AggregationsTermsInclude' })
+export type AggregationsTermsInclude = z.infer<typeof AggregationsTermsInclude>
+
+export const AggregationsFrequentItemSetsField = z.object({
+  field: Field,
+  exclude: AggregationsTermsExclude.describe('Values to exclude. Can be regular expression strings or arrays of strings of exact terms.').optional(),
+  include: AggregationsTermsInclude.describe('Values to include. Can be regular expression strings or arrays of strings of exact terms.').optional()
+}).meta({ id: 'AggregationsFrequentItemSetsField' })
+export type AggregationsFrequentItemSetsField = z.infer<typeof AggregationsFrequentItemSetsField>
+
+export interface AggregationsFrequentItemSetsAggregationShape {
+  fields: AggregationsFrequentItemSetsField[]
+  minimum_set_size?: integer | undefined
+  minimum_support?: double | undefined
+  size?: integer | undefined
+  filter?: QueryDslQueryContainerShape | undefined
+}
+export const AggregationsFrequentItemSetsAggregation = z.object({
+  fields: z.array(AggregationsFrequentItemSetsField).describe('Fields to analyze.'),
+  minimum_set_size: integer.describe('The minimum size of one item set.').optional(),
+  minimum_support: double.describe('The minimum support of one item set.').optional(),
+  size: integer.describe('The number of top item sets to return.').optional(),
+  get filter () { return QueryDslQueryContainer.describe('Query that filters documents from analysis.').optional() }
+}).meta({ id: 'AggregationsFrequentItemSetsAggregation' })
+export type AggregationsFrequentItemSetsAggregation = z.infer<typeof AggregationsFrequentItemSetsAggregation>
+
+/**
+ * Aggregation buckets. By default they are returned as an array, but if the aggregation has keys configured for
+ * the different buckets, the result is a dictionary.
+ */
+export const AggregationsBuckets = z.union([z.record(z.string(), z.any()), z.array(z.any())]).meta({ id: 'AggregationsBuckets' })
+export type AggregationsBuckets = z.infer<typeof AggregationsBuckets>
+
+export const AggregationsFiltersAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  filters: AggregationsBuckets.describe('Collection of queries from which to build buckets.').optional(),
+  other_bucket: z.boolean().describe('Set to `true` to add a bucket to the response which will contain all documents that do not match any of the given filters.').optional(),
+  other_bucket_key: z.string().describe('The key with which the other bucket is returned.').optional(),
+  keyed: z.boolean().describe('By default, the named filters aggregation returns the buckets as an object. Set to `false` to return the buckets as an array of objects.').optional()
+}).meta({ id: 'AggregationsFiltersAggregation' })
+export type AggregationsFiltersAggregation = z.infer<typeof AggregationsFiltersAggregation>
+
+export interface AggregationsGeoBoundsAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  wrap_longitude?: boolean | undefined
+}
+export const AggregationsGeoBoundsAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
+}).meta({ id: 'AggregationsGeoBoundsAggregation' })
+export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
+
+export interface AggregationsGeoCentroidAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  count?: long | undefined
+  location?: GeoLocation | undefined
+}
+export const AggregationsGeoCentroidAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  count: long.optional(),
+  location: GeoLocation.optional()
+}).meta({ id: 'AggregationsGeoCentroidAggregation' })
+export type AggregationsGeoCentroidAggregation = z.infer<typeof AggregationsGeoCentroidAggregation>
+
+export const AggregationsAggregationRange = z.object({
+  from: z.union([double, z.null()]).describe('Start of the range (inclusive).').optional(),
+  key: z.string().describe('Custom key to return the range with.').optional(),
+  to: z.union([double, z.null()]).describe('End of the range (exclusive).').optional()
+}).meta({ id: 'AggregationsAggregationRange' })
+export type AggregationsAggregationRange = z.infer<typeof AggregationsAggregationRange>
+
+export const AggregationsGeoDistanceAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  distance_type: GeoDistanceType.describe('The distance calculation type.').optional(),
+  field: Field.describe('A field of type `geo_point` used to evaluate the distance.').optional(),
+  origin: GeoLocation.describe('The origin  used to evaluate the distance.').optional(),
+  ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
+  unit: DistanceUnit.describe('The distance unit.').optional()
+}).meta({ id: 'AggregationsGeoDistanceAggregation' })
+export type AggregationsGeoDistanceAggregation = z.infer<typeof AggregationsGeoDistanceAggregation>
+
+/** A precision that can be expressed as a geohash length between 1 and 12, or a distance measure like "1km", "10m". */
+export const GeoHashPrecision = z.union([integer, z.string()]).meta({ id: 'GeoHashPrecision' })
+export type GeoHashPrecision = z.infer<typeof GeoHashPrecision>
+
+export const AggregationsGeoHashGridAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  bounds: GeoBounds.describe('The bounding box to filter the points in each bucket.').optional(),
+  field: Field.describe('Field containing indexed `geo_point` or `geo_shape` values. If the field contains an array, `geohash_grid` aggregates all array values.').optional(),
+  precision: GeoHashPrecision.describe('The string length of the geohashes used to define cells/buckets in the results.').optional(),
+  shard_size: integer.describe('Allows for more accurate counting of the top cells returned in the final result the aggregation. Defaults to returning `max(10,(size x number-of-shards))` buckets from each shard.').optional(),
+  size: integer.describe('The maximum number of geohash buckets to return.').optional()
+}).meta({ id: 'AggregationsGeoHashGridAggregation' })
+export type AggregationsGeoHashGridAggregation = z.infer<typeof AggregationsGeoHashGridAggregation>
+
+export const AggregationsGeoLinePoint = z.object({
+  field: Field.describe('The name of the geo_point field.')
+}).meta({ id: 'AggregationsGeoLinePoint' })
+export type AggregationsGeoLinePoint = z.infer<typeof AggregationsGeoLinePoint>
+
+export const AggregationsGeoLineSort = z.object({
+  field: Field.describe('The name of the numeric field to use as the sort key for ordering the points.')
+}).meta({ id: 'AggregationsGeoLineSort' })
+export type AggregationsGeoLineSort = z.infer<typeof AggregationsGeoLineSort>
+
+export const AggregationsGeoLineAggregation = z.object({
+  point: AggregationsGeoLinePoint.describe('The name of the geo_point field.'),
+  sort: AggregationsGeoLineSort.describe('The name of the numeric field to use as the sort key for ordering the points. When the `geo_line` aggregation is nested inside a `time_series` aggregation, this field defaults to `@timestamp`, and any other value will result in error.').optional(),
+  include_sort: z.boolean().describe('When `true`, returns an additional array of the sort values in the feature properties.').optional(),
+  sort_order: SortOrder.describe('The order in which the line is sorted (ascending or descending).').optional(),
+  size: integer.describe('The maximum length of the line represented in the aggregation. Valid sizes are between 1 and 10000.').optional()
+}).meta({ id: 'AggregationsGeoLineAggregation' })
+export type AggregationsGeoLineAggregation = z.infer<typeof AggregationsGeoLineAggregation>
+
+export const GeoTilePrecision = integer.meta({ id: 'GeoTilePrecision' })
+export type GeoTilePrecision = z.infer<typeof GeoTilePrecision>
+
+export const AggregationsGeoTileGridAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  field: Field.describe('Field containing indexed `geo_point` or `geo_shape` values. If the field contains an array, `geotile_grid` aggregates all array values.').optional(),
+  precision: GeoTilePrecision.describe('Integer zoom of the key used to define cells/buckets in the results. Values outside of the range [0,29] will be rejected.').optional(),
+  shard_size: integer.describe('Allows for more accurate counting of the top cells returned in the final result the aggregation. Defaults to returning `max(10,(size x number-of-shards))` buckets from each shard.').optional(),
+  size: integer.describe('The maximum number of buckets to return.').optional(),
+  bounds: GeoBounds.describe('A bounding box to filter the geo-points or geo-shapes in each bucket.').optional()
+}).meta({ id: 'AggregationsGeoTileGridAggregation' })
+export type AggregationsGeoTileGridAggregation = z.infer<typeof AggregationsGeoTileGridAggregation>
+
+export const AggregationsGeohexGridAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  field: Field.describe('Field containing indexed `geo_point` or `geo_shape` values. If the field contains an array, `geohex_grid` aggregates all array values.'),
+  precision: integer.describe('Integer zoom of the key used to defined cells or buckets in the results. Value should be between 0-15.').optional(),
+  bounds: GeoBounds.describe('Bounding box used to filter the geo-points in each bucket.').optional(),
+  size: integer.describe('Maximum number of buckets to return.').optional(),
+  shard_size: integer.describe('Number of buckets returned from each shard.').optional()
+}).meta({ id: 'AggregationsGeohexGridAggregation' })
+export type AggregationsGeohexGridAggregation = z.infer<typeof AggregationsGeohexGridAggregation>
+
+export const AggregationsGlobalAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape
+}).meta({ id: 'AggregationsGlobalAggregation' })
+export type AggregationsGlobalAggregation = z.infer<typeof AggregationsGlobalAggregation>
+
+export interface AggregationsHistogramAggregationShape {
+  extended_bounds?: AggregationsExtendedBounds | undefined
+  hard_bounds?: AggregationsExtendedBounds | undefined
+  field?: Field | undefined
+  interval?: double | undefined
+  min_doc_count?: integer | undefined
+  missing?: double | undefined
+  offset?: double | undefined
+  order?: AggregationsAggregateOrder | undefined
+  script?: ScriptShape | undefined
+  format?: string | undefined
+  keyed?: boolean | undefined
+}
+export const AggregationsHistogramAggregation = z.object({
+  extended_bounds: AggregationsExtendedBounds.describe('Enables extending the bounds of the histogram beyond the data itself.').optional(),
+  hard_bounds: AggregationsExtendedBounds.describe('Limits the range of buckets in the histogram. It is particularly useful in the case of open data ranges that can result in a very large number of buckets.').optional(),
+  field: Field.describe('The name of the field to aggregate on.').optional(),
+  interval: double.describe('The interval for the buckets. Must be a positive decimal.').optional(),
+  min_doc_count: integer.describe('Only returns buckets that have `min_doc_count` number of documents. By default, the response will fill gaps in the histogram with empty buckets.').optional(),
+  missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
+  order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  format: z.string().optional(),
+  keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
+}).meta({ id: 'AggregationsHistogramAggregation' })
+export type AggregationsHistogramAggregation = z.infer<typeof AggregationsHistogramAggregation>
+
+export const AggregationsIpRangeAggregationRange = z.object({
+  from: z.union([z.string(), z.null()]).describe('Start of the range.').optional(),
+  mask: z.string().describe('IP range defined as a CIDR mask.').optional(),
+  to: z.union([z.string(), z.null()]).describe('End of the range.').optional()
+}).meta({ id: 'AggregationsIpRangeAggregationRange' })
+export type AggregationsIpRangeAggregationRange = z.infer<typeof AggregationsIpRangeAggregationRange>
+
+export const AggregationsIpRangeAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  field: Field.describe('The date field whose values are used to build ranges.').optional(),
+  ranges: z.array(AggregationsIpRangeAggregationRange).describe('Array of IP ranges.').optional()
+}).meta({ id: 'AggregationsIpRangeAggregation' })
+export type AggregationsIpRangeAggregation = z.infer<typeof AggregationsIpRangeAggregation>
+
+export const AggregationsIpPrefixAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  field: Field.describe('The IP address field to aggregation on. The field mapping type must be `ip`.'),
+  prefix_length: integer.describe('Length of the network prefix. For IPv4 addresses the accepted range is [0, 32]. For IPv6 addresses the accepted range is [0, 128].'),
+  is_ipv6: z.boolean().describe('Defines whether the prefix applies to IPv6 addresses.').optional(),
+  append_prefix_length: z.boolean().describe('Defines whether the prefix length is appended to IP address keys in the response.').optional(),
+  keyed: z.boolean().describe('Defines whether buckets are returned as a hash rather than an array in the response.').optional(),
+  min_doc_count: long.describe('Minimum number of documents in a bucket for it to be included in the response.').optional()
+}).meta({ id: 'AggregationsIpPrefixAggregation' })
+export type AggregationsIpPrefixAggregation = z.infer<typeof AggregationsIpPrefixAggregation>
+
+export const MlRegressionInferenceOptions = z.object({
+  results_field: Field.describe('The field that is added to incoming documents to contain the inference prediction. Defaults to predicted_value.').optional(),
+  num_top_feature_importance_values: integer.describe('Specifies the maximum number of feature importance values per document.').optional()
+}).meta({ id: 'MlRegressionInferenceOptions' })
+export type MlRegressionInferenceOptions = z.infer<typeof MlRegressionInferenceOptions>
+
+export const MlClassificationInferenceOptions = z.object({
+  num_top_classes: integer.describe('Specifies the number of top class predictions to return. Defaults to 0.').optional(),
+  num_top_feature_importance_values: integer.describe('Specifies the maximum number of feature importance values per document.').optional(),
+  prediction_field_type: z.string().describe('Specifies the type of the predicted field to write. Acceptable values are: string, number, boolean. When boolean is provided 1.0 is transformed to true and 0.0 to false.').optional(),
+  results_field: z.string().describe('The field that is added to incoming documents to contain the inference prediction. Defaults to predicted_value.').optional(),
+  top_classes_results_field: z.string().describe('Specifies the field to which the top classes are written. Defaults to top_classes.').optional()
+}).meta({ id: 'MlClassificationInferenceOptions' })
+export type MlClassificationInferenceOptions = z.infer<typeof MlClassificationInferenceOptions>
+
+const AggregationsInferenceConfigContainerExclusiveProps = z.union([z.object({ regression: MlRegressionInferenceOptions }), z.object({ classification: MlClassificationInferenceOptions })])
+
+export const AggregationsInferenceConfigContainer = AggregationsInferenceConfigContainerExclusiveProps.meta({ id: 'AggregationsInferenceConfigContainer' })
+export type AggregationsInferenceConfigContainer = z.infer<typeof AggregationsInferenceConfigContainer>
+
+export const AggregationsInferenceAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape,
+  model_id: Name.describe('The ID or alias for the trained model.'),
+  inference_config: AggregationsInferenceConfigContainer.describe('Contains the inference type and its options.').optional()
+}).meta({ id: 'AggregationsInferenceAggregation' })
+export type AggregationsInferenceAggregation = z.infer<typeof AggregationsInferenceAggregation>
+
+export const Fields = z.union([Field, z.array(Field)]).meta({ id: 'Fields' })
+export type Fields = z.infer<typeof Fields>
+
+export const AggregationsMatrixAggregation = z.object({
+  fields: Fields.describe('An array of fields for computing the statistics.').optional(),
+  missing: z.record(Field, double).describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
+}).meta({ id: 'AggregationsMatrixAggregation' })
+export type AggregationsMatrixAggregation = z.infer<typeof AggregationsMatrixAggregation>
+
+export const AggregationsMatrixStatsAggregation = z.object({
+  ...AggregationsMatrixAggregation.shape,
+  mode: SortMode.describe('Array value the aggregation will use for array or multi-valued fields.').optional()
+}).meta({ id: 'AggregationsMatrixStatsAggregation' })
+export type AggregationsMatrixStatsAggregation = z.infer<typeof AggregationsMatrixStatsAggregation>
+
+export interface AggregationsMaxAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  format?: string | undefined
+}
+export const AggregationsMaxAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  format: z.string().optional()
+}).meta({ id: 'AggregationsMaxAggregation' })
+export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
+
+export const AggregationsMaxBucketAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape
+}).meta({ id: 'AggregationsMaxBucketAggregation' })
+export type AggregationsMaxBucketAggregation = z.infer<typeof AggregationsMaxBucketAggregation>
+
+export interface AggregationsMedianAbsoluteDeviationAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  format?: string | undefined
+  compression?: double | undefined
+  execution_hint?: AggregationsTDigestExecutionHint | undefined
+}
+export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  format: z.string().optional(),
+  compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
+  execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
+}).meta({ id: 'AggregationsMedianAbsoluteDeviationAggregation' })
+export type AggregationsMedianAbsoluteDeviationAggregation = z.infer<typeof AggregationsMedianAbsoluteDeviationAggregation>
+
+export interface AggregationsMinAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  format?: string | undefined
+}
+export const AggregationsMinAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  format: z.string().optional()
+}).meta({ id: 'AggregationsMinAggregation' })
+export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
+
+export const AggregationsMinBucketAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape
+}).meta({ id: 'AggregationsMinBucketAggregation' })
+export type AggregationsMinBucketAggregation = z.infer<typeof AggregationsMinBucketAggregation>
+
+export const AggregationsMissingAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  field: Field.describe('The name of the field.').optional(),
+  missing: AggregationsMissing.optional()
+}).meta({ id: 'AggregationsMissingAggregation' })
+export type AggregationsMissingAggregation = z.infer<typeof AggregationsMissingAggregation>
+
+export const AggregationsMovingAverageAggregationBase = z.object({
+  ...AggregationsPipelineAggregationBase.shape,
+  minimize: z.boolean().optional(),
+  predict: integer.optional(),
+  window: integer.optional()
+}).meta({ id: 'AggregationsMovingAverageAggregationBase' })
+export type AggregationsMovingAverageAggregationBase = z.infer<typeof AggregationsMovingAverageAggregationBase>
+
+/** For empty Class assignments */
+export const EmptyObject = z.object({
+}).meta({ id: 'EmptyObject' })
+export type EmptyObject = z.infer<typeof EmptyObject>
+
+export const AggregationsLinearMovingAverageAggregation = z.object({
+  ...AggregationsMovingAverageAggregationBase.shape,
+  model: z.literal('linear'),
+  settings: EmptyObject
+}).meta({ id: 'AggregationsLinearMovingAverageAggregation' })
+export type AggregationsLinearMovingAverageAggregation = z.infer<typeof AggregationsLinearMovingAverageAggregation>
+
+export const AggregationsSimpleMovingAverageAggregation = z.object({
+  ...AggregationsMovingAverageAggregationBase.shape,
+  model: z.literal('simple'),
+  settings: EmptyObject
+}).meta({ id: 'AggregationsSimpleMovingAverageAggregation' })
+export type AggregationsSimpleMovingAverageAggregation = z.infer<typeof AggregationsSimpleMovingAverageAggregation>
+
+export const AggregationsEwmaModelSettings = z.object({
+  alpha: float.optional()
+}).meta({ id: 'AggregationsEwmaModelSettings' })
+export type AggregationsEwmaModelSettings = z.infer<typeof AggregationsEwmaModelSettings>
+
+export const AggregationsEwmaMovingAverageAggregation = z.object({
+  ...AggregationsMovingAverageAggregationBase.shape,
+  model: z.literal('ewma'),
+  settings: AggregationsEwmaModelSettings
+}).meta({ id: 'AggregationsEwmaMovingAverageAggregation' })
+export type AggregationsEwmaMovingAverageAggregation = z.infer<typeof AggregationsEwmaMovingAverageAggregation>
+
+export const AggregationsHoltLinearModelSettings = z.object({
+  alpha: float.optional(),
+  beta: float.optional()
+}).meta({ id: 'AggregationsHoltLinearModelSettings' })
+export type AggregationsHoltLinearModelSettings = z.infer<typeof AggregationsHoltLinearModelSettings>
+
+export const AggregationsHoltMovingAverageAggregation = z.object({
+  ...AggregationsMovingAverageAggregationBase.shape,
+  model: z.literal('holt'),
+  settings: AggregationsHoltLinearModelSettings
+}).meta({ id: 'AggregationsHoltMovingAverageAggregation' })
+export type AggregationsHoltMovingAverageAggregation = z.infer<typeof AggregationsHoltMovingAverageAggregation>
+
+export const AggregationsHoltWintersType = z.enum(['add', 'mult']).meta({ id: 'AggregationsHoltWintersType' })
+export type AggregationsHoltWintersType = z.infer<typeof AggregationsHoltWintersType>
+
+export const AggregationsHoltWintersModelSettings = z.object({
+  alpha: float.optional(),
+  beta: float.optional(),
+  gamma: float.optional(),
+  pad: z.boolean().optional(),
+  period: integer.optional(),
+  type: AggregationsHoltWintersType.optional()
+}).meta({ id: 'AggregationsHoltWintersModelSettings' })
+export type AggregationsHoltWintersModelSettings = z.infer<typeof AggregationsHoltWintersModelSettings>
+
+export const AggregationsHoltWintersMovingAverageAggregation = z.object({
+  ...AggregationsMovingAverageAggregationBase.shape,
+  model: z.literal('holt_winters'),
+  settings: AggregationsHoltWintersModelSettings
+}).meta({ id: 'AggregationsHoltWintersMovingAverageAggregation' })
+export type AggregationsHoltWintersMovingAverageAggregation = z.infer<typeof AggregationsHoltWintersMovingAverageAggregation>
+
+export const AggregationsMovingAverageAggregation = z.union([AggregationsLinearMovingAverageAggregation, AggregationsSimpleMovingAverageAggregation, AggregationsEwmaMovingAverageAggregation, AggregationsHoltMovingAverageAggregation, AggregationsHoltWintersMovingAverageAggregation]).meta({ id: 'AggregationsMovingAverageAggregation' })
+export type AggregationsMovingAverageAggregation = z.infer<typeof AggregationsMovingAverageAggregation>
+
+export const AggregationsMovingPercentilesAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape,
+  window: integer.describe('The size of window to "slide" across the histogram.').optional(),
+  shift: integer.describe('By default, the window consists of the last n values excluding the current bucket. Increasing `shift` by 1, moves the starting window position by 1 to the right.').optional(),
+  keyed: z.boolean().optional()
+}).meta({ id: 'AggregationsMovingPercentilesAggregation' })
+export type AggregationsMovingPercentilesAggregation = z.infer<typeof AggregationsMovingPercentilesAggregation>
+
+export const AggregationsMovingFunctionAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape,
+  script: z.string().describe('The script that should be executed on each window of data.').optional(),
+  shift: integer.describe('By default, the window consists of the last n values excluding the current bucket. Increasing `shift` by 1, moves the starting window position by 1 to the right.').optional(),
+  window: integer.describe('The size of window to "slide" across the histogram.').optional()
+}).meta({ id: 'AggregationsMovingFunctionAggregation' })
+export type AggregationsMovingFunctionAggregation = z.infer<typeof AggregationsMovingFunctionAggregation>
+
+export const AggregationsTermsAggregationCollectMode = z.enum(['depth_first', 'breadth_first']).meta({ id: 'AggregationsTermsAggregationCollectMode' })
+export type AggregationsTermsAggregationCollectMode = z.infer<typeof AggregationsTermsAggregationCollectMode>
+
+const AggregationsMultiTermLookupCommonProps = z.object({
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
+})
+
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
+
+export interface AggregationsMultiTermLookupShape {
+  missing?: AggregationsMissing | undefined
+  field?: Field | undefined
+  script?: Script | undefined
+}
+export const AggregationsMultiTermLookup: z.ZodType<AggregationsMultiTermLookupShape> = AggregationsMultiTermLookupCommonProps.and(AggregationsMultiTermLookupExclusiveProps).meta({ id: 'AggregationsMultiTermLookup' })
+export type AggregationsMultiTermLookup = z.infer<typeof AggregationsMultiTermLookup>
+
+export interface AggregationsMultiTermsAggregationShape {
+  collect_mode?: AggregationsTermsAggregationCollectMode | undefined
+  order?: AggregationsAggregateOrder | undefined
+  min_doc_count?: long | undefined
+  shard_min_doc_count?: long | undefined
+  shard_size?: integer | undefined
+  show_term_doc_count_error?: boolean | undefined
+  size?: integer | undefined
+  terms: AggregationsMultiTermLookupShape[]
+}
+export const AggregationsMultiTermsAggregation = z.object({
+  collect_mode: AggregationsTermsAggregationCollectMode.describe('Specifies the strategy for data collection.').optional(),
+  order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
+  min_doc_count: long.describe('The minimum number of documents in a bucket for it to be returned.').optional(),
+  shard_min_doc_count: long.describe('The minimum number of documents in a bucket on each shard for it to be returned.').optional(),
+  shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
+  show_term_doc_count_error: z.boolean().describe('Calculates the doc count error on per term basis.').optional(),
+  size: integer.describe('The number of term buckets should be returned out of the overall terms list.').optional(),
+  get terms () { return AggregationsMultiTermLookup.array().describe('The field from which to generate sets of terms.') }
+}).meta({ id: 'AggregationsMultiTermsAggregation' })
+export type AggregationsMultiTermsAggregation = z.infer<typeof AggregationsMultiTermsAggregation>
+
+export const AggregationsNestedAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  path: Field.describe('The path to the field of type `nested`.').optional()
+}).meta({ id: 'AggregationsNestedAggregation' })
+export type AggregationsNestedAggregation = z.infer<typeof AggregationsNestedAggregation>
+
+export const AggregationsNormalizeMethod = z.enum(['rescale_0_1', 'rescale_0_100', 'percent_of_sum', 'mean', 'z-score', 'softmax']).meta({ id: 'AggregationsNormalizeMethod' })
+export type AggregationsNormalizeMethod = z.infer<typeof AggregationsNormalizeMethod>
+
+export const AggregationsNormalizeAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape,
+  method: AggregationsNormalizeMethod.describe('The specific method to apply.').optional()
+}).meta({ id: 'AggregationsNormalizeAggregation' })
+export type AggregationsNormalizeAggregation = z.infer<typeof AggregationsNormalizeAggregation>
+
+export const AggregationsParentAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  type: RelationName.describe('The child type that should be selected.').optional()
+}).meta({ id: 'AggregationsParentAggregation' })
+export type AggregationsParentAggregation = z.infer<typeof AggregationsParentAggregation>
+
+export const AggregationsHdrMethod = z.object({
+  number_of_significant_value_digits: integer.describe('Specifies the resolution of values for the histogram in number of significant digits.').optional()
+}).meta({ id: 'AggregationsHdrMethod' })
+export type AggregationsHdrMethod = z.infer<typeof AggregationsHdrMethod>
+
+export const AggregationsTDigest = z.object({
+  compression: integer.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
+  execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
+}).meta({ id: 'AggregationsTDigest' })
+export type AggregationsTDigest = z.infer<typeof AggregationsTDigest>
+
+export interface AggregationsPercentileRanksAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  format?: string | undefined
+  keyed?: boolean | undefined
+  values?: double[] | null | undefined
+  hdr?: AggregationsHdrMethod | undefined
+  tdigest?: AggregationsTDigest | undefined
+}
+export const AggregationsPercentileRanksAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  format: z.string().optional(),
+  keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
+  values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
+  hdr: AggregationsHdrMethod.describe('Uses the alternative High Dynamic Range Histogram algorithm to calculate percentile ranks.').optional(),
+  tdigest: AggregationsTDigest.describe('Sets parameters for the default TDigest algorithm used to calculate percentile ranks.').optional()
+}).meta({ id: 'AggregationsPercentileRanksAggregation' })
+export type AggregationsPercentileRanksAggregation = z.infer<typeof AggregationsPercentileRanksAggregation>
+
+export interface AggregationsPercentilesAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  format?: string | undefined
+  keyed?: boolean | undefined
+  percents?: double | double[] | undefined
+  hdr?: AggregationsHdrMethod | undefined
+  tdigest?: AggregationsTDigest | undefined
+}
+export const AggregationsPercentilesAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  format: z.string().optional(),
+  keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
+  percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
+  hdr: AggregationsHdrMethod.describe('Uses the alternative High Dynamic Range Histogram algorithm to calculate percentiles.').optional(),
+  tdigest: AggregationsTDigest.describe('Sets parameters for the default TDigest algorithm used to calculate percentiles.').optional()
+}).meta({ id: 'AggregationsPercentilesAggregation' })
+export type AggregationsPercentilesAggregation = z.infer<typeof AggregationsPercentilesAggregation>
+
+export const AggregationsPercentilesBucketAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape,
+  percents: z.array(double).describe('The list of percentiles to calculate.').optional()
+}).meta({ id: 'AggregationsPercentilesBucketAggregation' })
+export type AggregationsPercentilesBucketAggregation = z.infer<typeof AggregationsPercentilesBucketAggregation>
+
+export interface AggregationsRangeAggregationShape {
+  field?: Field | undefined
+  missing?: integer | undefined
+  ranges?: AggregationsAggregationRange[] | undefined
+  script?: ScriptShape | undefined
+  keyed?: boolean | undefined
+  format?: string | undefined
+}
+export const AggregationsRangeAggregation = z.object({
+  field: Field.describe('The date field whose values are use to build ranges.').optional(),
+  missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
+  format: z.string().optional()
+}).meta({ id: 'AggregationsRangeAggregation' })
+export type AggregationsRangeAggregation = z.infer<typeof AggregationsRangeAggregation>
+
+export const AggregationsRareTermsAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  exclude: AggregationsTermsExclude.describe('Terms that should be excluded from the aggregation.').optional(),
+  field: Field.describe('The field from which to return rare terms.').optional(),
+  include: AggregationsTermsInclude.describe('Terms that should be included in the aggregation.').optional(),
+  max_doc_count: long.describe('The maximum number of documents a term should appear in.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  precision: double.describe('The precision of the internal CuckooFilters. Smaller precision leads to better approximation, but higher memory usage.').optional(),
+  value_type: z.string().optional()
+}).meta({ id: 'AggregationsRareTermsAggregation' })
+export type AggregationsRareTermsAggregation = z.infer<typeof AggregationsRareTermsAggregation>
+
+export const AggregationsRateMode = z.enum(['sum', 'value_count']).meta({ id: 'AggregationsRateMode' })
+export type AggregationsRateMode = z.infer<typeof AggregationsRateMode>
+
+export interface AggregationsRateAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  format?: string | undefined
+  unit?: AggregationsCalendarInterval | undefined
+  mode?: AggregationsRateMode | undefined
+}
+export const AggregationsRateAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  format: z.string().optional(),
+  unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
+  mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
+}).meta({ id: 'AggregationsRateAggregation' })
+export type AggregationsRateAggregation = z.infer<typeof AggregationsRateAggregation>
+
+export const AggregationsReverseNestedAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  path: Field.describe('Defines the nested object field that should be joined back to. The default is empty, which means that it joins back to the root/main document level.').optional()
+}).meta({ id: 'AggregationsReverseNestedAggregation' })
+export type AggregationsReverseNestedAggregation = z.infer<typeof AggregationsReverseNestedAggregation>
+
+export const AggregationsSamplerAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional()
+}).meta({ id: 'AggregationsSamplerAggregation' })
+export type AggregationsSamplerAggregation = z.infer<typeof AggregationsSamplerAggregation>
+
+export interface AggregationsScriptedMetricAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  combine_script?: ScriptShape | undefined
+  init_script?: ScriptShape | undefined
+  map_script?: ScriptShape | undefined
+  params?: Record<string, unknown> | undefined
+  reduce_script?: ScriptShape | undefined
+}
+export const AggregationsScriptedMetricAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+}).meta({ id: 'AggregationsScriptedMetricAggregation' })
+export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
+
+export const AggregationsSerialDifferencingAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape,
+  lag: integer.describe('The historical bucket to subtract from the current value. Must be a positive, non-zero integer.').optional()
+}).meta({ id: 'AggregationsSerialDifferencingAggregation' })
+export type AggregationsSerialDifferencingAggregation = z.infer<typeof AggregationsSerialDifferencingAggregation>
+
+export const AggregationsChiSquareHeuristic = z.object({
+  background_is_superset: z.boolean().describe('Set to `false` if you defined a custom background filter that represents a different set of documents that you want to compare to.'),
+  include_negatives: z.boolean().describe('Set to `false` to filter out the terms that appear less often in the subset than in documents outside the subset.')
+}).meta({ id: 'AggregationsChiSquareHeuristic' })
+export type AggregationsChiSquareHeuristic = z.infer<typeof AggregationsChiSquareHeuristic>
+
+export const AggregationsTermsAggregationExecutionHint = z.enum(['map', 'global_ordinals', 'global_ordinals_hash', 'global_ordinals_low_cardinality']).meta({ id: 'AggregationsTermsAggregationExecutionHint' })
+export type AggregationsTermsAggregationExecutionHint = z.infer<typeof AggregationsTermsAggregationExecutionHint>
+
+export const AggregationsGoogleNormalizedDistanceHeuristic = z.object({
+  background_is_superset: z.boolean().describe('Set to `false` if you defined a custom background filter that represents a different set of documents that you want to compare to.').optional()
+}).meta({ id: 'AggregationsGoogleNormalizedDistanceHeuristic' })
+export type AggregationsGoogleNormalizedDistanceHeuristic = z.infer<typeof AggregationsGoogleNormalizedDistanceHeuristic>
+
+export const AggregationsMutualInformationHeuristic = z.object({
+  background_is_superset: z.boolean().describe('Set to `false` if you defined a custom background filter that represents a different set of documents that you want to compare to.').optional(),
+  include_negatives: z.boolean().describe('Set to `false` to filter out the terms that appear less often in the subset than in documents outside the subset.').optional()
+}).meta({ id: 'AggregationsMutualInformationHeuristic' })
+export type AggregationsMutualInformationHeuristic = z.infer<typeof AggregationsMutualInformationHeuristic>
+
+export const AggregationsPercentageScoreHeuristic = z.object({
+}).meta({ id: 'AggregationsPercentageScoreHeuristic' })
+export type AggregationsPercentageScoreHeuristic = z.infer<typeof AggregationsPercentageScoreHeuristic>
+
+export interface AggregationsScriptedHeuristicShape {
+  script: ScriptShape
+}
+export const AggregationsScriptedHeuristic = z.object({
+  get script () { return z.union([Script, ScriptSource]) }
+}).meta({ id: 'AggregationsScriptedHeuristic' })
+export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
+
+export const AggregationsPValueHeuristic = z.object({
+  background_is_superset: z.boolean().optional(),
+  normalize_above: long.describe('Should the results be normalized when above the given value. Allows for consistent significance results at various scales. Note: `0` is a special value which means no normalization').optional()
+}).meta({ id: 'AggregationsPValueHeuristic' })
+export type AggregationsPValueHeuristic = z.infer<typeof AggregationsPValueHeuristic>
+
+export interface AggregationsSignificantTermsAggregationShape {
+  background_filter?: QueryDslQueryContainerShape | undefined
+  chi_square?: AggregationsChiSquareHeuristic | undefined
+  exclude?: AggregationsTermsExclude | undefined
+  execution_hint?: AggregationsTermsAggregationExecutionHint | undefined
+  field?: Field | undefined
+  gnd?: AggregationsGoogleNormalizedDistanceHeuristic | undefined
+  include?: AggregationsTermsInclude | undefined
+  jlh?: EmptyObject | undefined
+  min_doc_count?: long | undefined
+  mutual_information?: AggregationsMutualInformationHeuristic | undefined
+  percentage?: AggregationsPercentageScoreHeuristic | undefined
+  script_heuristic?: AggregationsScriptedHeuristicShape | undefined
+  p_value?: AggregationsPValueHeuristic | undefined
+  shard_min_doc_count?: long | undefined
+  shard_size?: integer | undefined
+  size?: integer | undefined
+}
+export const AggregationsSignificantTermsAggregation = z.object({
+  get background_filter () { return QueryDslQueryContainer.describe('A background filter that can be used to focus in on significant terms within a narrower context, instead of the entire index.').optional() },
+  chi_square: AggregationsChiSquareHeuristic.describe('Use Chi square, as described in "Information Retrieval", Manning et al., Chapter 13.5.2, as the significance score.').optional(),
+  exclude: AggregationsTermsExclude.describe('Terms to exclude.').optional(),
+  execution_hint: AggregationsTermsAggregationExecutionHint.describe('Mechanism by which the aggregation should be executed: using field values directly or using global ordinals.').optional(),
+  field: Field.describe('The field from which to return significant terms.').optional(),
+  gnd: AggregationsGoogleNormalizedDistanceHeuristic.describe('Use Google normalized distance as described in "The Google Similarity Distance", Cilibrasi and Vitanyi, 2007, as the significance score.').optional(),
+  include: AggregationsTermsInclude.describe('Terms to include.').optional(),
+  jlh: EmptyObject.describe('Use JLH score as the significance score.').optional(),
+  min_doc_count: long.describe('Only return terms that are found in more than `min_doc_count` hits.').optional(),
+  mutual_information: AggregationsMutualInformationHeuristic.describe('Use mutual information as described in "Information Retrieval", Manning et al., Chapter 13.5.1, as the significance score.').optional(),
+  percentage: AggregationsPercentageScoreHeuristic.describe('A simple calculation of the number of documents in the foreground sample with a term divided by the number of documents in the background with the term.').optional(),
+  get script_heuristic () { return AggregationsScriptedHeuristic.describe('Customized score, implemented via a script.').optional() },
+  p_value: AggregationsPValueHeuristic.describe('Significant terms heuristic that calculates the p-value between the term existing in foreground and background sets. The p-value is the probability of obtaining test results at least as extreme as the results actually observed, under the assumption that the null hypothesis is correct. The p-value is calculated assuming that the foreground set and the background set are independent https://en.wikipedia.org/wiki/Bernoulli_trial, with the null hypothesis that the probabilities are the same.').optional(),
+  shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
+  shard_size: integer.describe('Can be used to control the volumes of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
+  size: integer.describe('The number of buckets returned out of the overall terms list.').optional()
+}).meta({ id: 'AggregationsSignificantTermsAggregation' })
+export type AggregationsSignificantTermsAggregation = z.infer<typeof AggregationsSignificantTermsAggregation>
+
+export interface AggregationsSignificantTextAggregationShape {
+  background_filter?: QueryDslQueryContainerShape | undefined
+  chi_square?: AggregationsChiSquareHeuristic | undefined
+  exclude?: AggregationsTermsExclude | undefined
+  execution_hint?: AggregationsTermsAggregationExecutionHint | undefined
+  field?: Field | undefined
+  filter_duplicate_text?: boolean | undefined
+  gnd?: AggregationsGoogleNormalizedDistanceHeuristic | undefined
+  include?: AggregationsTermsInclude | undefined
+  jlh?: EmptyObject | undefined
+  min_doc_count?: long | undefined
+  mutual_information?: AggregationsMutualInformationHeuristic | undefined
+  percentage?: AggregationsPercentageScoreHeuristic | undefined
+  script_heuristic?: AggregationsScriptedHeuristicShape | undefined
+  shard_min_doc_count?: long | undefined
+  shard_size?: integer | undefined
+  size?: integer | undefined
+  source_fields?: Fields | undefined
+}
+export const AggregationsSignificantTextAggregation = z.object({
+  get background_filter () { return QueryDslQueryContainer.describe('A background filter that can be used to focus in on significant terms within a narrower context, instead of the entire index.').optional() },
+  chi_square: AggregationsChiSquareHeuristic.describe('Use Chi square, as described in "Information Retrieval", Manning et al., Chapter 13.5.2, as the significance score.').optional(),
+  exclude: AggregationsTermsExclude.describe('Values to exclude.').optional(),
+  execution_hint: AggregationsTermsAggregationExecutionHint.describe('Determines whether the aggregation will use field values directly or global ordinals.').optional(),
+  field: Field.describe('The field from which to return significant text.').optional(),
+  filter_duplicate_text: z.boolean().describe('Whether to out duplicate text to deal with noisy data.').optional(),
+  gnd: AggregationsGoogleNormalizedDistanceHeuristic.describe('Use Google normalized distance as described in "The Google Similarity Distance", Cilibrasi and Vitanyi, 2007, as the significance score.').optional(),
+  include: AggregationsTermsInclude.describe('Values to include.').optional(),
+  jlh: EmptyObject.describe('Use JLH score as the significance score.').optional(),
+  min_doc_count: long.describe('Only return values that are found in more than `min_doc_count` hits.').optional(),
+  mutual_information: AggregationsMutualInformationHeuristic.describe('Use mutual information as described in "Information Retrieval", Manning et al., Chapter 13.5.1, as the significance score.').optional(),
+  percentage: AggregationsPercentageScoreHeuristic.describe('A simple calculation of the number of documents in the foreground sample with a term divided by the number of documents in the background with the term.').optional(),
+  get script_heuristic () { return AggregationsScriptedHeuristic.describe('Customized score, implemented via a script.').optional() },
+  shard_min_doc_count: long.describe('Regulates the certainty a shard has if the values should actually be added to the candidate list or not with respect to the min_doc_count. Values will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
+  shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
+  size: integer.describe('The number of buckets returned out of the overall terms list.').optional(),
+  source_fields: Fields.describe('Overrides the JSON `_source` fields from which text will be analyzed.').optional()
+}).meta({ id: 'AggregationsSignificantTextAggregation' })
+export type AggregationsSignificantTextAggregation = z.infer<typeof AggregationsSignificantTextAggregation>
+
+export interface AggregationsStatsAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  format?: string | undefined
+}
+export const AggregationsStatsAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  format: z.string().optional()
+}).meta({ id: 'AggregationsStatsAggregation' })
+export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
+
+export const AggregationsStatsBucketAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape
+}).meta({ id: 'AggregationsStatsBucketAggregation' })
+export type AggregationsStatsBucketAggregation = z.infer<typeof AggregationsStatsBucketAggregation>
+
+export interface AggregationsStringStatsAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  show_distribution?: boolean | undefined
+}
+export const AggregationsStringStatsAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
+}).meta({ id: 'AggregationsStringStatsAggregation' })
+export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
+
+export interface AggregationsSumAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  format?: string | undefined
+}
+export const AggregationsSumAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  format: z.string().optional()
+}).meta({ id: 'AggregationsSumAggregation' })
+export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
+
+export const AggregationsSumBucketAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape
+}).meta({ id: 'AggregationsSumBucketAggregation' })
+export type AggregationsSumBucketAggregation = z.infer<typeof AggregationsSumBucketAggregation>
+
+export interface AggregationsTermsAggregationShape {
+  collect_mode?: AggregationsTermsAggregationCollectMode | undefined
+  exclude?: AggregationsTermsExclude | undefined
+  execution_hint?: AggregationsTermsAggregationExecutionHint | undefined
+  field?: Field | undefined
+  include?: AggregationsTermsInclude | undefined
+  min_doc_count?: integer | undefined
+  missing?: AggregationsMissing | undefined
+  missing_order?: AggregationsMissingOrder | undefined
+  missing_bucket?: boolean | undefined
+  value_type?: string | undefined
+  order?: AggregationsAggregateOrder | undefined
+  script?: ScriptShape | undefined
+  shard_min_doc_count?: long | undefined
+  shard_size?: integer | undefined
+  show_term_doc_count_error?: boolean | undefined
+  size?: integer | undefined
+  format?: string | undefined
+}
+export const AggregationsTermsAggregation = z.object({
+  collect_mode: AggregationsTermsAggregationCollectMode.describe('Determines how child aggregations should be calculated: breadth-first or depth-first.').optional(),
+  exclude: AggregationsTermsExclude.describe('Values to exclude. Accepts regular expressions and partitions.').optional(),
+  execution_hint: AggregationsTermsAggregationExecutionHint.describe('Determines whether the aggregation will use field values directly or global ordinals.').optional(),
+  field: Field.describe('The field from which to return terms.').optional(),
+  include: AggregationsTermsInclude.describe('Values to include. Accepts regular expressions and partitions.').optional(),
+  min_doc_count: integer.describe('Only return values that are found in more than `min_doc_count` hits.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  missing_order: AggregationsMissingOrder.optional(),
+  missing_bucket: z.boolean().optional(),
+  value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
+  order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
+  shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
+  show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
+  size: integer.describe('The number of buckets returned out of the overall terms list.').optional(),
+  format: z.string().optional()
+}).meta({ id: 'AggregationsTermsAggregation' })
+export type AggregationsTermsAggregation = z.infer<typeof AggregationsTermsAggregation>
+
+export const AggregationsTimeSeriesAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  size: integer.describe('The maximum number of results to return.').optional(),
+  keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and returns the ranges as a hash rather than an array.').optional()
+}).meta({ id: 'AggregationsTimeSeriesAggregation' })
+export type AggregationsTimeSeriesAggregation = z.infer<typeof AggregationsTimeSeriesAggregation>
+
+export interface ScriptFieldShape {
+  script: ScriptShape
+  ignore_failure?: boolean | undefined
+}
+export const ScriptField = z.object({
+  get script () { return z.union([Script, ScriptSource]) },
+  ignore_failure: z.boolean().optional()
+}).meta({ id: 'ScriptField' })
+export type ScriptField = z.infer<typeof ScriptField>
+
+export const SearchSourceFilter = z.object({
+  exclude_vectors: z.boolean().describe('If `true`, vector fields are excluded from the returned source. This option takes precedence over `includes`: any vector field will remain excluded even if it matches an `includes` rule.').optional(),
+  excludes: Fields.describe('A list of fields to exclude from the returned source.').optional(),
+  exclude: Fields.describe('A list of fields to exclude from the returned source.').optional(),
+  includes: Fields.describe('A list of fields to include in the returned source.').optional(),
+  include: Fields.describe('A list of fields to include in the returned source.').optional()
+}).meta({ id: 'SearchSourceFilter' })
+export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
+
+/** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
+export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
+
+export interface AggregationsTopHitsAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  docvalue_fields?: QueryDslFieldAndFormat[] | undefined
+  explain?: boolean | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
+  from?: integer | undefined
+  highlight?: SearchHighlightShape | undefined
+  script_fields?: Record<string, ScriptFieldShape> | undefined
+  size?: integer | undefined
+  sort?: SortShape | undefined
+  _source?: SearchSourceConfig | undefined
+  stored_fields?: Fields | undefined
+  track_scores?: boolean | undefined
+  version?: boolean | undefined
+  seq_no_primary_term?: boolean | undefined
+}
+export const AggregationsTopHitsAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
+  explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  from: integer.describe('Starting document offset.').optional(),
+  get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
+  get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
+  size: integer.describe('The maximum number of top matching hits to return per bucket.').optional(),
+  get sort () { return Sort.describe('Sort order of the top matching hits. By default, the hits are sorted by the score of the main query.').optional() },
+  _source: SearchSourceConfig.describe('Selects the fields of the source that are returned.').optional(),
+  stored_fields: Fields.describe('Returns values for the specified stored fields (fields that use the `store` mapping option).').optional(),
+  track_scores: z.boolean().describe('If `true`, calculates and returns document scores, even if the scores are not used for sorting.').optional(),
+  version: z.boolean().describe('If `true`, returns document version as part of a hit.').optional(),
+  seq_no_primary_term: z.boolean().describe('If `true`, returns sequence number and primary term of the last modification of each hit.').optional()
+}).meta({ id: 'AggregationsTopHitsAggregation' })
+export type AggregationsTopHitsAggregation = z.infer<typeof AggregationsTopHitsAggregation>
+
+export interface AggregationsTestPopulationShape {
+  field: Field
+  script?: ScriptShape | undefined
+  filter?: QueryDslQueryContainerShape | undefined
+}
+export const AggregationsTestPopulation = z.object({
+  field: Field.describe('The field to aggregate.'),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
+}).meta({ id: 'AggregationsTestPopulation' })
+export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
+
+export const AggregationsTTestType = z.enum(['paired', 'homoscedastic', 'heteroscedastic']).meta({ id: 'AggregationsTTestType' })
+export type AggregationsTTestType = z.infer<typeof AggregationsTTestType>
+
+export interface AggregationsTTestAggregationShape {
+  a?: AggregationsTestPopulationShape | undefined
+  b?: AggregationsTestPopulationShape | undefined
+  type?: AggregationsTTestType | undefined
+}
+export const AggregationsTTestAggregation = z.object({
+  get a () { return AggregationsTestPopulation.describe('Test population A.').optional() },
+  get b () { return AggregationsTestPopulation.describe('Test population B.').optional() },
+  type: AggregationsTTestType.describe('The type of test.').optional()
+}).meta({ id: 'AggregationsTTestAggregation' })
+export type AggregationsTTestAggregation = z.infer<typeof AggregationsTTestAggregation>
+
+export const AggregationsTopMetricsValue = z.object({
+  field: Field.describe('A field to return as a metric.')
+}).meta({ id: 'AggregationsTopMetricsValue' })
+export type AggregationsTopMetricsValue = z.infer<typeof AggregationsTopMetricsValue>
+
+export interface AggregationsTopMetricsAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  metrics?: AggregationsTopMetricsValue | AggregationsTopMetricsValue[] | undefined
+  size?: integer | undefined
+  sort?: SortShape | undefined
+}
+export const AggregationsTopMetricsAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
+  size: integer.describe('The number of top documents from which to return metrics.').optional(),
+  get sort () { return Sort.describe('The sort order of the documents.').optional() }
+}).meta({ id: 'AggregationsTopMetricsAggregation' })
+export type AggregationsTopMetricsAggregation = z.infer<typeof AggregationsTopMetricsAggregation>
+
+export interface AggregationsFormattableMetricAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  format?: string | undefined
+}
+export const AggregationsFormattableMetricAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  format: z.string().optional()
+}).meta({ id: 'AggregationsFormattableMetricAggregation' })
+export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
+
+export interface AggregationsValueCountAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  format?: string | undefined
+}
+export const AggregationsValueCountAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  format: z.string().optional()
+}).meta({ id: 'AggregationsValueCountAggregation' })
+export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
+
+export interface AggregationsWeightedAverageValueShape {
+  field?: Field | undefined
+  missing?: double | undefined
+  script?: ScriptShape | undefined
+}
+export const AggregationsWeightedAverageValue = z.object({
+  field: Field.describe('The field from which to extract the values or weights.').optional(),
+  missing: double.describe('A value or weight to use if the field is missing.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() }
+}).meta({ id: 'AggregationsWeightedAverageValue' })
+export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
+
+export interface AggregationsWeightedAverageAggregationShape {
+  format?: string | undefined
+  value?: AggregationsWeightedAverageValueShape | undefined
+  value_type?: AggregationsValueType | undefined
+  weight?: AggregationsWeightedAverageValueShape | undefined
+}
+export const AggregationsWeightedAverageAggregation = z.object({
+  format: z.string().describe('A numeric response formatter.').optional(),
+  get value () { return AggregationsWeightedAverageValue.describe('Configuration for the field that provides the values.').optional() },
+  value_type: AggregationsValueType.optional(),
+  get weight () { return AggregationsWeightedAverageValue.describe('Configuration for the field or script that provides the weights.').optional() }
+}).meta({ id: 'AggregationsWeightedAverageAggregation' })
+export type AggregationsWeightedAverageAggregation = z.infer<typeof AggregationsWeightedAverageAggregation>
+
+export interface AggregationsVariableWidthHistogramAggregationShape {
+  field?: Field | undefined
+  buckets?: integer | undefined
+  shard_size?: integer | undefined
+  initial_buffer?: integer | undefined
+  script?: ScriptShape | undefined
+}
+export const AggregationsVariableWidthHistogramAggregation = z.object({
+  field: Field.describe('The name of the field.').optional(),
+  buckets: integer.describe('The target number of buckets.').optional(),
+  shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
+  initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() }
+}).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
+export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
+
+const AggregationsAggregationContainerCommonProps = z.object({
+  aggregations: z.record(z.string(), z.lazy(() => AggregationsAggregationContainer)).describe('Sub-aggregations for this aggregation. Only applies to bucket aggregations.').optional(),
+  aggs: z.record(z.string(), z.lazy(() => AggregationsAggregationContainer)).describe('Sub-aggregations for this aggregation. Only applies to bucket aggregations.').optional(),
+  meta: Metadata.optional()
+})
+
+const AggregationsAggregationContainerExclusiveProps = z.union([z.object({ adjacency_matrix: z.lazy(() => AggregationsAdjacencyMatrixAggregation) }), z.object({ auto_date_histogram: z.lazy(() => AggregationsAutoDateHistogramAggregation) }), z.object({ avg: z.lazy(() => AggregationsAverageAggregation) }), z.object({ avg_bucket: AggregationsAverageBucketAggregation }), z.object({ boxplot: z.lazy(() => AggregationsBoxplotAggregation) }), z.object({ bucket_script: z.lazy(() => AggregationsBucketScriptAggregation) }), z.object({ bucket_selector: z.lazy(() => AggregationsBucketSelectorAggregation) }), z.object({ bucket_sort: z.lazy(() => AggregationsBucketSortAggregation) }), z.object({ bucket_count_ks_test: AggregationsBucketKsAggregation }), z.object({ bucket_correlation: AggregationsBucketCorrelationAggregation }), z.object({ cardinality: z.lazy(() => AggregationsCardinalityAggregation) }), z.object({ cartesian_bounds: z.lazy(() => AggregationsCartesianBoundsAggregation) }), z.object({ cartesian_centroid: z.lazy(() => AggregationsCartesianCentroidAggregation) }), z.object({ categorize_text: AggregationsCategorizeTextAggregation }), z.object({ change_point: AggregationsChangePointAggregation }), z.object({ children: AggregationsChildrenAggregation }), z.object({ composite: z.lazy(() => AggregationsCompositeAggregation) }), z.object({ cumulative_cardinality: AggregationsCumulativeCardinalityAggregation }), z.object({ cumulative_sum: AggregationsCumulativeSumAggregation }), z.object({ date_histogram: z.lazy(() => AggregationsDateHistogramAggregation) }), z.object({ date_range: AggregationsDateRangeAggregation }), z.object({ derivative: AggregationsDerivativeAggregation }), z.object({ diversified_sampler: z.lazy(() => AggregationsDiversifiedSamplerAggregation) }), z.object({ extended_stats: z.lazy(() => AggregationsExtendedStatsAggregation) }), z.object({ extended_stats_bucket: AggregationsExtendedStatsBucketAggregation }), z.object({ frequent_item_sets: z.lazy(() => AggregationsFrequentItemSetsAggregation) }), z.object({ filter: z.lazy(() => QueryDslQueryContainer) }), z.object({ filters: AggregationsFiltersAggregation }), z.object({ geo_bounds: z.lazy(() => AggregationsGeoBoundsAggregation) }), z.object({ geo_centroid: z.lazy(() => AggregationsGeoCentroidAggregation) }), z.object({ geo_distance: AggregationsGeoDistanceAggregation }), z.object({ geohash_grid: AggregationsGeoHashGridAggregation }), z.object({ geo_line: AggregationsGeoLineAggregation }), z.object({ geotile_grid: AggregationsGeoTileGridAggregation }), z.object({ geohex_grid: AggregationsGeohexGridAggregation }), z.object({ global: AggregationsGlobalAggregation }), z.object({ histogram: z.lazy(() => AggregationsHistogramAggregation) }), z.object({ ip_range: AggregationsIpRangeAggregation }), z.object({ ip_prefix: AggregationsIpPrefixAggregation }), z.object({ inference: AggregationsInferenceAggregation }), z.object({ line: AggregationsGeoLineAggregation }), z.object({ matrix_stats: AggregationsMatrixStatsAggregation }), z.object({ max: z.lazy(() => AggregationsMaxAggregation) }), z.object({ max_bucket: AggregationsMaxBucketAggregation }), z.object({ median_absolute_deviation: z.lazy(() => AggregationsMedianAbsoluteDeviationAggregation) }), z.object({ min: z.lazy(() => AggregationsMinAggregation) }), z.object({ min_bucket: AggregationsMinBucketAggregation }), z.object({ missing: AggregationsMissingAggregation }), z.object({ moving_avg: AggregationsMovingAverageAggregation }), z.object({ moving_percentiles: AggregationsMovingPercentilesAggregation }), z.object({ moving_fn: AggregationsMovingFunctionAggregation }), z.object({ multi_terms: z.lazy(() => AggregationsMultiTermsAggregation) }), z.object({ nested: AggregationsNestedAggregation }), z.object({ normalize: AggregationsNormalizeAggregation }), z.object({ parent: AggregationsParentAggregation }), z.object({ percentile_ranks: z.lazy(() => AggregationsPercentileRanksAggregation) }), z.object({ percentiles: z.lazy(() => AggregationsPercentilesAggregation) }), z.object({ percentiles_bucket: AggregationsPercentilesBucketAggregation }), z.object({ range: z.lazy(() => AggregationsRangeAggregation) }), z.object({ rare_terms: AggregationsRareTermsAggregation }), z.object({ rate: z.lazy(() => AggregationsRateAggregation) }), z.object({ reverse_nested: AggregationsReverseNestedAggregation }), z.object({ sampler: AggregationsSamplerAggregation }), z.object({ scripted_metric: z.lazy(() => AggregationsScriptedMetricAggregation) }), z.object({ serial_diff: AggregationsSerialDifferencingAggregation }), z.object({ significant_terms: z.lazy(() => AggregationsSignificantTermsAggregation) }), z.object({ significant_text: z.lazy(() => AggregationsSignificantTextAggregation) }), z.object({ stats: z.lazy(() => AggregationsStatsAggregation) }), z.object({ stats_bucket: AggregationsStatsBucketAggregation }), z.object({ string_stats: z.lazy(() => AggregationsStringStatsAggregation) }), z.object({ sum: z.lazy(() => AggregationsSumAggregation) }), z.object({ sum_bucket: AggregationsSumBucketAggregation }), z.object({ terms: z.lazy(() => AggregationsTermsAggregation) }), z.object({ time_series: AggregationsTimeSeriesAggregation }), z.object({ top_hits: z.lazy(() => AggregationsTopHitsAggregation) }), z.object({ t_test: z.lazy(() => AggregationsTTestAggregation) }), z.object({ top_metrics: z.lazy(() => AggregationsTopMetricsAggregation) }), z.object({ value_count: z.lazy(() => AggregationsValueCountAggregation) }), z.object({ weighted_avg: z.lazy(() => AggregationsWeightedAverageAggregation) }), z.object({ variable_width_histogram: z.lazy(() => AggregationsVariableWidthHistogramAggregation) })])
+
+export interface AggregationsAggregationContainerShape {
+  aggregations?: Record<string, AggregationsAggregationContainerShape> | undefined
+  meta?: Metadata | undefined
+  adjacency_matrix?: AggregationsAdjacencyMatrixAggregation | undefined
+  auto_date_histogram?: AggregationsAutoDateHistogramAggregation | undefined
+  avg?: AggregationsAverageAggregation | undefined
+  avg_bucket?: AggregationsAverageBucketAggregation | undefined
+  boxplot?: AggregationsBoxplotAggregation | undefined
+  bucket_script?: AggregationsBucketScriptAggregation | undefined
+  bucket_selector?: AggregationsBucketSelectorAggregation | undefined
+  bucket_sort?: AggregationsBucketSortAggregation | undefined
+  bucket_count_ks_test?: AggregationsBucketKsAggregation | undefined
+  bucket_correlation?: AggregationsBucketCorrelationAggregation | undefined
+  cardinality?: AggregationsCardinalityAggregation | undefined
+  cartesian_bounds?: AggregationsCartesianBoundsAggregation | undefined
+  cartesian_centroid?: AggregationsCartesianCentroidAggregation | undefined
+  categorize_text?: AggregationsCategorizeTextAggregation | undefined
+  change_point?: AggregationsChangePointAggregation | undefined
+  children?: AggregationsChildrenAggregation | undefined
+  composite?: AggregationsCompositeAggregation | undefined
+  cumulative_cardinality?: AggregationsCumulativeCardinalityAggregation | undefined
+  cumulative_sum?: AggregationsCumulativeSumAggregation | undefined
+  date_histogram?: AggregationsDateHistogramAggregation | undefined
+  date_range?: AggregationsDateRangeAggregation | undefined
+  derivative?: AggregationsDerivativeAggregation | undefined
+  diversified_sampler?: AggregationsDiversifiedSamplerAggregation | undefined
+  extended_stats?: AggregationsExtendedStatsAggregation | undefined
+  extended_stats_bucket?: AggregationsExtendedStatsBucketAggregation | undefined
+  frequent_item_sets?: AggregationsFrequentItemSetsAggregation | undefined
+  filter?: QueryDslQueryContainer | undefined
+  filters?: AggregationsFiltersAggregation | undefined
+  geo_bounds?: AggregationsGeoBoundsAggregation | undefined
+  geo_centroid?: AggregationsGeoCentroidAggregation | undefined
+  geo_distance?: AggregationsGeoDistanceAggregation | undefined
+  geohash_grid?: AggregationsGeoHashGridAggregation | undefined
+  geo_line?: AggregationsGeoLineAggregation | undefined
+  geotile_grid?: AggregationsGeoTileGridAggregation | undefined
+  geohex_grid?: AggregationsGeohexGridAggregation | undefined
+  global?: AggregationsGlobalAggregation | undefined
+  histogram?: AggregationsHistogramAggregation | undefined
+  ip_range?: AggregationsIpRangeAggregation | undefined
+  ip_prefix?: AggregationsIpPrefixAggregation | undefined
+  inference?: AggregationsInferenceAggregation | undefined
+  line?: AggregationsGeoLineAggregation | undefined
+  matrix_stats?: AggregationsMatrixStatsAggregation | undefined
+  max?: AggregationsMaxAggregation | undefined
+  max_bucket?: AggregationsMaxBucketAggregation | undefined
+  median_absolute_deviation?: AggregationsMedianAbsoluteDeviationAggregation | undefined
+  min?: AggregationsMinAggregation | undefined
+  min_bucket?: AggregationsMinBucketAggregation | undefined
+  missing?: AggregationsMissingAggregation | undefined
+  moving_avg?: AggregationsMovingAverageAggregation | undefined
+  moving_percentiles?: AggregationsMovingPercentilesAggregation | undefined
+  moving_fn?: AggregationsMovingFunctionAggregation | undefined
+  multi_terms?: AggregationsMultiTermsAggregation | undefined
+  nested?: AggregationsNestedAggregation | undefined
+  normalize?: AggregationsNormalizeAggregation | undefined
+  parent?: AggregationsParentAggregation | undefined
+  percentile_ranks?: AggregationsPercentileRanksAggregation | undefined
+  percentiles?: AggregationsPercentilesAggregation | undefined
+  percentiles_bucket?: AggregationsPercentilesBucketAggregation | undefined
+  range?: AggregationsRangeAggregation | undefined
+  rare_terms?: AggregationsRareTermsAggregation | undefined
+  rate?: AggregationsRateAggregation | undefined
+  reverse_nested?: AggregationsReverseNestedAggregation | undefined
+  sampler?: AggregationsSamplerAggregation | undefined
+  scripted_metric?: AggregationsScriptedMetricAggregation | undefined
+  serial_diff?: AggregationsSerialDifferencingAggregation | undefined
+  significant_terms?: AggregationsSignificantTermsAggregation | undefined
+  significant_text?: AggregationsSignificantTextAggregation | undefined
+  stats?: AggregationsStatsAggregation | undefined
+  stats_bucket?: AggregationsStatsBucketAggregation | undefined
+  string_stats?: AggregationsStringStatsAggregation | undefined
+  sum?: AggregationsSumAggregation | undefined
+  sum_bucket?: AggregationsSumBucketAggregation | undefined
+  terms?: AggregationsTermsAggregation | undefined
+  time_series?: AggregationsTimeSeriesAggregation | undefined
+  top_hits?: AggregationsTopHitsAggregation | undefined
+  t_test?: AggregationsTTestAggregation | undefined
+  top_metrics?: AggregationsTopMetricsAggregation | undefined
+  value_count?: AggregationsValueCountAggregation | undefined
+  weighted_avg?: AggregationsWeightedAverageAggregation | undefined
+  variable_width_histogram?: AggregationsVariableWidthHistogramAggregation | undefined
+}
+export const AggregationsAggregationContainer: z.ZodType<AggregationsAggregationContainerShape> = AggregationsAggregationContainerCommonProps.and(AggregationsAggregationContainerExclusiveProps).meta({ id: 'AggregationsAggregationContainer' })
+export type AggregationsAggregationContainer = z.infer<typeof AggregationsAggregationContainer>
+
+/**
+ * Number of hits matching the query to count accurately. If true, the exact
+ * number of hits is returned at the cost of some performance. If false, the
+ * response does not include the total number of hits matching the query.
+ * Defaults to 10,000 hits.
+ */
+export const SearchTrackHits = z.union([z.boolean(), integer]).meta({ id: 'SearchTrackHits' })
+export type SearchTrackHits = z.infer<typeof SearchTrackHits>
+
+export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
+export type QueryVector = z.infer<typeof QueryVector>
+
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
+export const TextEmbedding = z.object({
+  model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
+  model_text: z.string().describe('The text to be converted into a vector by the specified model')
+}).meta({ id: 'TextEmbedding' })
+export type TextEmbedding = z.infer<typeof TextEmbedding>
+
+export const LookupQueryVectorBuilder = z.object({
+  id: z.string().describe('The ID of the document to fetch the vector from'),
+  index: z.string().describe('The name of the index to fetch the document from'),
+  path: z.string().describe('The name of the field containing the vector'),
+  routing: z.string().describe('The routing value to use when fetching the document').optional()
+}).meta({ id: 'LookupQueryVectorBuilder' })
+export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
+
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+
+export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
+export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
+
+export const RescoreVector = z.object({
+  oversample: float.describe('Applies the specified oversample factor to k on the approximate kNN search')
+}).meta({ id: 'RescoreVector' })
+export type RescoreVector = z.infer<typeof RescoreVector>
+
+export interface KnnSearchShape {
+  field: Field
+  query_vector?: QueryVector | undefined
+  query_vector_builder?: QueryVectorBuilder | undefined
+  k?: integer | undefined
+  num_candidates?: integer | undefined
+  visit_percentage?: float | undefined
+  boost?: float | undefined
+  filter?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+  similarity?: float | undefined
+  inner_hits?: SearchInnerHitsShape | undefined
+  rescore_vector?: RescoreVector | undefined
+  query_name?: string | undefined
+}
+export const KnnSearch = z.object({
+  field: Field.describe('The name of the vector field to search against'),
+  query_vector: QueryVector.describe('The query vector').optional(),
+  query_vector_builder: QueryVectorBuilder.describe('The query vector builder. You must provide a query_vector_builder or query_vector, but not both.').optional(),
+  k: integer.describe('The final number of nearest neighbors to return as top hits').optional(),
+  num_candidates: integer.describe('The number of nearest neighbor candidates to consider per shard').optional(),
+  visit_percentage: float.describe('The percentage of vectors to explore per shard while doing knn search with bbq_disk').optional(),
+  boost: float.describe('Boost value to apply to kNN scores').optional(),
+  get filter (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('Filters for the kNN search query').optional() },
+  similarity: float.describe('The minimum similarity for a vector to be considered a match').optional(),
+  get inner_hits () { return SearchInnerHits.describe('If defined, each search hit will contain inner hits.').optional() },
+  rescore_vector: RescoreVector.describe('Apply oversampling and rescoring to quantized vectors').optional(),
+  query_name: z.string().optional()
+}).meta({ id: 'KnnSearch' })
+export type KnnSearch = z.infer<typeof KnnSearch>
+
+export const SearchScoreMode = z.enum(['avg', 'max', 'min', 'multiply', 'total']).meta({ id: 'SearchScoreMode' })
+export type SearchScoreMode = z.infer<typeof SearchScoreMode>
+
+export interface SearchRescoreQueryShape {
+  Query: QueryDslQueryContainerShape
+  query_weight?: double | undefined
+  rescore_query_weight?: double | undefined
+  score_mode?: SearchScoreMode | undefined
+}
+export const SearchRescoreQuery = z.object({
+  get Query () { return QueryDslQueryContainer.describe('The query to use for rescoring. This query is only run on the Top-K results returned by the `query` and `post_filter` phases.') },
+  query_weight: double.describe('Relative importance of the original query versus the rescore query.').optional(),
+  rescore_query_weight: double.describe('Relative importance of the rescore query versus the original query.').optional(),
+  score_mode: SearchScoreMode.describe('Determines how scores are combined.').optional()
+}).meta({ id: 'SearchRescoreQuery' })
+export type SearchRescoreQuery = z.infer<typeof SearchRescoreQuery>
+
+export const SearchLearningToRank = z.object({
+  model_id: z.string().describe('The unique identifier of the trained model uploaded to Elasticsearch'),
+  params: z.record(z.string(), z.any()).describe('Named parameters to be passed to the query templates used for feature').optional()
+}).meta({ id: 'SearchLearningToRank' })
+export type SearchLearningToRank = z.infer<typeof SearchLearningToRank>
+
+export interface SearchScriptRescoreShape {
+  script: ScriptShape
+}
+export const SearchScriptRescore = z.object({
+  get script () { return z.union([Script, ScriptSource]) }
+}).meta({ id: 'SearchScriptRescore' })
+export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
+
+const SearchRescoreCommonProps = z.object({
+  window_size: integer.optional()
+})
+
+const SearchRescoreExclusiveProps = z.union([z.object({ query: z.lazy(() => SearchRescoreQuery) }), z.object({ learning_to_rank: SearchLearningToRank }), z.object({ script: z.lazy(() => SearchScriptRescore) })])
+
+export interface SearchRescoreShape {
+  window_size?: integer | undefined
+  query?: SearchRescoreQuery | undefined
+  learning_to_rank?: SearchLearningToRank | undefined
+  script?: SearchScriptRescore | undefined
+}
+export const SearchRescore: z.ZodType<SearchRescoreShape> = SearchRescoreCommonProps.and(SearchRescoreExclusiveProps).meta({ id: 'SearchRescore' })
+export type SearchRescore = z.infer<typeof SearchRescore>
+
+export interface RetrieverBaseShape {
+  filter?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+  min_score?: float | undefined
+  _name?: string | undefined
+}
+export const RetrieverBase = z.object({
+  get filter (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('Query to filter the documents that can match.').optional() },
+  min_score: float.describe('Minimum _score for matching documents. Documents with a lower _score are not included in the top documents.').optional(),
+  _name: z.string().describe('Retriever name.').optional()
+}).meta({ id: 'RetrieverBase' })
+export type RetrieverBase = z.infer<typeof RetrieverBase>
+
+export const SortResults = z.array(FieldValue).meta({ id: 'SortResults' })
+export type SortResults = z.infer<typeof SortResults>
+
+export interface StandardRetrieverShape {
+  filter?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+  min_score?: float | undefined
+  _name?: string | undefined
+  query?: QueryDslQueryContainerShape | undefined
+  search_after?: SortResults | undefined
+  terminate_after?: integer | undefined
+  sort?: SortShape | undefined
+  collapse?: SearchFieldCollapseShape | undefined
+}
+export const StandardRetriever = z.object({
+  get filter (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('Query to filter the documents that can match.').optional() },
+  min_score: float.describe('Minimum _score for matching documents. Documents with a lower _score are not included in the top documents.').optional(),
+  _name: z.string().describe('Retriever name.').optional(),
+  get query () { return QueryDslQueryContainer.describe('Defines a query to retrieve a set of top documents.').optional() },
+  search_after: SortResults.describe('Defines a search after object parameter used for pagination.').optional(),
+  terminate_after: integer.describe('Maximum number of documents to collect for each shard.').optional(),
+  get sort () { return Sort.describe('A sort object that that specifies the order of matching documents.').optional() },
+  get collapse () { return SearchFieldCollapse.describe('Collapses the top documents by a specified key into a single top document per key.').optional() }
+}).meta({ id: 'StandardRetriever' })
+export type StandardRetriever = z.infer<typeof StandardRetriever>
+
+export interface KnnRetrieverShape {
+  filter?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+  min_score?: float | undefined
+  _name?: string | undefined
+  field: string
+  query_vector?: QueryVector | undefined
+  query_vector_builder?: QueryVectorBuilder | undefined
+  k: integer
+  num_candidates: integer
+  visit_percentage?: float | undefined
+  similarity?: float | undefined
+  rescore_vector?: RescoreVector | undefined
+}
+export const KnnRetriever = z.object({
+  get filter (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('Query to filter the documents that can match.').optional() },
+  min_score: float.describe('Minimum _score for matching documents. Documents with a lower _score are not included in the top documents.').optional(),
+  _name: z.string().describe('Retriever name.').optional(),
+  field: z.string().describe('The name of the vector field to search against.'),
+  query_vector: QueryVector.describe('Query vector. Must have the same number of dimensions as the vector field you are searching against. You must provide a query_vector_builder or query_vector, but not both.').optional(),
+  query_vector_builder: QueryVectorBuilder.describe('Defines a model to build a query vector.').optional(),
+  k: integer.describe('Number of nearest neighbors to return as top hits.'),
+  num_candidates: integer.describe('Number of nearest neighbor candidates to consider per shard.'),
+  visit_percentage: float.describe('The percentage of vectors to explore per shard while doing knn search with bbq_disk').optional(),
+  similarity: float.describe('The minimum similarity required for a document to be considered a match.').optional(),
+  rescore_vector: RescoreVector.describe('Apply oversampling and rescoring to quantized vectors').optional()
+}).meta({ id: 'KnnRetriever' })
+export type KnnRetriever = z.infer<typeof KnnRetriever>
+
+export interface RRFRetrieverComponentShape {
+  retriever: RetrieverContainerShape
+  weight?: float | undefined
+}
+/** Wraps a retriever with an optional weight for RRF scoring. */
+export const RRFRetrieverComponent = z.object({
+  get retriever () { return RetrieverContainer.describe('The nested retriever configuration.') },
+  weight: float.describe('Weight multiplier for this retriever\'s contribution to the RRF score. Higher values increase influence. Defaults to 1.0 if not specified. Must be non-negative.').optional()
+}).meta({ id: 'RRFRetrieverComponent' })
+export type RRFRetrieverComponent = z.infer<typeof RRFRetrieverComponent>
+
+export type RRFRetrieverEntryShape = RetrieverContainerShape | RRFRetrieverComponentShape
+/** Either a direct RetrieverContainer (backward compatible) or an RRFRetrieverComponent with weight. */
+export const RRFRetrieverEntry: z.ZodType<RRFRetrieverEntryShape> = z.union([z.lazy(() => RetrieverContainer), z.lazy(() => RRFRetrieverComponent)]).meta({ id: 'RRFRetrieverEntry' })
+export type RRFRetrieverEntry = z.infer<typeof RRFRetrieverEntry>
+
+export interface RRFRetrieverShape {
+  filter?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+  min_score?: float | undefined
+  _name?: string | undefined
+  retrievers: RRFRetrieverEntryShape[]
+  rank_constant?: integer | undefined
+  rank_window_size?: integer | undefined
+  query?: string | undefined
+  fields?: string[] | undefined
+}
+export const RRFRetriever = z.object({
+  get filter (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('Query to filter the documents that can match.').optional() },
+  min_score: float.describe('Minimum _score for matching documents. Documents with a lower _score are not included in the top documents.').optional(),
+  _name: z.string().describe('Retriever name.').optional(),
+  get retrievers () { return RRFRetrieverEntry.array().describe('A list of child retrievers to specify which sets of returned top documents will have the RRF formula applied to them. Each retriever can optionally include a weight parameter.') },
+  rank_constant: integer.describe('This value determines how much influence documents in individual result sets per query have over the final ranked result set.').optional(),
+  rank_window_size: integer.describe('This value determines the size of the individual result sets per query.').optional(),
+  query: z.string().optional(),
+  fields: z.array(z.string()).optional()
+}).meta({ id: 'RRFRetriever' })
+export type RRFRetriever = z.infer<typeof RRFRetriever>
+
+export const MappingChunkRescorerChunkingSettings = z.object({
+  max_chunk_size: integer.describe('The maximum size of a chunk in words. This value cannot be lower than `20` (for `sentence` strategy) or `10` (for `word` strategy). This value should not exceed the window size for the associated model.'),
+  overlap: integer.describe('The number of overlapping words for chunks. It is applicable only to a `word` chunking strategy. This value cannot be higher than half the `max_chunk_size` value.').optional(),
+  sentence_overlap: integer.describe('The number of overlapping sentences for chunks. It is applicable only for a `sentence` chunking strategy. It can be either `1` or `0`.').optional(),
+  separator_group: z.string().describe('Only applicable to the `recursive` strategy and required when using it. Sets a predefined list of separators in the saved chunking settings based on the selected text type. Values can be `markdown` or `plaintext`. Using this parameter is an alternative to manually specifying a custom `separators` list.').optional(),
+  separators: z.array(z.string()).describe('Only applicable to the `recursive` strategy and required when using it. A list of strings used as possible split points when chunking text. Each string can be a plain string or a regular expression (regex) pattern. The system tries each separator in order to split the text, starting from the first item in the list. After splitting, it attempts to recombine smaller pieces into larger chunks that stay within the `max_chunk_size` limit, to reduce the total number of chunks generated.').optional(),
+  strategy: z.string().describe('The chunking strategy: `sentence`, `word`, `none` or `recursive`.  * If `strategy` is set to `recursive`, you must also specify: - `max_chunk_size` - either `separators` or`separator_group` Learn more about different chunking strategies in the linked documentation.').optional()
+}).meta({ id: 'MappingChunkRescorerChunkingSettings' })
+export type MappingChunkRescorerChunkingSettings = z.infer<typeof MappingChunkRescorerChunkingSettings>
+
+export const ChunkRescorer = z.object({
+  size: integer.describe('The number of chunks per document to evaluate for reranking.').optional(),
+  chunking_settings: MappingChunkRescorerChunkingSettings.describe('Chunking settings to apply').optional()
+}).meta({ id: 'ChunkRescorer' })
+export type ChunkRescorer = z.infer<typeof ChunkRescorer>
+
+export interface TextSimilarityRerankerShape {
+  filter?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+  min_score?: float | undefined
+  _name?: string | undefined
+  retriever: RetrieverContainerShape
+  rank_window_size?: integer | undefined
+  inference_id?: string | undefined
+  inference_text: string
+  field: string
+  chunk_rescorer?: ChunkRescorer | undefined
+}
+export const TextSimilarityReranker = z.object({
+  get filter (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('Query to filter the documents that can match.').optional() },
+  min_score: float.describe('Minimum _score for matching documents. Documents with a lower _score are not included in the top documents.').optional(),
+  _name: z.string().describe('Retriever name.').optional(),
+  get retriever () { return RetrieverContainer.describe('The nested retriever which will produce the first-level results, that will later be used for reranking.') },
+  rank_window_size: integer.describe('This value determines how many documents we will consider from the nested retriever.').optional(),
+  inference_id: z.string().describe('Unique identifier of the inference endpoint created using the inference API.').optional(),
+  inference_text: z.string().describe('The text snippet used as the basis for similarity comparison.'),
+  field: z.string().describe('The document field to be used for text similarity comparisons. This field should contain the text that will be evaluated against the inference_text.'),
+  chunk_rescorer: ChunkRescorer.describe('Whether to rescore on only the best matching chunks.').optional()
+}).meta({ id: 'TextSimilarityReranker' })
+export type TextSimilarityReranker = z.infer<typeof TextSimilarityReranker>
+
 export const Id = z.string().meta({ id: 'Id' })
 export type Id = z.infer<typeof Id>
+
+export interface RuleRetrieverShape {
+  filter?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+  min_score?: float | undefined
+  _name?: string | undefined
+  ruleset_ids: Id | Id[]
+  match_criteria: unknown
+  retriever: RetrieverContainerShape
+  rank_window_size?: integer | undefined
+}
+export const RuleRetriever = z.object({
+  get filter (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('Query to filter the documents that can match.').optional() },
+  min_score: float.describe('Minimum _score for matching documents. Documents with a lower _score are not included in the top documents.').optional(),
+  _name: z.string().describe('Retriever name.').optional(),
+  ruleset_ids: z.union([Id, z.array(Id)]).describe('The ruleset IDs containing the rules this retriever is evaluating against.'),
+  match_criteria: z.any().describe('The match criteria that will determine if a rule in the provided rulesets should be applied.'),
+  get retriever () { return RetrieverContainer.describe('The retriever whose results rules should be applied to.') },
+  rank_window_size: integer.describe('This value determines the size of the individual result set.').optional()
+}).meta({ id: 'RuleRetriever' })
+export type RuleRetriever = z.infer<typeof RuleRetriever>
+
+export interface RescorerRetrieverShape {
+  filter?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+  min_score?: float | undefined
+  _name?: string | undefined
+  retriever: RetrieverContainerShape
+  rescore: SearchRescoreShape | SearchRescoreShape[]
+}
+export const RescorerRetriever = z.object({
+  get filter (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('Query to filter the documents that can match.').optional() },
+  min_score: float.describe('Minimum _score for matching documents. Documents with a lower _score are not included in the top documents.').optional(),
+  _name: z.string().describe('Retriever name.').optional(),
+  get retriever () { return RetrieverContainer.describe('Inner retriever.') },
+  get rescore (): z.ZodUnion<readonly [typeof SearchRescore, z.ZodArray<typeof SearchRescore>]> { return z.union([SearchRescore, SearchRescore.array()]) }
+}).meta({ id: 'RescorerRetriever' })
+export type RescorerRetriever = z.infer<typeof RescorerRetriever>
+
+export const ScoreNormalizer = z.enum(['none', 'minmax', 'l2_norm']).meta({ id: 'ScoreNormalizer' })
+export type ScoreNormalizer = z.infer<typeof ScoreNormalizer>
+
+export interface InnerRetrieverShape {
+  retriever: RetrieverContainerShape
+  weight: float
+  normalizer: ScoreNormalizer
+}
+export const InnerRetriever = z.object({
+  get retriever () { return RetrieverContainer },
+  weight: float,
+  normalizer: ScoreNormalizer
+}).meta({ id: 'InnerRetriever' })
+export type InnerRetriever = z.infer<typeof InnerRetriever>
+
+export interface LinearRetrieverShape {
+  filter?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+  min_score?: float | undefined
+  _name?: string | undefined
+  retrievers?: InnerRetrieverShape[] | undefined
+  rank_window_size?: integer | undefined
+  query?: string | undefined
+  fields?: string[] | undefined
+  normalizer?: ScoreNormalizer | undefined
+}
+export const LinearRetriever = z.object({
+  get filter (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('Query to filter the documents that can match.').optional() },
+  min_score: float.describe('Minimum _score for matching documents. Documents with a lower _score are not included in the top documents.').optional(),
+  _name: z.string().describe('Retriever name.').optional(),
+  get retrievers () { return InnerRetriever.array().describe('Inner retrievers.').optional() },
+  rank_window_size: integer.optional(),
+  query: z.string().optional(),
+  fields: z.array(z.string()).optional(),
+  normalizer: ScoreNormalizer.optional()
+}).meta({ id: 'LinearRetriever' })
+export type LinearRetriever = z.infer<typeof LinearRetriever>
+
+export const SpecifiedDocument = z.object({
+  index: IndexName.optional(),
+  id: Id
+}).meta({ id: 'SpecifiedDocument' })
+export type SpecifiedDocument = z.infer<typeof SpecifiedDocument>
+
+export interface PinnedRetrieverShape {
+  filter?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+  min_score?: float | undefined
+  _name?: string | undefined
+  retriever: RetrieverContainerShape
+  ids?: string[] | undefined
+  docs?: SpecifiedDocument[] | undefined
+  rank_window_size?: integer | undefined
+}
+export const PinnedRetriever = z.object({
+  get filter (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('Query to filter the documents that can match.').optional() },
+  min_score: float.describe('Minimum _score for matching documents. Documents with a lower _score are not included in the top documents.').optional(),
+  _name: z.string().describe('Retriever name.').optional(),
+  get retriever () { return RetrieverContainer.describe('Inner retriever.') },
+  ids: z.array(z.string()).optional(),
+  docs: z.array(SpecifiedDocument).optional(),
+  rank_window_size: integer.optional()
+}).meta({ id: 'PinnedRetriever' })
+export type PinnedRetriever = z.infer<typeof PinnedRetriever>
+
+export const DiversifyRetrieverTypes = z.enum(['mmr']).meta({ id: 'DiversifyRetrieverTypes' })
+export type DiversifyRetrieverTypes = z.infer<typeof DiversifyRetrieverTypes>
+
+export interface DiversifyRetrieverShape {
+  filter?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+  min_score?: float | undefined
+  _name?: string | undefined
+  type: DiversifyRetrieverTypes
+  field: string
+  retriever: RetrieverContainerShape
+  size?: integer | undefined
+  rank_window_size?: integer | undefined
+  query_vector?: QueryVector | undefined
+  query_vector_builder?: QueryVectorBuilder | undefined
+  lambda?: float | undefined
+}
+export const DiversifyRetriever = z.object({
+  get filter (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('Query to filter the documents that can match.').optional() },
+  min_score: float.describe('Minimum _score for matching documents. Documents with a lower _score are not included in the top documents.').optional(),
+  _name: z.string().describe('Retriever name.').optional(),
+  type: DiversifyRetrieverTypes.describe('The diversification strategy to apply.'),
+  field: z.string().describe('The document field on which to diversify results on.'),
+  get retriever () { return RetrieverContainer.describe('The nested retriever whose results will be diversified.') },
+  size: integer.describe('The number of top documents to return after diversification.').optional(),
+  rank_window_size: integer.describe('The number of top documents from the nested retriever to consider for diversification.').optional(),
+  query_vector: QueryVector.describe('The query vector used for diversification.').optional(),
+  query_vector_builder: QueryVectorBuilder.describe('a dense vector query vector builder to use instead of a static query_vector').optional(),
+  lambda: float.describe('Controls the trade-off between relevance and diversity for MMR. A value of 0.0 focuses solely on diversity, while a value of 1.0 focuses solely on relevance. Required for MMR').optional()
+}).meta({ id: 'DiversifyRetriever' })
+export type DiversifyRetriever = z.infer<typeof DiversifyRetriever>
+
+const RetrieverContainerExclusiveProps = z.union([z.object({ standard: z.lazy(() => StandardRetriever) }), z.object({ knn: z.lazy(() => KnnRetriever) }), z.object({ rrf: z.lazy(() => RRFRetriever) }), z.object({ text_similarity_reranker: z.lazy(() => TextSimilarityReranker) }), z.object({ rule: z.lazy(() => RuleRetriever) }), z.object({ rescorer: z.lazy(() => RescorerRetriever) }), z.object({ linear: z.lazy(() => LinearRetriever) }), z.object({ pinned: z.lazy(() => PinnedRetriever) }), z.object({ diversify: z.lazy(() => DiversifyRetriever) })])
+
+export interface RetrieverContainerShape {
+  standard?: StandardRetriever | undefined
+  knn?: KnnRetriever | undefined
+  rrf?: RRFRetriever | undefined
+  text_similarity_reranker?: TextSimilarityReranker | undefined
+  rule?: RuleRetriever | undefined
+  rescorer?: RescorerRetriever | undefined
+  linear?: LinearRetriever | undefined
+  pinned?: PinnedRetriever | undefined
+  diversify?: DiversifyRetriever | undefined
+}
+export const RetrieverContainer: z.ZodType<RetrieverContainerShape> = RetrieverContainerExclusiveProps.meta({ id: 'RetrieverContainer' })
+export type RetrieverContainer = z.infer<typeof RetrieverContainer>
+
+export const SlicedScroll = z.object({
+  field: Field.optional(),
+  id: Id,
+  max: integer
+}).meta({ id: 'SlicedScroll' })
+export type SlicedScroll = z.infer<typeof SlicedScroll>
+
+export const SearchSuggester = z.object({
+  text: z.string().describe('Global suggest text, to avoid repetition when the same text is used in several suggesters').optional()
+}).catchall(z.any()).meta({ id: 'SearchSuggester' })
+export type SearchSuggester = z.infer<typeof SearchSuggester>
+
+export const SearchPointInTimeReference = z.object({
+  id: Id,
+  keep_alive: Duration.optional()
+}).meta({ id: 'SearchPointInTimeReference' })
+export type SearchPointInTimeReference = z.infer<typeof SearchPointInTimeReference>
+
+export const MappingRuntimeFieldType = z.enum(['boolean', 'composite', 'date', 'double', 'geo_point', 'geo_shape', 'ip', 'keyword', 'long', 'lookup']).meta({ id: 'MappingRuntimeFieldType' })
+export type MappingRuntimeFieldType = z.infer<typeof MappingRuntimeFieldType>
+
+export const MappingCompositeSubField = z.object({
+  type: MappingRuntimeFieldType
+}).meta({ id: 'MappingCompositeSubField' })
+export type MappingCompositeSubField = z.infer<typeof MappingCompositeSubField>
+
+export const MappingRuntimeFieldFetchFields = z.object({
+  field: Field,
+  format: z.string().optional()
+}).meta({ id: 'MappingRuntimeFieldFetchFields' })
+export type MappingRuntimeFieldFetchFields = z.infer<typeof MappingRuntimeFieldFetchFields>
+
+export interface MappingRuntimeFieldShape {
+  fields?: Record<string, MappingCompositeSubField> | undefined
+  fetch_fields?: MappingRuntimeFieldFetchFields[] | undefined
+  format?: string | undefined
+  input_field?: Field | undefined
+  target_field?: Field | undefined
+  target_index?: IndexName | undefined
+  script?: ScriptShape | undefined
+  type: MappingRuntimeFieldType
+}
+export const MappingRuntimeField = z.object({
+  fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
+  format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
+  input_field: Field.describe('For type `lookup`').optional(),
+  target_field: Field.describe('For type `lookup`').optional(),
+  target_index: IndexName.describe('For type `lookup`').optional(),
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
+  type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
+}).meta({ id: 'MappingRuntimeField' })
+export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
+
+export type MappingRuntimeFieldsShape = Record<Field, MappingRuntimeFieldShape>
+export const MappingRuntimeFields: z.ZodType<MappingRuntimeFieldsShape> = z.record(Field, z.lazy(() => MappingRuntimeField)).meta({ id: 'MappingRuntimeFields' })
+export type MappingRuntimeFields = z.infer<typeof MappingRuntimeFields>
+
+export interface SearchSearchRequestBodyShape {
+  aggregations?: Record<string, AggregationsAggregationContainerShape> | undefined
+  collapse?: SearchFieldCollapseShape | undefined
+  explain?: boolean | undefined
+  ext?: Record<string, unknown> | undefined
+  from?: integer | undefined
+  highlight?: SearchHighlightShape | undefined
+  track_total_hits?: SearchTrackHits | undefined
+  indices_boost?: Array<Record<IndexName, double>> | undefined
+  docvalue_fields?: QueryDslFieldAndFormat[] | undefined
+  knn?: KnnSearchShape | KnnSearchShape[] | undefined
+  min_score?: double | undefined
+  post_filter?: QueryDslQueryContainerShape | undefined
+  profile?: boolean | undefined
+  query?: QueryDslQueryContainerShape | undefined
+  rescore?: SearchRescoreShape | SearchRescoreShape[] | undefined
+  retriever?: RetrieverContainerShape | undefined
+  script_fields?: Record<string, ScriptFieldShape> | undefined
+  search_after?: SortResults | undefined
+  size?: integer | undefined
+  slice?: SlicedScroll | undefined
+  sort?: SortShape | undefined
+  _source?: SearchSourceConfig | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
+  suggest?: SearchSuggester | undefined
+  terminate_after?: long | undefined
+  timeout?: string | undefined
+  track_scores?: boolean | undefined
+  version?: boolean | undefined
+  seq_no_primary_term?: boolean | undefined
+  stored_fields?: Fields | undefined
+  pit?: SearchPointInTimeReference | undefined
+  runtime_mappings?: MappingRuntimeFieldsShape | undefined
+  stats?: string[] | undefined
+}
+export const SearchSearchRequestBody = z.object({
+  get aggregations (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof AggregationsAggregationContainer>> { return z.record(z.string(), AggregationsAggregationContainer).describe('Defines the aggregations that are run as part of the search request.').optional() },
+  get collapse () { return SearchFieldCollapse.describe('Collapses search results the values of the specified field.').optional() },
+  explain: z.boolean().describe('If `true`, the request returns detailed information about score computation as part of a hit.').optional(),
+  ext: z.record(z.string(), z.any()).describe('Configuration of search extensions defined by Elasticsearch plugins.').optional(),
+  from: integer.describe('The starting document offset, which must be non-negative. By default, you cannot page through more than 10,000 hits using the `from` and `size` parameters. To page through more hits, use the `search_after` parameter.').optional(),
+  get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
+  track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
+  indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
+  min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
+  get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
+  profile: z.boolean().describe('Set to `true` to return detailed timing information about the execution of individual components in a search request. NOTE: This is a debugging tool and adds significant overhead to search execution.').optional(),
+  get query () { return QueryDslQueryContainer.describe('The search definition using the Query DSL.').optional() },
+  get rescore (): z.ZodOptional<z.ZodUnion<readonly [typeof SearchRescore, z.ZodArray<typeof SearchRescore>]>> { return z.union([SearchRescore, SearchRescore.array()]).describe('Can be used to improve precision by reordering just the top (for example 100 - 500) documents returned by the `query` and `post_filter` phases.').optional() },
+  get retriever () { return RetrieverContainer.describe('A retriever is a specification to describe top documents returned from a search. A retriever replaces other elements of the search API that also return top documents such as `query` and `knn`.').optional() },
+  get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Retrieve a script evaluation (based on different fields) for each hit.').optional() },
+  search_after: SortResults.describe('Used to retrieve the next page of hits using a set of sort values from the previous page.').optional(),
+  size: integer.describe('The number of hits to return, which must not be negative. By default, you cannot page through more than 10,000 hits using the `from` and `size` parameters. To page through more hits, use the `search_after` property.').optional(),
+  slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
+  get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
+  _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
+  terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
+  timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
+  track_scores: z.boolean().describe('If `true`, calculate and return document scores, even if the scores are not used for sorting.').optional(),
+  version: z.boolean().describe('If `true`, the request returns the document version as part of a hit.').optional(),
+  seq_no_primary_term: z.boolean().describe('If `true`, the request returns sequence number and primary term of the last modification of each hit.').optional(),
+  stored_fields: Fields.describe('A comma-separated list of stored fields to return as part of a hit. If no fields are specified, no stored fields are included in the response. If this field is specified, the `_source` property defaults to `false`. You can pass `_source: true` to return both source fields and stored fields in the search response.').optional(),
+  pit: SearchPointInTimeReference.describe('Limit the search to a point in time (PIT). If you provide a PIT, you cannot specify an `<index>` in the request path.').optional(),
+  get runtime_mappings () { return MappingRuntimeFields.describe('One or more runtime fields in the search request. These fields take precedence over mapped fields with the same name.').optional() },
+  stats: z.array(z.string()).describe('The stats groups to associate with the search. Each group maintains a statistics aggregation for its associated searches. You can retrieve these stats using the indices stats API.').optional()
+}).meta({ id: 'SearchSearchRequestBody' })
+export type SearchSearchRequestBody = z.infer<typeof SearchSearchRequestBody>
+
+export type ScriptSourceShape = string | SearchSearchRequestBodyShape
+export const ScriptSource: z.ZodType<ScriptSourceShape> = z.union([z.string(), z.lazy(() => SearchSearchRequestBody)]).meta({ id: 'ScriptSource' })
+export type ScriptSource = z.infer<typeof ScriptSource>
+
+export const ScriptLanguage = z.union([z.enum(['painless', 'expression', 'mustache', 'java']), z.string()]).meta({ id: 'ScriptLanguage' })
+export type ScriptLanguage = z.infer<typeof ScriptLanguage>
+
+export interface ScriptShape {
+  source?: ScriptSourceShape | undefined
+  id?: Id | undefined
+  params?: Record<string, unknown> | undefined
+  lang?: ScriptLanguage | undefined
+  options?: Record<string, string> | undefined
+}
+export const Script = z.object({
+  get source () { return ScriptSource.describe('The script source.').optional() },
+  id: Id.describe('The `id` for a stored script.').optional(),
+  params: z.record(z.string(), z.any()).describe('Specifies any named parameters that are passed into the script as variables. Use parameters instead of hard-coded values to decrease compile time.').optional(),
+  lang: ScriptLanguage.describe('Specifies the language the script is written in.').optional(),
+  options: z.record(z.string(), z.string()).optional()
+}).meta({ id: 'Script' })
+export type Script = z.infer<typeof Script>
+
+export interface QueryDslScriptScoreFunctionShape {
+  script: ScriptShape
+}
+export const QueryDslScriptScoreFunction = z.object({
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
+}).meta({ id: 'QueryDslScriptScoreFunction' })
+export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
+
+const QueryDslFunctionScoreContainerCommonProps = z.object({
+  filter: z.lazy(() => QueryDslQueryContainer).optional(),
+  weight: double.optional()
+})
+
+const QueryDslFunctionScoreContainerExclusiveProps = z.union([z.object({ exp: QueryDslDecayFunction }), z.object({ gauss: QueryDslDecayFunction }), z.object({ linear: QueryDslDecayFunction }), z.object({ field_value_factor: QueryDslFieldValueFactorScoreFunction }), z.object({ random_score: QueryDslRandomScoreFunction }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreFunction) })])
+
+export interface QueryDslFunctionScoreContainerShape {
+  filter?: QueryDslQueryContainerShape | undefined
+  weight?: double | undefined
+  exp?: QueryDslDecayFunction | undefined
+  gauss?: QueryDslDecayFunction | undefined
+  linear?: QueryDslDecayFunction | undefined
+  field_value_factor?: QueryDslFieldValueFactorScoreFunction | undefined
+  random_score?: QueryDslRandomScoreFunction | undefined
+  script_score?: QueryDslScriptScoreFunction | undefined
+}
+export const QueryDslFunctionScoreContainer: z.ZodType<QueryDslFunctionScoreContainerShape> = QueryDslFunctionScoreContainerCommonProps.and(QueryDslFunctionScoreContainerExclusiveProps).meta({ id: 'QueryDslFunctionScoreContainer' })
+export type QueryDslFunctionScoreContainer = z.infer<typeof QueryDslFunctionScoreContainer>
+
+export const QueryDslFunctionScoreMode = z.enum(['multiply', 'sum', 'avg', 'first', 'max', 'min']).meta({ id: 'QueryDslFunctionScoreMode' })
+export type QueryDslFunctionScoreMode = z.infer<typeof QueryDslFunctionScoreMode>
+
+export interface QueryDslFunctionScoreQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  boost_mode?: QueryDslFunctionBoostMode | undefined
+  functions?: QueryDslFunctionScoreContainerShape[] | undefined
+  max_boost?: double | undefined
+  min_score?: double | undefined
+  query?: QueryDslQueryContainerShape | undefined
+  score_mode?: QueryDslFunctionScoreMode | undefined
+}
+export const QueryDslFunctionScoreQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  boost_mode: QueryDslFunctionBoostMode.describe('Defines how he newly computed score is combined with the score of the query').optional(),
+  get functions () { return QueryDslFunctionScoreContainer.array().describe('One or more functions that compute a new score for each document returned by the query.').optional() },
+  max_boost: double.describe('Restricts the new score to not exceed the provided limit.').optional(),
+  min_score: double.describe('Excludes documents that do not meet the provided score threshold.').optional(),
+  get query () { return QueryDslQueryContainer.describe('A query that determines the documents for which a new score is computed.').optional() },
+  score_mode: QueryDslFunctionScoreMode.describe('Specifies how the computed scores are combined').optional()
+}).meta({ id: 'QueryDslFunctionScoreQuery' })
+export type QueryDslFunctionScoreQuery = z.infer<typeof QueryDslFunctionScoreQuery>
+
+export const MultiTermQueryRewrite = z.string().meta({ id: 'MultiTermQueryRewrite' })
+export type MultiTermQueryRewrite = z.infer<typeof MultiTermQueryRewrite>
+
+export const Fuzziness = z.union([z.string(), integer]).meta({ id: 'Fuzziness' })
+export type Fuzziness = z.infer<typeof Fuzziness>
+
+export const QueryDslFuzzyQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  max_expansions: integer.describe('Maximum number of variations created.').optional(),
+  prefix_length: integer.describe('Number of beginning characters left unchanged when creating expansions.').optional(),
+  rewrite: MultiTermQueryRewrite.describe('Number of beginning characters left unchanged when creating expansions.').optional(),
+  transpositions: z.boolean().describe('Indicates whether edits include transpositions of two adjacent characters (for example `ab` to `ba`).').optional(),
+  fuzziness: Fuzziness.describe('Maximum edit distance allowed for matching.').optional(),
+  value: z.union([z.string(), double, z.boolean()]).describe('Term you wish to find in the provided field.')
+}).meta({ id: 'QueryDslFuzzyQuery' })
+export type QueryDslFuzzyQuery = z.infer<typeof QueryDslFuzzyQuery>
+
+export const QueryDslGeoExecution = z.enum(['memory', 'indexed']).meta({ id: 'QueryDslGeoExecution' })
+export type QueryDslGeoExecution = z.infer<typeof QueryDslGeoExecution>
+
+export const QueryDslGeoValidationMethod = z.enum(['coerce', 'ignore_malformed', 'strict']).meta({ id: 'QueryDslGeoValidationMethod' })
+export type QueryDslGeoValidationMethod = z.infer<typeof QueryDslGeoValidationMethod>
+
+export const QueryDslGeoBoundingBoxQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  type: QueryDslGeoExecution.optional(),
+  validation_method: QueryDslGeoValidationMethod.describe('Set to `IGNORE_MALFORMED` to accept geo points with invalid latitude or longitude. Set to `COERCE` to also try to infer correct latitude or longitude.').optional(),
+  ignore_unmapped: z.boolean().describe('Set to `true` to ignore an unmapped field and not match any documents for this query. Set to `false` to throw an exception if the field is not mapped.').optional()
+}).catchall(z.any()).meta({ id: 'QueryDslGeoBoundingBoxQuery' })
+export type QueryDslGeoBoundingBoxQuery = z.infer<typeof QueryDslGeoBoundingBoxQuery>
+
+export const Distance = z.string().meta({ id: 'Distance' })
+export type Distance = z.infer<typeof Distance>
+
+export const QueryDslGeoDistanceQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  distance: Distance.describe('The radius of the circle centred on the specified location. Points which fall into this circle are considered to be matches.'),
+  distance_type: GeoDistanceType.describe('How to compute the distance. Set to `plane` for a faster calculation that\'s inaccurate on long distances and close to the poles.').optional(),
+  validation_method: QueryDslGeoValidationMethod.describe('Set to `IGNORE_MALFORMED` to accept geo points with invalid latitude or longitude. Set to `COERCE` to also try to infer correct latitude or longitude.').optional(),
+  ignore_unmapped: z.boolean().describe('Set to `true` to ignore an unmapped field and not match any documents for this query. Set to `false` to throw an exception if the field is not mapped.').optional()
+}).catchall(z.any()).meta({ id: 'QueryDslGeoDistanceQuery' })
+export type QueryDslGeoDistanceQuery = z.infer<typeof QueryDslGeoDistanceQuery>
+
+/** A map tile reference, represented as `{zoom}/{x}/{y}` */
+export const GeoTile = z.string().meta({ id: 'GeoTile' })
+export type GeoTile = z.infer<typeof GeoTile>
+
+/** A map hex cell (H3) reference */
+export const GeoHexCell = z.string().meta({ id: 'GeoHexCell' })
+export type GeoHexCell = z.infer<typeof GeoHexCell>
+
+const QueryDslGeoGridQueryExclusiveProps = z.union([z.object({ geotile: GeoTile }), z.object({ geohash: GeoHash }), z.object({ geohex: GeoHexCell })])
+
+export const QueryDslGeoGridQuery = QueryDslGeoGridQueryExclusiveProps.meta({ id: 'QueryDslGeoGridQuery' })
+export type QueryDslGeoGridQuery = z.infer<typeof QueryDslGeoGridQuery>
+
+export const QueryDslGeoPolygonQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  validation_method: QueryDslGeoValidationMethod.optional(),
+  ignore_unmapped: z.boolean().optional()
+}).catchall(z.any()).meta({ id: 'QueryDslGeoPolygonQuery' })
+export type QueryDslGeoPolygonQuery = z.infer<typeof QueryDslGeoPolygonQuery>
+
+export const QueryDslGeoShapeQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  ignore_unmapped: z.boolean().describe('Set to `true` to ignore an unmapped field and not match any documents for this query. Set to `false` to throw an exception if the field is not mapped.').optional()
+}).catchall(z.any()).meta({ id: 'QueryDslGeoShapeQuery' })
+export type QueryDslGeoShapeQuery = z.infer<typeof QueryDslGeoShapeQuery>
+
+export const QueryDslChildScoreMode = z.enum(['none', 'avg', 'sum', 'max', 'min']).meta({ id: 'QueryDslChildScoreMode' })
+export type QueryDslChildScoreMode = z.infer<typeof QueryDslChildScoreMode>
+
+export interface QueryDslHasChildQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  ignore_unmapped?: boolean | undefined
+  inner_hits?: SearchInnerHitsShape | undefined
+  max_children?: integer | undefined
+  min_children?: integer | undefined
+  query: QueryDslQueryContainerShape
+  score_mode?: QueryDslChildScoreMode | undefined
+  type: RelationName
+}
+export const QueryDslHasChildQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  ignore_unmapped: z.boolean().describe('Indicates whether to ignore an unmapped `type` and not return any documents instead of an error.').optional(),
+  get inner_hits () { return SearchInnerHits.describe('If defined, each search hit will contain inner hits.').optional() },
+  max_children: integer.describe('Maximum number of child documents that match the query allowed for a returned parent document. If the parent document exceeds this limit, it is excluded from the search results.').optional(),
+  min_children: integer.describe('Minimum number of child documents that match the query required to match the query for a returned parent document. If the parent document does not meet this limit, it is excluded from the search results.').optional(),
+  get query () { return QueryDslQueryContainer.describe('Query you wish to run on child documents of the `type` field. If a child document matches the search, the query returns the parent document.') },
+  score_mode: QueryDslChildScoreMode.describe('Indicates how scores for matching child documents affect the root parent document’s relevance score.').optional(),
+  type: RelationName.describe('Name of the child relationship mapped for the `join` field.')
+}).meta({ id: 'QueryDslHasChildQuery' })
+export type QueryDslHasChildQuery = z.infer<typeof QueryDslHasChildQuery>
+
+export interface QueryDslHasParentQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  ignore_unmapped?: boolean | undefined
+  inner_hits?: SearchInnerHitsShape | undefined
+  parent_type: RelationName
+  query: QueryDslQueryContainerShape
+  score?: boolean | undefined
+}
+export const QueryDslHasParentQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  ignore_unmapped: z.boolean().describe('Indicates whether to ignore an unmapped `parent_type` and not return any documents instead of an error. You can use this parameter to query multiple indices that may not contain the `parent_type`.').optional(),
+  get inner_hits () { return SearchInnerHits.describe('If defined, each search hit will contain inner hits.').optional() },
+  parent_type: RelationName.describe('Name of the parent relationship mapped for the `join` field.'),
+  get query () { return QueryDslQueryContainer.describe('Query you wish to run on parent documents of the `parent_type` field. If a parent document matches the search, the query returns its child documents.') },
+  score: z.boolean().describe('Indicates whether the relevance score of a matching parent document is aggregated into its child documents.').optional()
+}).meta({ id: 'QueryDslHasParentQuery' })
+export type QueryDslHasParentQuery = z.infer<typeof QueryDslHasParentQuery>
+
+export const Ids = z.union([Id, z.array(Id)]).meta({ id: 'Ids' })
+export type Ids = z.infer<typeof Ids>
+
+export const QueryDslIdsQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  values: Ids.describe('An array of document IDs.').optional()
+}).meta({ id: 'QueryDslIdsQuery' })
+export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
+
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
+
+export interface QueryDslIntervalsFilterShape {
+  after?: QueryDslIntervalsContainer | undefined
+  before?: QueryDslIntervalsContainer | undefined
+  contained_by?: QueryDslIntervalsContainer | undefined
+  containing?: QueryDslIntervalsContainer | undefined
+  not_contained_by?: QueryDslIntervalsContainer | undefined
+  not_containing?: QueryDslIntervalsContainer | undefined
+  not_overlapping?: QueryDslIntervalsContainer | undefined
+  overlapping?: QueryDslIntervalsContainer | undefined
+  script?: Script | undefined
+}
+export const QueryDslIntervalsFilter: z.ZodType<QueryDslIntervalsFilterShape> = QueryDslIntervalsFilterExclusiveProps.meta({ id: 'QueryDslIntervalsFilter' })
+export type QueryDslIntervalsFilter = z.infer<typeof QueryDslIntervalsFilter>
+
+export interface QueryDslIntervalsAnyOfShape {
+  intervals: QueryDslIntervalsContainerShape[]
+  filter?: QueryDslIntervalsFilterShape | undefined
+}
+export const QueryDslIntervalsAnyOf = z.object({
+  get intervals () { return QueryDslIntervalsContainer.array().describe('An array of rules to match.') },
+  get filter () { return QueryDslIntervalsFilter.describe('Rule used to filter returned intervals.').optional() }
+}).meta({ id: 'QueryDslIntervalsAnyOf' })
+export type QueryDslIntervalsAnyOf = z.infer<typeof QueryDslIntervalsAnyOf>
+
+export const QueryDslIntervalsFuzzy = z.object({
+  analyzer: z.string().describe('Analyzer used to normalize the term.').optional(),
+  fuzziness: Fuzziness.describe('Maximum edit distance allowed for matching.').optional(),
+  prefix_length: integer.describe('Number of beginning characters left unchanged when creating expansions.').optional(),
+  term: z.string().describe('The term to match.'),
+  transpositions: z.boolean().describe('Indicates whether edits include transpositions of two adjacent characters (for example, `ab` to `ba`).').optional(),
+  use_field: Field.describe('If specified, match intervals from this field rather than the top-level field. The `term` is normalized using the search analyzer from this field, unless `analyzer` is specified separately.').optional()
+}).meta({ id: 'QueryDslIntervalsFuzzy' })
+export type QueryDslIntervalsFuzzy = z.infer<typeof QueryDslIntervalsFuzzy>
+
+export interface QueryDslIntervalsMatchShape {
+  analyzer?: string | undefined
+  max_gaps?: integer | undefined
+  ordered?: boolean | undefined
+  query: string
+  use_field?: Field | undefined
+  filter?: QueryDslIntervalsFilterShape | undefined
+}
+export const QueryDslIntervalsMatch = z.object({
+  analyzer: z.string().describe('Analyzer used to analyze terms in the query.').optional(),
+  max_gaps: integer.describe('Maximum number of positions between the matching terms. Terms further apart than this are not considered matches.').optional(),
+  ordered: z.boolean().describe('If `true`, matching terms must appear in their specified order.').optional(),
+  query: z.string().describe('Text you wish to find in the provided field.'),
+  use_field: Field.describe('If specified, match intervals from this field rather than the top-level field. The `term` is normalized using the search analyzer from this field, unless `analyzer` is specified separately.').optional(),
+  get filter () { return QueryDslIntervalsFilter.describe('An optional interval filter.').optional() }
+}).meta({ id: 'QueryDslIntervalsMatch' })
+export type QueryDslIntervalsMatch = z.infer<typeof QueryDslIntervalsMatch>
+
+export const QueryDslIntervalsPrefix = z.object({
+  analyzer: z.string().describe('Analyzer used to analyze the `prefix`.').optional(),
+  prefix: z.string().describe('Beginning characters of terms you wish to find in the top-level field.'),
+  use_field: Field.describe('If specified, match intervals from this field rather than the top-level field. The `prefix` is normalized using the search analyzer from this field, unless `analyzer` is specified separately.').optional()
+}).meta({ id: 'QueryDslIntervalsPrefix' })
+export type QueryDslIntervalsPrefix = z.infer<typeof QueryDslIntervalsPrefix>
+
+export const QueryDslIntervalsRange = z.object({
+  analyzer: z.string().describe('Analyzer used to analyze the `prefix`.').optional(),
+  gte: z.string().describe('Lower term, either gte or gt must be provided.').optional(),
+  gt: z.string().describe('Lower term, either gte or gt must be provided.').optional(),
+  lte: z.string().describe('Upper term, either lte or lt must be provided.').optional(),
+  lt: z.string().describe('Upper term, either lte or lt must be provided.').optional(),
+  use_field: Field.describe('If specified, match intervals from this field rather than the top-level field. The `prefix` is normalized using the search analyzer from this field, unless `analyzer` is specified separately.').optional()
+}).meta({ id: 'QueryDslIntervalsRange' })
+export type QueryDslIntervalsRange = z.infer<typeof QueryDslIntervalsRange>
+
+export const QueryDslIntervalsRegexp = z.object({
+  analyzer: z.string().describe('Analyzer used to analyze the `prefix`.').optional(),
+  pattern: z.string().describe('Regex pattern.'),
+  use_field: Field.describe('If specified, match intervals from this field rather than the top-level field. The `prefix` is normalized using the search analyzer from this field, unless `analyzer` is specified separately.').optional()
+}).meta({ id: 'QueryDslIntervalsRegexp' })
+export type QueryDslIntervalsRegexp = z.infer<typeof QueryDslIntervalsRegexp>
+
+export const QueryDslIntervalsWildcard = z.object({
+  analyzer: z.string().describe('Analyzer used to analyze the `pattern`. Defaults to the top-level field\'s analyzer.').optional(),
+  pattern: z.string().describe('Wildcard pattern used to find matching terms.'),
+  use_field: Field.describe('If specified, match intervals from this field rather than the top-level field. The `pattern` is normalized using the search analyzer from this field, unless `analyzer` is specified separately.').optional()
+}).meta({ id: 'QueryDslIntervalsWildcard' })
+export type QueryDslIntervalsWildcard = z.infer<typeof QueryDslIntervalsWildcard>
+
+const QueryDslIntervalsContainerExclusiveProps = z.union([z.object({ all_of: z.lazy(() => QueryDslIntervalsAllOf) }), z.object({ any_of: z.lazy(() => QueryDslIntervalsAnyOf) }), z.object({ fuzzy: QueryDslIntervalsFuzzy }), z.object({ match: z.lazy(() => QueryDslIntervalsMatch) }), z.object({ prefix: QueryDslIntervalsPrefix }), z.object({ range: QueryDslIntervalsRange }), z.object({ regexp: QueryDslIntervalsRegexp }), z.object({ wildcard: QueryDslIntervalsWildcard })])
+
+export interface QueryDslIntervalsContainerShape {
+  all_of?: QueryDslIntervalsAllOf | undefined
+  any_of?: QueryDslIntervalsAnyOf | undefined
+  fuzzy?: QueryDslIntervalsFuzzy | undefined
+  match?: QueryDslIntervalsMatch | undefined
+  prefix?: QueryDslIntervalsPrefix | undefined
+  range?: QueryDslIntervalsRange | undefined
+  regexp?: QueryDslIntervalsRegexp | undefined
+  wildcard?: QueryDslIntervalsWildcard | undefined
+}
+export const QueryDslIntervalsContainer: z.ZodType<QueryDslIntervalsContainerShape> = QueryDslIntervalsContainerExclusiveProps.meta({ id: 'QueryDslIntervalsContainer' })
+export type QueryDslIntervalsContainer = z.infer<typeof QueryDslIntervalsContainer>
+
+export interface QueryDslIntervalsAllOfShape {
+  intervals: QueryDslIntervalsContainerShape[]
+  max_gaps?: integer | undefined
+  ordered?: boolean | undefined
+  filter?: QueryDslIntervalsFilterShape | undefined
+}
+export const QueryDslIntervalsAllOf = z.object({
+  get intervals () { return QueryDslIntervalsContainer.array().describe('An array of rules to combine. All rules must produce a match in a document for the overall source to match.') },
+  max_gaps: integer.describe('Maximum number of positions between the matching terms. Intervals produced by the rules further apart than this are not considered matches.').optional(),
+  ordered: z.boolean().describe('If `true`, intervals produced by the rules should appear in the order in which they are specified.').optional(),
+  get filter () { return QueryDslIntervalsFilter.describe('Rule used to filter returned intervals.').optional() }
+}).meta({ id: 'QueryDslIntervalsAllOf' })
+export type QueryDslIntervalsAllOf = z.infer<typeof QueryDslIntervalsAllOf>
+
+const QueryDslIntervalsQueryExclusiveProps = z.union([z.object({ all_of: z.lazy(() => QueryDslIntervalsAllOf) }), z.object({ any_of: z.lazy(() => QueryDslIntervalsAnyOf) }), z.object({ fuzzy: QueryDslIntervalsFuzzy }), z.object({ match: z.lazy(() => QueryDslIntervalsMatch) }), z.object({ prefix: QueryDslIntervalsPrefix }), z.object({ range: QueryDslIntervalsRange }), z.object({ regexp: QueryDslIntervalsRegexp }), z.object({ wildcard: QueryDslIntervalsWildcard })])
+
+export interface QueryDslIntervalsQueryShape {
+  all_of?: QueryDslIntervalsAllOf | undefined
+  any_of?: QueryDslIntervalsAnyOf | undefined
+  fuzzy?: QueryDslIntervalsFuzzy | undefined
+  match?: QueryDslIntervalsMatch | undefined
+  prefix?: QueryDslIntervalsPrefix | undefined
+  range?: QueryDslIntervalsRange | undefined
+  regexp?: QueryDslIntervalsRegexp | undefined
+  wildcard?: QueryDslIntervalsWildcard | undefined
+}
+export const QueryDslIntervalsQuery: z.ZodType<QueryDslIntervalsQueryShape> = QueryDslIntervalsQueryExclusiveProps.meta({ id: 'QueryDslIntervalsQuery' })
+export type QueryDslIntervalsQuery = z.infer<typeof QueryDslIntervalsQuery>
+
+export interface KnnQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  field: Field
+  query_vector?: QueryVector | undefined
+  query_vector_builder?: QueryVectorBuilder | undefined
+  num_candidates?: integer | undefined
+  visit_percentage?: float | undefined
+  k?: integer | undefined
+  filter?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+  similarity?: float | undefined
+  rescore_vector?: RescoreVector | undefined
+}
+export const KnnQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  field: Field.describe('The name of the vector field to search against'),
+  query_vector: QueryVector.describe('The query vector').optional(),
+  query_vector_builder: QueryVectorBuilder.describe('The query vector builder. You must provide a query_vector_builder or query_vector, but not both.').optional(),
+  num_candidates: integer.describe('The number of nearest neighbor candidates to consider per shard').optional(),
+  visit_percentage: float.describe('The percentage of vectors to explore per shard while doing knn search with bbq_disk').optional(),
+  k: integer.describe('The final number of nearest neighbors to return as top hits').optional(),
+  get filter (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('Filters for the kNN search query').optional() },
+  similarity: float.describe('The minimum similarity for a vector to be considered a match').optional(),
+  rescore_vector: RescoreVector.describe('Apply oversampling and rescoring to quantized vectors').optional()
+}).meta({ id: 'KnnQuery' })
+export type KnnQuery = z.infer<typeof KnnQuery>
+
+export const QueryDslZeroTermsQuery = z.enum(['all', 'none']).meta({ id: 'QueryDslZeroTermsQuery' })
+export type QueryDslZeroTermsQuery = z.infer<typeof QueryDslZeroTermsQuery>
+
+export const QueryDslMatchQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  analyzer: z.string().describe('Analyzer used to convert the text in the query value into tokens.').optional(),
+  auto_generate_synonyms_phrase_query: z.boolean().describe('If `true`, match phrase queries are automatically created for multi-term synonyms.').optional(),
+  cutoff_frequency: double.optional(),
+  fuzziness: Fuzziness.describe('Maximum edit distance allowed for matching.').optional(),
+  fuzzy_rewrite: MultiTermQueryRewrite.describe('Method used to rewrite the query.').optional(),
+  fuzzy_transpositions: z.boolean().describe('If `true`, edits for fuzzy matching include transpositions of two adjacent characters (for example, `ab` to `ba`).').optional(),
+  lenient: z.boolean().describe('If `true`, format-based errors, such as providing a text query value for a numeric field, are ignored.').optional(),
+  max_expansions: integer.describe('Maximum number of terms to which the query will expand.').optional(),
+  minimum_should_match: MinimumShouldMatch.describe('Minimum number of clauses that must match for a document to be returned.').optional(),
+  operator: QueryDslOperator.describe('Boolean logic used to interpret text in the query value.').optional(),
+  prefix_length: integer.describe('Number of beginning characters left unchanged for fuzzy matching.').optional(),
+  query: z.union([z.string(), float, z.boolean()]).describe('Text, number, boolean value or date you wish to find in the provided field.'),
+  zero_terms_query: QueryDslZeroTermsQuery.describe('Indicates whether no documents are returned if the `analyzer` removes all tokens, such as when using a `stop` filter.').optional()
+}).meta({ id: 'QueryDslMatchQuery' })
+export type QueryDslMatchQuery = z.infer<typeof QueryDslMatchQuery>
+
+export const QueryDslMatchAllQuery = z.object({
+  ...QueryDslQueryBase.shape
+}).meta({ id: 'QueryDslMatchAllQuery' })
+export type QueryDslMatchAllQuery = z.infer<typeof QueryDslMatchAllQuery>
+
+export const QueryDslMatchBoolPrefixQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  analyzer: z.string().describe('Analyzer used to convert the text in the query value into tokens.').optional(),
+  fuzziness: Fuzziness.describe('Maximum edit distance allowed for matching. Can be applied to the term subqueries constructed for all terms but the final term.').optional(),
+  fuzzy_rewrite: MultiTermQueryRewrite.describe('Method used to rewrite the query. Can be applied to the term subqueries constructed for all terms but the final term.').optional(),
+  fuzzy_transpositions: z.boolean().describe('If `true`, edits for fuzzy matching include transpositions of two adjacent characters (for example, `ab` to `ba`). Can be applied to the term subqueries constructed for all terms but the final term.').optional(),
+  max_expansions: integer.describe('Maximum number of terms to which the query will expand. Can be applied to the term subqueries constructed for all terms but the final term.').optional(),
+  minimum_should_match: MinimumShouldMatch.describe('Minimum number of clauses that must match for a document to be returned. Applied to the constructed bool query.').optional(),
+  operator: QueryDslOperator.describe('Boolean logic used to interpret text in the query value. Applied to the constructed bool query.').optional(),
+  prefix_length: integer.describe('Number of beginning characters left unchanged for fuzzy matching. Can be applied to the term subqueries constructed for all terms but the final term.').optional(),
+  query: z.string().describe('Terms you wish to find in the provided field. The last term is used in a prefix query.')
+}).meta({ id: 'QueryDslMatchBoolPrefixQuery' })
+export type QueryDslMatchBoolPrefixQuery = z.infer<typeof QueryDslMatchBoolPrefixQuery>
+
+export const QueryDslMatchNoneQuery = z.object({
+  ...QueryDslQueryBase.shape
+}).meta({ id: 'QueryDslMatchNoneQuery' })
+export type QueryDslMatchNoneQuery = z.infer<typeof QueryDslMatchNoneQuery>
+
+export const QueryDslMatchPhraseQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  analyzer: z.string().describe('Analyzer used to convert the text in the query value into tokens.').optional(),
+  query: z.string().describe('Query terms that are analyzed and turned into a phrase query.'),
+  slop: integer.describe('Maximum number of positions allowed between matching tokens.').optional(),
+  zero_terms_query: QueryDslZeroTermsQuery.describe('Indicates whether no documents are returned if the `analyzer` removes all tokens, such as when using a `stop` filter.').optional()
+}).meta({ id: 'QueryDslMatchPhraseQuery' })
+export type QueryDslMatchPhraseQuery = z.infer<typeof QueryDslMatchPhraseQuery>
+
+export const QueryDslMatchPhrasePrefixQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  analyzer: z.string().describe('Analyzer used to convert text in the query value into tokens.').optional(),
+  max_expansions: integer.describe('Maximum number of terms to which the last provided term of the query value will expand.').optional(),
+  query: z.string().describe('Text you wish to find in the provided field.'),
+  slop: integer.describe('Maximum number of positions allowed between matching tokens.').optional(),
+  zero_terms_query: QueryDslZeroTermsQuery.describe('Indicates whether no documents are returned if the analyzer removes all tokens, such as when using a `stop` filter.').optional()
+}).meta({ id: 'QueryDslMatchPhrasePrefixQuery' })
+export type QueryDslMatchPhrasePrefixQuery = z.infer<typeof QueryDslMatchPhrasePrefixQuery>
+
+/** Only to be used in query and path parameters, as the array form is actually a csv */
+export const Routing = z.union([z.string(), z.array(z.string())]).meta({ id: 'Routing' })
+export type Routing = z.infer<typeof Routing>
+
+export const VersionNumber = long.meta({ id: 'VersionNumber' })
+export type VersionNumber = z.infer<typeof VersionNumber>
+
+export const VersionType = z.enum(['internal', 'external', 'external_gte']).meta({ id: 'VersionType' })
+export type VersionType = z.infer<typeof VersionType>
+
+export const QueryDslLikeDocument = z.object({
+  doc: z.any().describe('A document not present in the index.').optional(),
+  fields: z.array(Field).optional(),
+  _id: Id.describe('ID of a document.').optional(),
+  _index: IndexName.describe('Index of a document.').optional(),
+  per_field_analyzer: z.record(Field, z.string()).describe('Overrides the default analyzer.').optional(),
+  routing: Routing.optional(),
+  version: VersionNumber.optional(),
+  version_type: VersionType.optional()
+}).meta({ id: 'QueryDslLikeDocument' })
+export type QueryDslLikeDocument = z.infer<typeof QueryDslLikeDocument>
+
+/** Text that we want similar documents for or a lookup to a document's field for the text. */
+export const QueryDslLike = z.union([z.string(), QueryDslLikeDocument]).meta({ id: 'QueryDslLike' })
+export type QueryDslLike = z.infer<typeof QueryDslLike>
+
+export const AnalysisStopWordLanguage = z.enum(['_arabic_', '_armenian_', '_basque_', '_bengali_', '_brazilian_', '_bulgarian_', '_catalan_', '_cjk_', '_czech_', '_danish_', '_dutch_', '_english_', '_estonian_', '_finnish_', '_french_', '_galician_', '_german_', '_greek_', '_hindi_', '_hungarian_', '_indonesian_', '_irish_', '_italian_', '_latvian_', '_lithuanian_', '_norwegian_', '_persian_', '_portuguese_', '_romanian_', '_russian_', '_serbian_', '_sorani_', '_spanish_', '_swedish_', '_thai_', '_turkish_', '_none_']).meta({ id: 'AnalysisStopWordLanguage' })
+export type AnalysisStopWordLanguage = z.infer<typeof AnalysisStopWordLanguage>
+
+/**
+ * Language value, such as _arabic_ or _thai_. Defaults to _english_.
+ * Each language value corresponds to a predefined list of stop words in Lucene. See Stop words by language for supported language values and their stop words.
+ * Also accepts an array of stop words.
+ */
+export const AnalysisStopWords = z.union([AnalysisStopWordLanguage, z.array(z.string())]).meta({ id: 'AnalysisStopWords' })
+export type AnalysisStopWords = z.infer<typeof AnalysisStopWords>
+
+export const QueryDslMoreLikeThisQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  analyzer: z.string().describe('The analyzer that is used to analyze the free form text. Defaults to the analyzer associated with the first field in fields.').optional(),
+  boost_terms: double.describe('Each term in the formed query could be further boosted by their tf-idf score. This sets the boost factor to use when using this feature. Defaults to deactivated (0).').optional(),
+  fail_on_unsupported_field: z.boolean().describe('Controls whether the query should fail (throw an exception) if any of the specified fields are not of the supported types (`text` or `keyword`).').optional(),
+  fields: z.array(Field).describe('A list of fields to fetch and analyze the text from. Defaults to the `index.query.default_field` index setting, which has a default value of `*`.').optional(),
+  include: z.boolean().describe('Specifies whether the input documents should also be included in the search results returned.').optional(),
+  like: z.union([QueryDslLike, z.array(QueryDslLike)]).describe('Specifies free form text and/or a single or multiple documents for which you want to find similar documents.'),
+  max_doc_freq: integer.describe('The maximum document frequency above which the terms are ignored from the input document.').optional(),
+  max_query_terms: integer.describe('The maximum number of query terms that can be selected.').optional(),
+  max_word_length: integer.describe('The maximum word length above which the terms are ignored. Defaults to unbounded (`0`).').optional(),
+  min_doc_freq: integer.describe('The minimum document frequency below which the terms are ignored from the input document.').optional(),
+  minimum_should_match: MinimumShouldMatch.describe('After the disjunctive query has been formed, this parameter controls the number of terms that must match.').optional(),
+  min_term_freq: integer.describe('The minimum term frequency below which the terms are ignored from the input document.').optional(),
+  min_word_length: integer.describe('The minimum word length below which the terms are ignored.').optional(),
+  routing: z.string().optional(),
+  stop_words: AnalysisStopWords.describe('An array of stop words. Any word in this set is ignored.').optional(),
+  unlike: z.union([QueryDslLike, z.array(QueryDslLike)]).describe('Used in combination with `like` to exclude documents that match a set of terms.').optional(),
+  version: VersionNumber.optional(),
+  version_type: VersionType.optional()
+}).meta({ id: 'QueryDslMoreLikeThisQuery' })
+export type QueryDslMoreLikeThisQuery = z.infer<typeof QueryDslMoreLikeThisQuery>
+
+export const QueryDslTextQueryType = z.enum(['best_fields', 'most_fields', 'cross_fields', 'phrase', 'phrase_prefix', 'bool_prefix']).meta({ id: 'QueryDslTextQueryType' })
+export type QueryDslTextQueryType = z.infer<typeof QueryDslTextQueryType>
+
+export const QueryDslMultiMatchQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  analyzer: z.string().describe('Analyzer used to convert the text in the query value into tokens.').optional(),
+  auto_generate_synonyms_phrase_query: z.boolean().describe('If `true`, match phrase queries are automatically created for multi-term synonyms.').optional(),
+  cutoff_frequency: double.optional(),
+  fields: Fields.describe('The fields to be queried. Defaults to the `index.query.default_field` index settings, which in turn defaults to `*`.').optional(),
+  fuzziness: Fuzziness.describe('Maximum edit distance allowed for matching.').optional(),
+  fuzzy_rewrite: MultiTermQueryRewrite.describe('Method used to rewrite the query.').optional(),
+  fuzzy_transpositions: z.boolean().describe('If `true`, edits for fuzzy matching include transpositions of two adjacent characters (for example, `ab` to `ba`). Can be applied to the term subqueries constructed for all terms but the final term.').optional(),
+  lenient: z.boolean().describe('If `true`, format-based errors, such as providing a text query value for a numeric field, are ignored.').optional(),
+  max_expansions: integer.describe('Maximum number of terms to which the query will expand.').optional(),
+  minimum_should_match: MinimumShouldMatch.describe('Minimum number of clauses that must match for a document to be returned.').optional(),
+  operator: QueryDslOperator.describe('Boolean logic used to interpret text in the query value.').optional(),
+  prefix_length: integer.describe('Number of beginning characters left unchanged for fuzzy matching.').optional(),
+  query: z.string().describe('Text, number, boolean value or date you wish to find in the provided field.'),
+  slop: integer.describe('Maximum number of positions allowed between matching tokens.').optional(),
+  tie_breaker: double.describe('Determines how scores for each per-term blended query and scores across groups are combined.').optional(),
+  type: QueryDslTextQueryType.describe('How `the` multi_match query is executed internally.').optional(),
+  zero_terms_query: QueryDslZeroTermsQuery.describe('Indicates whether no documents are returned if the `analyzer` removes all tokens, such as when using a `stop` filter.').optional()
+}).meta({ id: 'QueryDslMultiMatchQuery' })
+export type QueryDslMultiMatchQuery = z.infer<typeof QueryDslMultiMatchQuery>
+
+export interface QueryDslNestedQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  ignore_unmapped?: boolean | undefined
+  inner_hits?: SearchInnerHitsShape | undefined
+  path: Field
+  query: QueryDslQueryContainerShape
+  score_mode?: QueryDslChildScoreMode | undefined
+}
+export const QueryDslNestedQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  ignore_unmapped: z.boolean().describe('Indicates whether to ignore an unmapped path and not return any documents instead of an error.').optional(),
+  get inner_hits () { return SearchInnerHits.describe('If defined, each search hit will contain inner hits.').optional() },
+  path: Field.describe('Path to the nested object you wish to search.'),
+  get query () { return QueryDslQueryContainer.describe('Query you wish to run on nested objects in the path.') },
+  score_mode: QueryDslChildScoreMode.describe('How scores for matching child objects affect the root parent document’s relevance score.').optional()
+}).meta({ id: 'QueryDslNestedQuery' })
+export type QueryDslNestedQuery = z.infer<typeof QueryDslNestedQuery>
+
+export const QueryDslParentIdQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  id: Id.describe('ID of the parent document.').optional(),
+  ignore_unmapped: z.boolean().describe('Indicates whether to ignore an unmapped `type` and not return any documents instead of an error.').optional(),
+  type: RelationName.describe('Name of the child relationship mapped for the `join` field.').optional()
+}).meta({ id: 'QueryDslParentIdQuery' })
+export type QueryDslParentIdQuery = z.infer<typeof QueryDslParentIdQuery>
+
+export const QueryDslPercolateQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  document: z.any().describe('The source of the document being percolated.').optional(),
+  documents: z.array(z.any()).describe('An array of sources of the documents being percolated.').optional(),
+  field: Field.describe('Field that holds the indexed queries. The field must use the `percolator` mapping type.'),
+  id: Id.describe('The ID of a stored document to percolate.').optional(),
+  index: IndexName.describe('The index of a stored document to percolate.').optional(),
+  name: z.string().describe('The suffix used for the `_percolator_document_slot` field when multiple `percolate` queries are specified.').optional(),
+  preference: z.string().describe('Preference used to fetch document to percolate.').optional(),
+  routing: z.string().describe('Routing used to fetch document to percolate.').optional(),
+  version: VersionNumber.describe('The expected version of a stored document to percolate.').optional()
+}).meta({ id: 'QueryDslPercolateQuery' })
+export type QueryDslPercolateQuery = z.infer<typeof QueryDslPercolateQuery>
+
+export const QueryDslPinnedDoc = z.object({
+  _id: Id.describe('The unique document ID.'),
+  _index: IndexName.describe('The index that contains the document.').optional()
+}).meta({ id: 'QueryDslPinnedDoc' })
+export type QueryDslPinnedDoc = z.infer<typeof QueryDslPinnedDoc>
+
+const QueryDslPinnedQueryCommonProps = z.object({
+  organic: z.lazy(() => QueryDslQueryContainer).describe('Any choice of query used to rank documents which will be ranked below the "pinned" documents.')
+})
+
+const QueryDslPinnedQueryExclusiveProps = z.union([z.object({ ids: z.array(Id) }), z.object({ docs: z.array(QueryDslPinnedDoc) })])
+
+export interface QueryDslPinnedQueryShape {
+  organic: QueryDslQueryContainerShape
+  ids?: Id[] | undefined
+  docs?: QueryDslPinnedDoc[] | undefined
+}
+export const QueryDslPinnedQuery: z.ZodType<QueryDslPinnedQueryShape> = QueryDslPinnedQueryCommonProps.and(QueryDslPinnedQueryExclusiveProps).meta({ id: 'QueryDslPinnedQuery' })
+export type QueryDslPinnedQuery = z.infer<typeof QueryDslPinnedQuery>
+
+export const QueryDslPrefixQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  rewrite: MultiTermQueryRewrite.describe('Method used to rewrite the query.').optional(),
+  value: z.string().describe('Beginning characters of terms you wish to find in the provided field.'),
+  case_insensitive: z.boolean().describe('Allows ASCII case insensitive matching of the value with the indexed field values when set to `true`. Default is `false` which means the case sensitivity of matching depends on the underlying field’s mapping.').optional()
+}).meta({ id: 'QueryDslPrefixQuery' })
+export type QueryDslPrefixQuery = z.infer<typeof QueryDslPrefixQuery>
+
+export const QueryDslQueryStringQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  allow_leading_wildcard: z.boolean().describe('If `true`, the wildcard characters `*` and `?` are allowed as the first character of the query string.').optional(),
+  analyzer: z.string().describe('Analyzer used to convert text in the query string into tokens.').optional(),
+  analyze_wildcard: z.boolean().describe('If `true`, the query attempts to analyze wildcard terms in the query string.').optional(),
+  auto_generate_synonyms_phrase_query: z.boolean().describe('If `true`, match phrase queries are automatically created for multi-term synonyms.').optional(),
+  default_field: Field.describe('Default field to search if no field is provided in the query string. Supports wildcards (`*`). Defaults to the `index.query.default_field` index setting, which has a default value of `*`.').optional(),
+  default_operator: QueryDslOperator.describe('Default boolean logic used to interpret text in the query string if no operators are specified.').optional(),
+  enable_position_increments: z.boolean().describe('If `true`, enable position increments in queries constructed from a `query_string` search.').optional(),
+  escape: z.boolean().optional(),
+  fields: z.array(Field).describe('Array of fields to search. Supports wildcards (`*`).').optional(),
+  fuzziness: Fuzziness.describe('Maximum edit distance allowed for fuzzy matching.').optional(),
+  fuzzy_max_expansions: integer.describe('Maximum number of terms to which the query expands for fuzzy matching.').optional(),
+  fuzzy_prefix_length: integer.describe('Number of beginning characters left unchanged for fuzzy matching.').optional(),
+  fuzzy_rewrite: MultiTermQueryRewrite.describe('Method used to rewrite the query.').optional(),
+  fuzzy_transpositions: z.boolean().describe('If `true`, edits for fuzzy matching include transpositions of two adjacent characters (for example, `ab` to `ba`).').optional(),
+  lenient: z.boolean().describe('If `true`, format-based errors, such as providing a text value for a numeric field, are ignored.').optional(),
+  max_determinized_states: integer.describe('Maximum number of automaton states required for the query.').optional(),
+  minimum_should_match: MinimumShouldMatch.describe('Minimum number of clauses that must match for a document to be returned.').optional(),
+  phrase_slop: double.describe('Maximum number of positions allowed between matching tokens for phrases.').optional(),
+  query: z.string().describe('Query string you wish to parse and use for search.'),
+  quote_analyzer: z.string().describe('Analyzer used to convert quoted text in the query string into tokens. For quoted text, this parameter overrides the analyzer specified in the `analyzer` parameter.').optional(),
+  quote_field_suffix: z.string().describe('Suffix appended to quoted text in the query string. You can use this suffix to use a different analysis method for exact matches.').optional(),
+  rewrite: MultiTermQueryRewrite.describe('Method used to rewrite the query.').optional(),
+  tie_breaker: double.describe('How to combine the queries generated from the individual search terms in the resulting `dis_max` query.').optional(),
+  time_zone: TimeZone.describe('Coordinated Universal Time (UTC) offset or IANA time zone used to convert date values in the query string to UTC.').optional(),
+  type: QueryDslTextQueryType.describe('Determines how the query matches and scores documents.').optional()
+}).meta({ id: 'QueryDslQueryStringQuery' })
+export type QueryDslQueryStringQuery = z.infer<typeof QueryDslQueryStringQuery>
+
+export const QueryDslRangeRelation = z.enum(['within', 'contains', 'intersects']).meta({ id: 'QueryDslRangeRelation' })
+export type QueryDslRangeRelation = z.infer<typeof QueryDslRangeRelation>
+
+export const QueryDslRangeQueryBase = z.object({
+  ...QueryDslQueryBase.shape,
+  relation: QueryDslRangeRelation.describe('Indicates how the range query matches values for `range` fields.').optional(),
+  gt: z.any().describe('Greater than.').optional(),
+  gte: z.any().describe('Greater than or equal to.').optional(),
+  lt: z.any().describe('Less than.').optional(),
+  lte: z.any().describe('Less than or equal to.').optional()
+}).meta({ id: 'QueryDslRangeQueryBase' })
+export type QueryDslRangeQueryBase = z.infer<typeof QueryDslRangeQueryBase>
+
+export const DateFormat = z.string().meta({ id: 'DateFormat' })
+export type DateFormat = z.infer<typeof DateFormat>
+
+export const QueryDslUntypedRangeQuery = z.object({
+  ...QueryDslRangeQueryBase.shape,
+  format: DateFormat.describe('Date format used to convert `date` values in the query.').optional(),
+  time_zone: TimeZone.describe('Coordinated Universal Time (UTC) offset or IANA time zone used to convert `date` values in the query to UTC.').optional()
+}).meta({ id: 'QueryDslUntypedRangeQuery' })
+export type QueryDslUntypedRangeQuery = z.infer<typeof QueryDslUntypedRangeQuery>
+
+export const QueryDslDateRangeQuery = z.object({
+  ...QueryDslRangeQueryBase.shape,
+  format: DateFormat.describe('Date format used to convert `date` values in the query.').optional(),
+  time_zone: TimeZone.describe('Coordinated Universal Time (UTC) offset or IANA time zone used to convert `date` values in the query to UTC.').optional()
+}).meta({ id: 'QueryDslDateRangeQuery' })
+export type QueryDslDateRangeQuery = z.infer<typeof QueryDslDateRangeQuery>
+
+export const QueryDslNumberRangeQuery = z.object({
+  ...QueryDslRangeQueryBase.shape
+}).meta({ id: 'QueryDslNumberRangeQuery' })
+export type QueryDslNumberRangeQuery = z.infer<typeof QueryDslNumberRangeQuery>
+
+export const QueryDslLongNumberRangeQuery = z.object({
+  ...QueryDslRangeQueryBase.shape
+}).meta({ id: 'QueryDslLongNumberRangeQuery' })
+export type QueryDslLongNumberRangeQuery = z.infer<typeof QueryDslLongNumberRangeQuery>
+
+export const QueryDslTermRangeQuery = z.object({
+  ...QueryDslRangeQueryBase.shape
+}).meta({ id: 'QueryDslTermRangeQuery' })
+export type QueryDslTermRangeQuery = z.infer<typeof QueryDslTermRangeQuery>
+
+export const QueryDslRangeQuery = z.union([QueryDslUntypedRangeQuery, QueryDslDateRangeQuery, QueryDslNumberRangeQuery, QueryDslLongNumberRangeQuery, QueryDslTermRangeQuery]).meta({ id: 'QueryDslRangeQuery' })
+export type QueryDslRangeQuery = z.infer<typeof QueryDslRangeQuery>
+
+export const QueryDslRankFeatureFunction = z.object({
+}).meta({ id: 'QueryDslRankFeatureFunction' })
+export type QueryDslRankFeatureFunction = z.infer<typeof QueryDslRankFeatureFunction>
+
+export const QueryDslRankFeatureFunctionSaturation = z.object({
+  pivot: float.describe('Configurable pivot value so that the result will be less than 0.5.').optional()
+}).meta({ id: 'QueryDslRankFeatureFunctionSaturation' })
+export type QueryDslRankFeatureFunctionSaturation = z.infer<typeof QueryDslRankFeatureFunctionSaturation>
+
+export const QueryDslRankFeatureFunctionLogarithm = z.object({
+  scaling_factor: float.describe('Configurable scaling factor.')
+}).meta({ id: 'QueryDslRankFeatureFunctionLogarithm' })
+export type QueryDslRankFeatureFunctionLogarithm = z.infer<typeof QueryDslRankFeatureFunctionLogarithm>
+
+export const QueryDslRankFeatureFunctionLinear = z.object({
+}).meta({ id: 'QueryDslRankFeatureFunctionLinear' })
+export type QueryDslRankFeatureFunctionLinear = z.infer<typeof QueryDslRankFeatureFunctionLinear>
+
+export const QueryDslRankFeatureFunctionSigmoid = z.object({
+  pivot: float.describe('Configurable pivot value so that the result will be less than 0.5.'),
+  exponent: float.describe('Configurable Exponent.')
+}).meta({ id: 'QueryDslRankFeatureFunctionSigmoid' })
+export type QueryDslRankFeatureFunctionSigmoid = z.infer<typeof QueryDslRankFeatureFunctionSigmoid>
+
+export const QueryDslRankFeatureQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  field: Field.describe('`rank_feature` or `rank_features` field used to boost relevance scores.'),
+  saturation: QueryDslRankFeatureFunctionSaturation.describe('Saturation function used to boost relevance scores based on the value of the rank feature `field`.').optional(),
+  log: QueryDslRankFeatureFunctionLogarithm.describe('Logarithmic function used to boost relevance scores based on the value of the rank feature `field`.').optional(),
+  linear: QueryDslRankFeatureFunctionLinear.describe('Linear function used to boost relevance scores based on the value of the rank feature `field`.').optional(),
+  sigmoid: QueryDslRankFeatureFunctionSigmoid.describe('Sigmoid function used to boost relevance scores based on the value of the rank feature `field`.').optional()
+}).meta({ id: 'QueryDslRankFeatureQuery' })
+export type QueryDslRankFeatureQuery = z.infer<typeof QueryDslRankFeatureQuery>
+
+export const QueryDslRegexpQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  case_insensitive: z.boolean().describe('Allows case insensitive matching of the regular expression value with the indexed field values when set to `true`. When `false`, case sensitivity of matching depends on the underlying field’s mapping.').optional(),
+  flags: z.string().describe('Enables optional operators for the regular expression.').optional(),
+  max_determinized_states: integer.describe('Maximum number of automaton states required for the query.').optional(),
+  rewrite: MultiTermQueryRewrite.describe('Method used to rewrite the query.').optional(),
+  value: z.string().describe('Regular expression for terms you wish to find in the provided field.')
+}).meta({ id: 'QueryDslRegexpQuery' })
+export type QueryDslRegexpQuery = z.infer<typeof QueryDslRegexpQuery>
+
+export interface QueryDslRuleQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  organic: QueryDslQueryContainerShape
+  ruleset_ids?: Id | Id[] | undefined
+  ruleset_id?: string | undefined
+  match_criteria: unknown
+}
+export const QueryDslRuleQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  get organic () { return QueryDslQueryContainer },
+  ruleset_ids: z.union([Id, z.array(Id)]).optional(),
+  ruleset_id: z.string().optional(),
+  match_criteria: z.any()
+}).meta({ id: 'QueryDslRuleQuery' })
+export type QueryDslRuleQuery = z.infer<typeof QueryDslRuleQuery>
+
+export interface QueryDslScriptQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  script: ScriptShape
+}
+export const QueryDslScriptQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+}).meta({ id: 'QueryDslScriptQuery' })
+export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
+
+export interface QueryDslScriptScoreQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  min_score?: float | undefined
+  query: QueryDslQueryContainerShape
+  script: ScriptShape
+}
+export const QueryDslScriptScoreQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
+  get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+}).meta({ id: 'QueryDslScriptScoreQuery' })
+export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
+
+export const QueryDslSemanticQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  field: z.string().describe('The field to query, which must be a semantic_text field type'),
+  query: z.string().describe('The query text')
+}).meta({ id: 'QueryDslSemanticQuery' })
+export type QueryDslSemanticQuery = z.infer<typeof QueryDslSemanticQuery>
+
+export const QueryDslShapeQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  ignore_unmapped: z.boolean().describe('When set to `true` the query ignores an unmapped field and will not match any documents.').optional()
+}).catchall(z.any()).meta({ id: 'QueryDslShapeQuery' })
+export type QueryDslShapeQuery = z.infer<typeof QueryDslShapeQuery>
+
+/**
+ * A set of flags that can be represented as a single enum value or a set of values that are encoded
+ * as a pipe-separated string
+ *
+ * Depending on the target language, code generators can use this hint to generate language specific
+ * flags enum constructs and the corresponding (de-)serialization code.
+ */
+export const SpecUtilsPipeSeparatedFlags = z.union([z.any(), z.string()]).meta({ id: 'SpecUtilsPipeSeparatedFlags' })
+export type SpecUtilsPipeSeparatedFlags = z.infer<typeof SpecUtilsPipeSeparatedFlags>
+
+/** Query flags can be either a single flag or a combination of flags, e.g. `OR|AND|PREFIX` */
+export const QueryDslSimpleQueryStringFlags = SpecUtilsPipeSeparatedFlags.meta({ id: 'QueryDslSimpleQueryStringFlags' })
+export type QueryDslSimpleQueryStringFlags = z.infer<typeof QueryDslSimpleQueryStringFlags>
+
+export const QueryDslSimpleQueryStringQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  analyzer: z.string().describe('Analyzer used to convert text in the query string into tokens.').optional(),
+  analyze_wildcard: z.boolean().describe('If `true`, the query attempts to analyze wildcard terms in the query string.').optional(),
+  auto_generate_synonyms_phrase_query: z.boolean().describe('If `true`, the parser creates a match_phrase query for each multi-position token.').optional(),
+  default_operator: QueryDslOperator.describe('Default boolean logic used to interpret text in the query string if no operators are specified.').optional(),
+  fields: z.array(Field).describe('Array of fields you wish to search. Accepts wildcard expressions. You also can boost relevance scores for matches to particular fields using a caret (`^`) notation. Defaults to the `index.query.default_field index` setting, which has a default value of `*`.').optional(),
+  flags: QueryDslSimpleQueryStringFlags.describe('List of enabled operators for the simple query string syntax.').optional(),
+  fuzzy_max_expansions: integer.describe('Maximum number of terms to which the query expands for fuzzy matching.').optional(),
+  fuzzy_prefix_length: integer.describe('Number of beginning characters left unchanged for fuzzy matching.').optional(),
+  fuzzy_transpositions: z.boolean().describe('If `true`, edits for fuzzy matching include transpositions of two adjacent characters (for example, `ab` to `ba`).').optional(),
+  lenient: z.boolean().describe('If `true`, format-based errors, such as providing a text value for a numeric field, are ignored.').optional(),
+  minimum_should_match: MinimumShouldMatch.describe('Minimum number of clauses that must match for a document to be returned.').optional(),
+  query: z.string().describe('Query string in the simple query string syntax you wish to parse and use for search.'),
+  quote_field_suffix: z.string().describe('Suffix appended to quoted text in the query string.').optional()
+}).meta({ id: 'QueryDslSimpleQueryStringQuery' })
+export type QueryDslSimpleQueryStringQuery = z.infer<typeof QueryDslSimpleQueryStringQuery>
+
+export interface QueryDslSpanFieldMaskingQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  field: Field
+  query: QueryDslSpanQueryShape
+}
+export const QueryDslSpanFieldMaskingQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  field: Field,
+  get query () { return QueryDslSpanQuery }
+}).meta({ id: 'QueryDslSpanFieldMaskingQuery' })
+export type QueryDslSpanFieldMaskingQuery = z.infer<typeof QueryDslSpanFieldMaskingQuery>
+
+export interface QueryDslSpanFirstQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  end: integer
+  match: QueryDslSpanQueryShape
+}
+export const QueryDslSpanFirstQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  end: integer.describe('Controls the maximum end position permitted in a match.'),
+  get match () { return QueryDslSpanQuery.describe('Can be any other span type query.') }
+}).meta({ id: 'QueryDslSpanFirstQuery' })
+export type QueryDslSpanFirstQuery = z.infer<typeof QueryDslSpanFirstQuery>
+
+/** Can only be used as a clause in a span_near query. */
+export const QueryDslSpanGapQuery = z.record(Field, integer).meta({ id: 'QueryDslSpanGapQuery' })
+export type QueryDslSpanGapQuery = z.infer<typeof QueryDslSpanGapQuery>
+
+export interface QueryDslSpanMultiTermQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  match: QueryDslQueryContainerShape
+}
+export const QueryDslSpanMultiTermQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  get match () { return QueryDslQueryContainer.describe('Should be a multi term query (one of `wildcard`, `fuzzy`, `prefix`, `range`, or `regexp` query).') }
+}).meta({ id: 'QueryDslSpanMultiTermQuery' })
+export type QueryDslSpanMultiTermQuery = z.infer<typeof QueryDslSpanMultiTermQuery>
+
+export interface QueryDslSpanNearQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  clauses: QueryDslSpanQueryShape[]
+  in_order?: boolean | undefined
+  slop?: integer | undefined
+}
+export const QueryDslSpanNearQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  get clauses () { return QueryDslSpanQuery.array().describe('Array of one or more other span type queries.') },
+  in_order: z.boolean().describe('Controls whether matches are required to be in-order.').optional(),
+  slop: integer.describe('Controls the maximum number of intervening unmatched positions permitted.').optional()
+}).meta({ id: 'QueryDslSpanNearQuery' })
+export type QueryDslSpanNearQuery = z.infer<typeof QueryDslSpanNearQuery>
+
+export interface QueryDslSpanNotQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  dist?: integer | undefined
+  exclude: QueryDslSpanQueryShape
+  include: QueryDslSpanQueryShape
+  post?: integer | undefined
+  pre?: integer | undefined
+}
+export const QueryDslSpanNotQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  dist: integer.describe('The number of tokens from within the include span that can’t have overlap with the exclude span. Equivalent to setting both `pre` and `post`.').optional(),
+  get exclude () { return QueryDslSpanQuery.describe('Span query whose matches must not overlap those returned.') },
+  get include () { return QueryDslSpanQuery.describe('Span query whose matches are filtered.') },
+  post: integer.describe('The number of tokens after the include span that can’t have overlap with the exclude span.').optional(),
+  pre: integer.describe('The number of tokens before the include span that can’t have overlap with the exclude span.').optional()
+}).meta({ id: 'QueryDslSpanNotQuery' })
+export type QueryDslSpanNotQuery = z.infer<typeof QueryDslSpanNotQuery>
+
+export interface QueryDslSpanOrQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  clauses: QueryDslSpanQueryShape[]
+}
+export const QueryDslSpanOrQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  get clauses () { return QueryDslSpanQuery.array().describe('Array of one or more other span type queries.') }
+}).meta({ id: 'QueryDslSpanOrQuery' })
+export type QueryDslSpanOrQuery = z.infer<typeof QueryDslSpanOrQuery>
+
+export const QueryDslSpanTermQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  value: FieldValue,
+  term: FieldValue
+}).meta({ id: 'QueryDslSpanTermQuery' })
+export type QueryDslSpanTermQuery = z.infer<typeof QueryDslSpanTermQuery>
+
+export interface QueryDslSpanWithinQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  big: QueryDslSpanQueryShape
+  little: QueryDslSpanQueryShape
+}
+export const QueryDslSpanWithinQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  get big () { return QueryDslSpanQuery.describe('Can be any span query. Matching spans from `little` that are enclosed within `big` are returned.') },
+  get little () { return QueryDslSpanQuery.describe('Can be any span query. Matching spans from `little` that are enclosed within `big` are returned.') }
+}).meta({ id: 'QueryDslSpanWithinQuery' })
+export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
+
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+
+export interface QueryDslSpanQueryShape {
+  span_containing?: QueryDslSpanContainingQuery | undefined
+  span_field_masking?: QueryDslSpanFieldMaskingQuery | undefined
+  span_first?: QueryDslSpanFirstQuery | undefined
+  span_gap?: QueryDslSpanGapQuery | undefined
+  span_multi?: QueryDslSpanMultiTermQuery | undefined
+  span_near?: QueryDslSpanNearQuery | undefined
+  span_not?: QueryDslSpanNotQuery | undefined
+  span_or?: QueryDslSpanOrQuery | undefined
+  span_term?: Record<Field, QueryDslSpanTermQuery> | undefined
+  span_within?: QueryDslSpanWithinQuery | undefined
+}
+export const QueryDslSpanQuery: z.ZodType<QueryDslSpanQueryShape> = QueryDslSpanQueryExclusiveProps.meta({ id: 'QueryDslSpanQuery' })
+export type QueryDslSpanQuery = z.infer<typeof QueryDslSpanQuery>
+
+export interface QueryDslSpanContainingQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  big: QueryDslSpanQueryShape
+  little: QueryDslSpanQueryShape
+}
+export const QueryDslSpanContainingQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  get big () { return QueryDslSpanQuery.describe('Can be any span query. Matching spans from `big` that contain matches from `little` are returned.') },
+  get little () { return QueryDslSpanQuery.describe('Can be any span query. Matching spans from `big` that contain matches from `little` are returned.') }
+}).meta({ id: 'QueryDslSpanContainingQuery' })
+export type QueryDslSpanContainingQuery = z.infer<typeof QueryDslSpanContainingQuery>
+
+export const TokenPruningConfig = z.object({
+  tokens_freq_ratio_threshold: integer.describe('Tokens whose frequency is more than this threshold times the average frequency of all tokens in the specified field are considered outliers and pruned.').optional(),
+  tokens_weight_threshold: float.describe('Tokens whose weight is less than this threshold are considered nonsignificant and pruned.').optional(),
+  only_score_pruned_tokens: z.boolean().describe('Whether to only score pruned tokens, vs only scoring kept tokens.').optional()
+}).meta({ id: 'TokenPruningConfig' })
+export type TokenPruningConfig = z.infer<typeof TokenPruningConfig>
+
+const QueryDslSparseVectorQueryCommonProps = z.object({
+  field: Field.describe('The name of the field that contains the token-weight pairs to be searched against. This field must be a mapped sparse_vector field.'),
+  query: z.string().describe('The query text you want to use for search. If inference_id is specified, query must also be specified.').optional(),
+  prune: z.boolean().describe('Whether to perform pruning, omitting the non-significant tokens from the query to improve query performance. If prune is true but the pruning_config is not specified, pruning will occur but default values will be used. Default: false').optional(),
+  pruning_config: TokenPruningConfig.describe('Optional pruning configuration. If enabled, this will omit non-significant tokens from the query in order to improve query performance. This is only used if prune is set to true. If prune is set to true but pruning_config is not specified, default values will be used.').optional()
+})
+
+const QueryDslSparseVectorQueryExclusiveProps = z.union([z.object({ query_vector: z.record(z.string(), float) }), z.object({ inference_id: Id })])
+
+export const QueryDslSparseVectorQuery = QueryDslSparseVectorQueryCommonProps.and(QueryDslSparseVectorQueryExclusiveProps).meta({ id: 'QueryDslSparseVectorQuery' })
+export type QueryDslSparseVectorQuery = z.infer<typeof QueryDslSparseVectorQuery>
+
+export const QueryDslTermQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  value: FieldValue.describe('Term you wish to find in the provided field.'),
+  case_insensitive: z.boolean().describe('Allows ASCII case insensitive matching of the value with the indexed field values when set to `true`. When `false`, the case sensitivity of matching depends on the underlying field’s mapping.').optional()
+}).meta({ id: 'QueryDslTermQuery' })
+export type QueryDslTermQuery = z.infer<typeof QueryDslTermQuery>
+
+export const QueryDslTermsQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional()
+}).catchall(z.any()).meta({ id: 'QueryDslTermsQuery' })
+export type QueryDslTermsQuery = z.infer<typeof QueryDslTermsQuery>
+
+export interface QueryDslTermsSetQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  minimum_should_match?: MinimumShouldMatch | undefined
+  minimum_should_match_field?: Field | undefined
+  minimum_should_match_script?: ScriptShape | undefined
+  terms: FieldValue[]
+}
+export const QueryDslTermsSetQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
+  minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
+}).meta({ id: 'QueryDslTermsSetQuery' })
+export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
+
+export const QueryDslTextExpansionQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  model_id: z.string().describe('The text expansion NLP model to use'),
+  model_text: z.string().describe('The query text'),
+  pruning_config: TokenPruningConfig.describe('Token pruning configurations').optional()
+}).meta({ id: 'QueryDslTextExpansionQuery' })
+export type QueryDslTextExpansionQuery = z.infer<typeof QueryDslTextExpansionQuery>
+
+export const QueryDslWeightedTokensQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  tokens: z.union([z.record(z.string(), float), z.array(z.record(z.string(), float))]).describe('The tokens representing this query'),
+  pruning_config: TokenPruningConfig.describe('Token pruning configurations').optional()
+}).meta({ id: 'QueryDslWeightedTokensQuery' })
+export type QueryDslWeightedTokensQuery = z.infer<typeof QueryDslWeightedTokensQuery>
+
+export const QueryDslWildcardQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  case_insensitive: z.boolean().describe('Allows case insensitive matching of the pattern with the indexed field values when set to true. Default is false which means the case sensitivity of matching depends on the underlying field’s mapping.').optional(),
+  rewrite: MultiTermQueryRewrite.describe('Method used to rewrite the query.').optional(),
+  value: z.string().describe('Wildcard pattern for terms you wish to find in the provided field. Required, when wildcard is not set.').optional(),
+  wildcard: z.string().describe('Wildcard pattern for terms you wish to find in the provided field. Required, when value is not set.').optional()
+}).meta({ id: 'QueryDslWildcardQuery' })
+export type QueryDslWildcardQuery = z.infer<typeof QueryDslWildcardQuery>
+
+export const QueryDslWrapperQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  query: z.string().describe('A base64 encoded query. The binary data format can be any of JSON, YAML, CBOR or SMILE encodings')
+}).meta({ id: 'QueryDslWrapperQuery' })
+export type QueryDslWrapperQuery = z.infer<typeof QueryDslWrapperQuery>
+
+export const QueryDslTypeQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  value: z.string()
+}).meta({ id: 'QueryDslTypeQuery' })
+export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
+
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+
+export interface QueryDslQueryContainerShape {
+  bool?: QueryDslBoolQuery | undefined
+  boosting?: QueryDslBoostingQuery | undefined
+  common?: Record<Field, QueryDslCommonTermsQuery> | undefined
+  combined_fields?: QueryDslCombinedFieldsQuery | undefined
+  constant_score?: QueryDslConstantScoreQuery | undefined
+  dis_max?: QueryDslDisMaxQuery | undefined
+  distance_feature?: QueryDslDistanceFeatureQuery | undefined
+  exists?: QueryDslExistsQuery | undefined
+  function_score?: QueryDslFunctionScoreQuery | undefined
+  fuzzy?: Record<Field, QueryDslFuzzyQuery> | undefined
+  geo_bounding_box?: QueryDslGeoBoundingBoxQuery | undefined
+  geo_distance?: QueryDslGeoDistanceQuery | undefined
+  geo_grid?: Record<Field, QueryDslGeoGridQuery> | undefined
+  geo_polygon?: QueryDslGeoPolygonQuery | undefined
+  geo_shape?: QueryDslGeoShapeQuery | undefined
+  has_child?: QueryDslHasChildQuery | undefined
+  has_parent?: QueryDslHasParentQuery | undefined
+  ids?: QueryDslIdsQuery | undefined
+  intervals?: Record<Field, QueryDslIntervalsQuery> | undefined
+  knn?: KnnQuery | undefined
+  match?: Record<Field, QueryDslMatchQuery> | undefined
+  match_all?: QueryDslMatchAllQuery | undefined
+  match_bool_prefix?: Record<Field, QueryDslMatchBoolPrefixQuery> | undefined
+  match_none?: QueryDslMatchNoneQuery | undefined
+  match_phrase?: Record<Field, QueryDslMatchPhraseQuery> | undefined
+  match_phrase_prefix?: Record<Field, QueryDslMatchPhrasePrefixQuery> | undefined
+  more_like_this?: QueryDslMoreLikeThisQuery | undefined
+  multi_match?: QueryDslMultiMatchQuery | undefined
+  nested?: QueryDslNestedQuery | undefined
+  parent_id?: QueryDslParentIdQuery | undefined
+  percolate?: QueryDslPercolateQuery | undefined
+  pinned?: QueryDslPinnedQuery | undefined
+  prefix?: Record<Field, QueryDslPrefixQuery> | undefined
+  query_string?: QueryDslQueryStringQuery | undefined
+  range?: Record<Field, QueryDslRangeQuery> | undefined
+  rank_feature?: QueryDslRankFeatureQuery | undefined
+  regexp?: Record<Field, QueryDslRegexpQuery> | undefined
+  rule?: QueryDslRuleQuery | undefined
+  script?: QueryDslScriptQuery | undefined
+  script_score?: QueryDslScriptScoreQuery | undefined
+  semantic?: QueryDslSemanticQuery | undefined
+  shape?: QueryDslShapeQuery | undefined
+  simple_query_string?: QueryDslSimpleQueryStringQuery | undefined
+  span_containing?: QueryDslSpanContainingQuery | undefined
+  span_field_masking?: QueryDslSpanFieldMaskingQuery | undefined
+  span_first?: QueryDslSpanFirstQuery | undefined
+  span_multi?: QueryDslSpanMultiTermQuery | undefined
+  span_near?: QueryDslSpanNearQuery | undefined
+  span_not?: QueryDslSpanNotQuery | undefined
+  span_or?: QueryDslSpanOrQuery | undefined
+  span_term?: Record<Field, QueryDslSpanTermQuery> | undefined
+  span_within?: QueryDslSpanWithinQuery | undefined
+  sparse_vector?: QueryDslSparseVectorQuery | undefined
+  term?: Record<Field, QueryDslTermQuery> | undefined
+  terms?: QueryDslTermsQuery | undefined
+  terms_set?: Record<Field, QueryDslTermsSetQuery> | undefined
+  text_expansion?: Record<Field, QueryDslTextExpansionQuery> | undefined
+  weighted_tokens?: Record<Field, QueryDslWeightedTokensQuery> | undefined
+  wildcard?: Record<Field, QueryDslWildcardQuery> | undefined
+  wrapper?: QueryDslWrapperQuery | undefined
+  type?: QueryDslTypeQuery | undefined
+}
+/** An Elasticsearch Query DSL (Domain Specific Language) object that defines a query. */
+export const QueryDslQueryContainer: z.ZodType<QueryDslQueryContainerShape> = QueryDslQueryContainerExclusiveProps.meta({ id: 'QueryDslQueryContainer' })
+export type QueryDslQueryContainer = z.infer<typeof QueryDslQueryContainer>
+
+export const SearchHighlighterOrder = z.enum(['score']).meta({ id: 'SearchHighlighterOrder' })
+export type SearchHighlighterOrder = z.infer<typeof SearchHighlighterOrder>
+
+export const SearchHighlighterTagsSchema = z.enum(['styled']).meta({ id: 'SearchHighlighterTagsSchema' })
+export type SearchHighlighterTagsSchema = z.infer<typeof SearchHighlighterTagsSchema>
+
+export interface SearchHighlightBaseShape {
+  type?: SearchHighlighterType | undefined
+  boundary_chars?: string | undefined
+  boundary_max_scan?: integer | undefined
+  boundary_scanner?: SearchBoundaryScanner | undefined
+  boundary_scanner_locale?: string | undefined
+  force_source?: boolean | undefined
+  fragmenter?: SearchHighlighterFragmenter | undefined
+  fragment_size?: integer | undefined
+  highlight_filter?: boolean | undefined
+  highlight_query?: QueryDslQueryContainerShape | undefined
+  max_fragment_length?: integer | undefined
+  max_analyzed_offset?: integer | undefined
+  no_match_size?: integer | undefined
+  number_of_fragments?: integer | undefined
+  options?: Record<string, unknown> | undefined
+  order?: SearchHighlighterOrder | undefined
+  phrase_limit?: integer | undefined
+  post_tags?: string[] | undefined
+  pre_tags?: string[] | undefined
+  require_field_match?: boolean | undefined
+  tags_schema?: SearchHighlighterTagsSchema | undefined
+}
+export const SearchHighlightBase = z.object({
+  type: SearchHighlighterType.optional(),
+  boundary_chars: z.string().describe('A string that contains each boundary character.').optional(),
+  boundary_max_scan: integer.describe('How far to scan for boundary characters.').optional(),
+  boundary_scanner: SearchBoundaryScanner.describe('Specifies how to break the highlighted fragments: chars, sentence, or word. Only valid for the unified and fvh highlighters. Defaults to `sentence` for the `unified` highlighter. Defaults to `chars` for the `fvh` highlighter.').optional(),
+  boundary_scanner_locale: z.string().describe('Controls which locale is used to search for sentence and word boundaries. This parameter takes a form of a language tag, for example: `"en-US"`, `"fr-FR"`, `"ja-JP"`.').optional(),
+  force_source: z.boolean().optional(),
+  fragmenter: SearchHighlighterFragmenter.describe('Specifies how text should be broken up in highlight snippets: `simple` or `span`. Only valid for the `plain` highlighter.').optional(),
+  fragment_size: integer.describe('The size of the highlighted fragment in characters.').optional(),
+  highlight_filter: z.boolean().optional(),
+  get highlight_query () { return QueryDslQueryContainer.describe('Highlight matches for a query other than the search query. This is especially useful if you use a rescore query because those are not taken into account by highlighting by default.').optional() },
+  max_fragment_length: integer.optional(),
+  max_analyzed_offset: integer.describe('If set to a non-negative value, highlighting stops at this defined maximum limit. The rest of the text is not processed, thus not highlighted and no error is returned The `max_analyzed_offset` query setting does not override the `index.highlight.max_analyzed_offset` setting, which prevails when it’s set to lower value than the query setting.').optional(),
+  no_match_size: integer.describe('The amount of text you want to return from the beginning of the field if there are no matching fragments to highlight.').optional(),
+  number_of_fragments: integer.describe('The maximum number of fragments to return. If the number of fragments is set to `0`, no fragments are returned. Instead, the entire field contents are highlighted and returned. This can be handy when you need to highlight short texts such as a title or address, but fragmentation is not required. If `number_of_fragments` is `0`, `fragment_size` is ignored.').optional(),
+  options: z.record(z.string(), z.any()).optional(),
+  order: SearchHighlighterOrder.describe('Sorts highlighted fragments by score when set to `score`. By default, fragments will be output in the order they appear in the field (order: `none`). Setting this option to `score` will output the most relevant fragments first. Each highlighter applies its own logic to compute relevancy scores.').optional(),
+  phrase_limit: integer.describe('Controls the number of matching phrases in a document that are considered. Prevents the `fvh` highlighter from analyzing too many phrases and consuming too much memory. When using `matched_fields`, `phrase_limit` phrases per matched field are considered. Raising the limit increases query time and consumes more memory. Only supported by the `fvh` highlighter.').optional(),
+  post_tags: z.array(z.string()).describe('Use in conjunction with `pre_tags` to define the HTML tags to use for the highlighted text. By default, highlighted text is wrapped in `<em>` and `</em>` tags.').optional(),
+  pre_tags: z.array(z.string()).describe('Use in conjunction with `post_tags` to define the HTML tags to use for the highlighted text. By default, highlighted text is wrapped in `<em>` and `</em>` tags.').optional(),
+  require_field_match: z.boolean().describe('By default, only fields that contains a query match are highlighted. Set to `false` to highlight all fields.').optional(),
+  tags_schema: SearchHighlighterTagsSchema.describe('Set to `styled` to use the built-in tag schema.').optional()
+}).meta({ id: 'SearchHighlightBase' })
+export type SearchHighlightBase = z.infer<typeof SearchHighlightBase>
+
+export const SearchHighlighterEncoder = z.enum(['default', 'html']).meta({ id: 'SearchHighlighterEncoder' })
+export type SearchHighlighterEncoder = z.infer<typeof SearchHighlighterEncoder>
+
+export interface SearchHighlightFieldShape {
+  type?: SearchHighlighterType | undefined
+  boundary_chars?: string | undefined
+  boundary_max_scan?: integer | undefined
+  boundary_scanner?: SearchBoundaryScanner | undefined
+  boundary_scanner_locale?: string | undefined
+  force_source?: boolean | undefined
+  fragmenter?: SearchHighlighterFragmenter | undefined
+  fragment_size?: integer | undefined
+  highlight_filter?: boolean | undefined
+  highlight_query?: QueryDslQueryContainerShape | undefined
+  max_fragment_length?: integer | undefined
+  max_analyzed_offset?: integer | undefined
+  no_match_size?: integer | undefined
+  number_of_fragments?: integer | undefined
+  options?: Record<string, unknown> | undefined
+  order?: SearchHighlighterOrder | undefined
+  phrase_limit?: integer | undefined
+  post_tags?: string[] | undefined
+  pre_tags?: string[] | undefined
+  require_field_match?: boolean | undefined
+  tags_schema?: SearchHighlighterTagsSchema | undefined
+  fragment_offset?: integer | undefined
+  matched_fields?: Fields | undefined
+}
+export const SearchHighlightField = z.object({
+  type: SearchHighlighterType.optional(),
+  boundary_chars: z.string().describe('A string that contains each boundary character.').optional(),
+  boundary_max_scan: integer.describe('How far to scan for boundary characters.').optional(),
+  boundary_scanner: SearchBoundaryScanner.describe('Specifies how to break the highlighted fragments: chars, sentence, or word. Only valid for the unified and fvh highlighters. Defaults to `sentence` for the `unified` highlighter. Defaults to `chars` for the `fvh` highlighter.').optional(),
+  boundary_scanner_locale: z.string().describe('Controls which locale is used to search for sentence and word boundaries. This parameter takes a form of a language tag, for example: `"en-US"`, `"fr-FR"`, `"ja-JP"`.').optional(),
+  force_source: z.boolean().optional(),
+  fragmenter: SearchHighlighterFragmenter.describe('Specifies how text should be broken up in highlight snippets: `simple` or `span`. Only valid for the `plain` highlighter.').optional(),
+  fragment_size: integer.describe('The size of the highlighted fragment in characters.').optional(),
+  highlight_filter: z.boolean().optional(),
+  get highlight_query () { return QueryDslQueryContainer.describe('Highlight matches for a query other than the search query. This is especially useful if you use a rescore query because those are not taken into account by highlighting by default.').optional() },
+  max_fragment_length: integer.optional(),
+  max_analyzed_offset: integer.describe('If set to a non-negative value, highlighting stops at this defined maximum limit. The rest of the text is not processed, thus not highlighted and no error is returned The `max_analyzed_offset` query setting does not override the `index.highlight.max_analyzed_offset` setting, which prevails when it’s set to lower value than the query setting.').optional(),
+  no_match_size: integer.describe('The amount of text you want to return from the beginning of the field if there are no matching fragments to highlight.').optional(),
+  number_of_fragments: integer.describe('The maximum number of fragments to return. If the number of fragments is set to `0`, no fragments are returned. Instead, the entire field contents are highlighted and returned. This can be handy when you need to highlight short texts such as a title or address, but fragmentation is not required. If `number_of_fragments` is `0`, `fragment_size` is ignored.').optional(),
+  options: z.record(z.string(), z.any()).optional(),
+  order: SearchHighlighterOrder.describe('Sorts highlighted fragments by score when set to `score`. By default, fragments will be output in the order they appear in the field (order: `none`). Setting this option to `score` will output the most relevant fragments first. Each highlighter applies its own logic to compute relevancy scores.').optional(),
+  phrase_limit: integer.describe('Controls the number of matching phrases in a document that are considered. Prevents the `fvh` highlighter from analyzing too many phrases and consuming too much memory. When using `matched_fields`, `phrase_limit` phrases per matched field are considered. Raising the limit increases query time and consumes more memory. Only supported by the `fvh` highlighter.').optional(),
+  post_tags: z.array(z.string()).describe('Use in conjunction with `pre_tags` to define the HTML tags to use for the highlighted text. By default, highlighted text is wrapped in `<em>` and `</em>` tags.').optional(),
+  pre_tags: z.array(z.string()).describe('Use in conjunction with `post_tags` to define the HTML tags to use for the highlighted text. By default, highlighted text is wrapped in `<em>` and `</em>` tags.').optional(),
+  require_field_match: z.boolean().describe('By default, only fields that contains a query match are highlighted. Set to `false` to highlight all fields.').optional(),
+  tags_schema: SearchHighlighterTagsSchema.describe('Set to `styled` to use the built-in tag schema.').optional(),
+  fragment_offset: integer.optional(),
+  matched_fields: Fields.optional()
+}).meta({ id: 'SearchHighlightField' })
+export type SearchHighlightField = z.infer<typeof SearchHighlightField>
+
+export interface SearchHighlightShape {
+  type?: SearchHighlighterType | undefined
+  boundary_chars?: string | undefined
+  boundary_max_scan?: integer | undefined
+  boundary_scanner?: SearchBoundaryScanner | undefined
+  boundary_scanner_locale?: string | undefined
+  force_source?: boolean | undefined
+  fragmenter?: SearchHighlighterFragmenter | undefined
+  fragment_size?: integer | undefined
+  highlight_filter?: boolean | undefined
+  highlight_query?: QueryDslQueryContainerShape | undefined
+  max_fragment_length?: integer | undefined
+  max_analyzed_offset?: integer | undefined
+  no_match_size?: integer | undefined
+  number_of_fragments?: integer | undefined
+  options?: Record<string, unknown> | undefined
+  order?: SearchHighlighterOrder | undefined
+  phrase_limit?: integer | undefined
+  post_tags?: string[] | undefined
+  pre_tags?: string[] | undefined
+  require_field_match?: boolean | undefined
+  tags_schema?: SearchHighlighterTagsSchema | undefined
+  encoder?: SearchHighlighterEncoder | undefined
+  fields: Record<Field, SearchHighlightFieldShape> | Array<Record<Field, SearchHighlightFieldShape>>
+}
+export const SearchHighlight = z.object({
+  type: SearchHighlighterType.optional(),
+  boundary_chars: z.string().describe('A string that contains each boundary character.').optional(),
+  boundary_max_scan: integer.describe('How far to scan for boundary characters.').optional(),
+  boundary_scanner: SearchBoundaryScanner.describe('Specifies how to break the highlighted fragments: chars, sentence, or word. Only valid for the unified and fvh highlighters. Defaults to `sentence` for the `unified` highlighter. Defaults to `chars` for the `fvh` highlighter.').optional(),
+  boundary_scanner_locale: z.string().describe('Controls which locale is used to search for sentence and word boundaries. This parameter takes a form of a language tag, for example: `"en-US"`, `"fr-FR"`, `"ja-JP"`.').optional(),
+  force_source: z.boolean().optional(),
+  fragmenter: SearchHighlighterFragmenter.describe('Specifies how text should be broken up in highlight snippets: `simple` or `span`. Only valid for the `plain` highlighter.').optional(),
+  fragment_size: integer.describe('The size of the highlighted fragment in characters.').optional(),
+  highlight_filter: z.boolean().optional(),
+  get highlight_query () { return QueryDslQueryContainer.describe('Highlight matches for a query other than the search query. This is especially useful if you use a rescore query because those are not taken into account by highlighting by default.').optional() },
+  max_fragment_length: integer.optional(),
+  max_analyzed_offset: integer.describe('If set to a non-negative value, highlighting stops at this defined maximum limit. The rest of the text is not processed, thus not highlighted and no error is returned The `max_analyzed_offset` query setting does not override the `index.highlight.max_analyzed_offset` setting, which prevails when it’s set to lower value than the query setting.').optional(),
+  no_match_size: integer.describe('The amount of text you want to return from the beginning of the field if there are no matching fragments to highlight.').optional(),
+  number_of_fragments: integer.describe('The maximum number of fragments to return. If the number of fragments is set to `0`, no fragments are returned. Instead, the entire field contents are highlighted and returned. This can be handy when you need to highlight short texts such as a title or address, but fragmentation is not required. If `number_of_fragments` is `0`, `fragment_size` is ignored.').optional(),
+  options: z.record(z.string(), z.any()).optional(),
+  order: SearchHighlighterOrder.describe('Sorts highlighted fragments by score when set to `score`. By default, fragments will be output in the order they appear in the field (order: `none`). Setting this option to `score` will output the most relevant fragments first. Each highlighter applies its own logic to compute relevancy scores.').optional(),
+  phrase_limit: integer.describe('Controls the number of matching phrases in a document that are considered. Prevents the `fvh` highlighter from analyzing too many phrases and consuming too much memory. When using `matched_fields`, `phrase_limit` phrases per matched field are considered. Raising the limit increases query time and consumes more memory. Only supported by the `fvh` highlighter.').optional(),
+  post_tags: z.array(z.string()).describe('Use in conjunction with `pre_tags` to define the HTML tags to use for the highlighted text. By default, highlighted text is wrapped in `<em>` and `</em>` tags.').optional(),
+  pre_tags: z.array(z.string()).describe('Use in conjunction with `post_tags` to define the HTML tags to use for the highlighted text. By default, highlighted text is wrapped in `<em>` and `</em>` tags.').optional(),
+  require_field_match: z.boolean().describe('By default, only fields that contains a query match are highlighted. Set to `false` to highlight all fields.').optional(),
+  tags_schema: SearchHighlighterTagsSchema.describe('Set to `styled` to use the built-in tag schema.').optional(),
+  encoder: SearchHighlighterEncoder.optional(),
+  get fields (): z.ZodUnion<readonly [z.ZodRecord<typeof Field, typeof SearchHighlightField>, z.ZodArray<z.ZodRecord<typeof Field, typeof SearchHighlightField>>]> { return z.union([z.record(Field, SearchHighlightField), z.array(z.record(Field, SearchHighlightField))]) }
+}).meta({ id: 'SearchHighlight' })
+export type SearchHighlight = z.infer<typeof SearchHighlight>
+
+export interface SearchInnerHitsShape {
+  name?: Name | undefined
+  size?: integer | undefined
+  from?: integer | undefined
+  collapse?: SearchFieldCollapseShape | undefined
+  docvalue_fields?: QueryDslFieldAndFormat[] | undefined
+  explain?: boolean | undefined
+  highlight?: SearchHighlightShape | undefined
+  ignore_unmapped?: boolean | undefined
+  script_fields?: Record<Field, ScriptFieldShape> | undefined
+  seq_no_primary_term?: boolean | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
+  sort?: SortShape | undefined
+  _source?: SearchSourceConfig | undefined
+  stored_fields?: Fields | undefined
+  track_scores?: boolean | undefined
+  version?: boolean | undefined
+}
+export const SearchInnerHits = z.object({
+  name: Name.describe('The name for the particular inner hit definition in the response. Useful when a search request contains multiple inner hits.').optional(),
+  size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
+  from: integer.describe('Inner hit starting document offset.').optional(),
+  get collapse () { return SearchFieldCollapse.optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
+  explain: z.boolean().optional(),
+  get highlight () { return SearchHighlight.optional() },
+  ignore_unmapped: z.boolean().optional(),
+  get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
+  seq_no_primary_term: z.boolean().optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
+  get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
+  _source: SearchSourceConfig.optional(),
+  stored_fields: Fields.optional(),
+  track_scores: z.boolean().optional(),
+  version: z.boolean().optional()
+}).meta({ id: 'SearchInnerHits' })
+export type SearchInnerHits = z.infer<typeof SearchInnerHits>
+
+export interface SearchFieldCollapseShape {
+  field: Field
+  inner_hits?: SearchInnerHitsShape | SearchInnerHitsShape[] | undefined
+  max_concurrent_group_searches?: integer | undefined
+  collapse?: SearchFieldCollapseShape | undefined
+}
+export const SearchFieldCollapse = z.object({
+  field: Field.describe('The field to collapse the result set on'),
+  get inner_hits (): z.ZodOptional<z.ZodUnion<readonly [typeof SearchInnerHits, z.ZodArray<typeof SearchInnerHits>]>> { return z.union([SearchInnerHits, SearchInnerHits.array()]).describe('The number of inner hits and their sort order').optional() },
+  max_concurrent_group_searches: integer.describe('The number of concurrent requests allowed to retrieve the inner_hits per group').optional(),
+  get collapse () { return SearchFieldCollapse.optional() }
+}).meta({ id: 'SearchFieldCollapse' })
+export type SearchFieldCollapse = z.infer<typeof SearchFieldCollapse>
 
 export const SearchTotalHitsRelation = z.enum(['eq', 'gte']).meta({ id: 'SearchTotalHitsRelation' })
 export type SearchTotalHitsRelation = z.infer<typeof SearchTotalHitsRelation>
@@ -415,10 +4340,6 @@ export const SearchInnerHitsResult = z.object({
 }).meta({ id: 'SearchInnerHitsResult' })
 export type SearchInnerHitsResult = z.infer<typeof SearchInnerHitsResult>
 
-/** Path to field or array of paths. Some API's support wildcards in the path to select multiple fields. */
-export const Field = z.string().meta({ id: 'Field' })
-export type Field = z.infer<typeof Field>
-
 export interface SearchNestedIdentityShape {
   field: Field
   offset: integer
@@ -433,16 +4354,6 @@ export type SearchNestedIdentity = z.infer<typeof SearchNestedIdentity>
 
 export const SequenceNumber = long.meta({ id: 'SequenceNumber' })
 export type SequenceNumber = z.infer<typeof SequenceNumber>
-
-export const VersionNumber = long.meta({ id: 'VersionNumber' })
-export type VersionNumber = z.infer<typeof VersionNumber>
-
-/** A field value. */
-export const FieldValue = z.union([long, double, z.string(), z.boolean(), z.null()]).meta({ id: 'FieldValue' })
-export type FieldValue = z.infer<typeof FieldValue>
-
-export const SortResults = z.array(FieldValue).meta({ id: 'SortResults' })
-export type SortResults = z.infer<typeof SortResults>
 
 export interface SearchHitShape {
   _index: IndexName
@@ -567,8 +4478,19 @@ export const SearchShardProfile = z.object({
 }).meta({ id: 'SearchShardProfile' })
 export type SearchShardProfile = z.infer<typeof SearchShardProfile>
 
+/**
+ * Coordinator snapshot of the original search request, serialized under `profile.request` when profiling is enabled.
+ * Introduced in Elasticsearch 9.5; omitted when the cluster contains mixed-version nodes that do not serialize this metadata.
+ */
+export const SearchSearchRequestCoordinatorMetadata = z.object({
+  source: z.lazy(() => SearchSearchRequestBody).describe('Original query source from the search request (`SearchSourceBuilder` as JSON).').optional(),
+  indices: z.array(IndexName).describe('Target index expressions from the request (before index resolution).').optional()
+}).meta({ id: 'SearchSearchRequestCoordinatorMetadata' })
+export type SearchSearchRequestCoordinatorMetadata = z.infer<typeof SearchSearchRequestCoordinatorMetadata>
+
 export const SearchProfile = z.object({
-  shards: z.array(SearchShardProfile)
+  shards: z.array(SearchShardProfile),
+  request: SearchSearchRequestCoordinatorMetadata.describe('When profiling is enabled, the original query source and target indices from the coordinating request.').optional()
 }).meta({ id: 'SearchProfile' })
 export type SearchProfile = z.infer<typeof SearchProfile>
 
@@ -663,17 +4585,6 @@ export const ClusterStatistics = z.object({
   details: z.record(ClusterAlias, ClusterDetails).optional()
 }).meta({ id: 'ClusterStatistics' })
 export type ClusterStatistics = z.infer<typeof ClusterStatistics>
-
-export const EpochTime = z.any().meta({ id: 'EpochTime' })
-export type EpochTime = z.infer<typeof EpochTime>
-
-/**
- * A date and time, either as a string whose format can depend on the context (defaulting to ISO 8601), or a
- * number of milliseconds since the Epoch. Elasticsearch accepts both as input, but will generally output a string
- * representation.
- */
-export const DateTime = z.union([z.string(), EpochTime]).meta({ id: 'DateTime' })
-export type DateTime = z.infer<typeof DateTime>
 
 export const RequestBase = z.object({
 }).meta({ id: 'RequestBase' })

--- a/packages/es-schemas/src/async_search_status.ts
+++ b/packages/es-schemas/src/async_search_status.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/async_search_submit.ts
+++ b/packages/es-schemas/src/async_search_submit.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -636,7 +637,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -647,11 +648,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -667,7 +668,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -680,7 +681,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -694,7 +695,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -740,7 +741,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -756,7 +757,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -770,7 +771,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -835,7 +836,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -935,7 +936,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -950,7 +951,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -962,7 +963,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -1035,7 +1036,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -1053,7 +1054,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -1072,7 +1073,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -1103,7 +1104,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -1163,7 +1164,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -1246,7 +1247,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -1298,7 +1299,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -1314,7 +1315,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1386,7 +1387,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1401,7 +1402,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1507,7 +1508,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1589,7 +1590,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1610,7 +1611,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1626,7 +1627,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1741,7 +1742,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1818,7 +1819,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1840,7 +1841,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1867,7 +1868,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1899,7 +1900,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1931,12 +1932,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1974,7 +1975,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -2071,7 +2072,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -2090,7 +2091,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -2104,7 +2105,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -2145,7 +2146,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -2166,7 +2167,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -2181,7 +2182,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -2205,10 +2206,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -2229,7 +2230,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -2265,7 +2266,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -2281,7 +2282,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -2295,7 +2296,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -2308,7 +2309,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2338,7 +2339,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2449,6 +2450,36 @@ export type SearchTrackHits = z.infer<typeof SearchTrackHits>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2463,7 +2494,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2530,7 +2561,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2885,12 +2916,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2943,7 +2974,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2957,7 +2988,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2998,7 +3029,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -3176,7 +3207,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3700,7 +3731,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3716,7 +3747,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3879,7 +3910,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3955,7 +3986,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3996,7 +4027,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -4237,7 +4268,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -4249,13 +4281,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4445,8 +4478,19 @@ export const SearchShardProfile = z.object({
 }).meta({ id: 'SearchShardProfile' })
 export type SearchShardProfile = z.infer<typeof SearchShardProfile>
 
+/**
+ * Coordinator snapshot of the original search request, serialized under `profile.request` when profiling is enabled.
+ * Introduced in Elasticsearch 9.5; omitted when the cluster contains mixed-version nodes that do not serialize this metadata.
+ */
+export const SearchSearchRequestCoordinatorMetadata = z.object({
+  source: z.lazy(() => SearchSearchRequestBody).describe('Original query source from the search request (`SearchSourceBuilder` as JSON).').optional(),
+  indices: z.array(IndexName).describe('Target index expressions from the request (before index resolution).').optional()
+}).meta({ id: 'SearchSearchRequestCoordinatorMetadata' })
+export type SearchSearchRequestCoordinatorMetadata = z.infer<typeof SearchSearchRequestCoordinatorMetadata>
+
 export const SearchProfile = z.object({
-  shards: z.array(SearchShardProfile)
+  shards: z.array(SearchShardProfile),
+  request: SearchSearchRequestCoordinatorMetadata.describe('When profiling is enabled, the original query source and target indices from the coordinating request.').optional()
 }).meta({ id: 'SearchProfile' })
 export type SearchProfile = z.infer<typeof SearchProfile>
 
@@ -4667,7 +4711,7 @@ export const AsyncSearchSubmitRequest = z.object({
   highlight: z.lazy(() => SearchHighlight).optional().meta({ found_in: 'body' }),
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If true, the exact number of hits is returned at the cost of some performance. If false, the response does not include the total number of hits matching the query. Defaults to 10,000 hits.').optional().meta({ found_in: 'body' }),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boosts the _score of documents from specified indices.').optional().meta({ found_in: 'body' }),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns doc values for field names matching these patterns in the hits.fields property of the response.').optional().meta({ found_in: 'body' }),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns doc values for field names matching these patterns in the hits.fields property of the response.').optional().meta({ found_in: 'body' }),
   knn: z.union([z.lazy(() => KnnSearch), z.array(z.lazy(() => KnnSearch))]).describe('Defines the approximate kNN search to run.').optional().meta({ found_in: 'body' }),
   min_score: double.describe('Minimum _score for matching documents. Documents with a lower _score are not included in search results and results collected by aggregations.').optional().meta({ found_in: 'body' }),
   post_filter: z.lazy(() => QueryDslQueryContainer).optional().meta({ found_in: 'body' }),
@@ -4680,7 +4724,7 @@ export const AsyncSearchSubmitRequest = z.object({
   slice: SlicedScroll.optional().meta({ found_in: 'body' }),
   sort: z.lazy(() => Sort).optional().meta({ found_in: 'body' }),
   _source: SearchSourceConfig.describe('Indicates which source fields are returned for matching documents. These fields are returned in the hits._source property of the search response.').optional().meta({ found_in: 'body' }),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional().meta({ found_in: 'body' }),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional().meta({ found_in: 'body' }),
   suggest: SearchSuggester.optional().meta({ found_in: 'body' }),
   terminate_after: long.describe('Maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. Defaults to 0, which does not terminate query execution early.').optional().meta({ found_in: 'body' }),
   timeout: z.string().describe('Specifies the period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional().meta({ found_in: 'body' }),

--- a/packages/es-schemas/src/autoscaling_delete_autoscaling_policy.ts
+++ b/packages/es-schemas/src/autoscaling_delete_autoscaling_policy.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/autoscaling_get_autoscaling_capacity.ts
+++ b/packages/es-schemas/src/autoscaling_get_autoscaling_capacity.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/autoscaling_get_autoscaling_policy.ts
+++ b/packages/es-schemas/src/autoscaling_get_autoscaling_policy.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/autoscaling_put_autoscaling_policy.ts
+++ b/packages/es-schemas/src/autoscaling_put_autoscaling_policy.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/bulk.ts
+++ b/packages/es-schemas/src/bulk.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -335,7 +336,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -663,7 +664,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -726,7 +727,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -765,7 +766,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface SearchInnerHitsShape {
@@ -779,7 +780,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -791,13 +793,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -865,7 +868,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -997,6 +1000,36 @@ export type QueryDslIntervalsQuery = z.infer<typeof QueryDslIntervalsQuery>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -1011,7 +1044,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -1409,7 +1442,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -1425,7 +1458,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -1592,7 +1625,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -1668,7 +1701,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -1709,7 +1742,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -1806,7 +1839,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -1817,11 +1850,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -1837,7 +1870,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -1850,7 +1883,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -1864,7 +1897,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -1910,7 +1943,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -1926,7 +1959,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -1940,7 +1973,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -2015,7 +2048,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -2030,7 +2063,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -2042,7 +2075,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -2108,7 +2141,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -2126,7 +2159,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -2145,7 +2178,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -2176,7 +2209,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -2257,7 +2290,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -2340,7 +2373,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -2392,7 +2425,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -2408,7 +2441,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -2480,7 +2513,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -2495,7 +2528,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -2601,7 +2634,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -2680,7 +2713,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -2701,7 +2734,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -2717,7 +2750,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -2832,7 +2865,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -2909,7 +2942,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -2931,7 +2964,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -2958,7 +2991,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -2990,7 +3023,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -3022,12 +3055,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -3065,7 +3098,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -3162,7 +3195,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -3181,7 +3214,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -3195,7 +3228,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -3236,7 +3269,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -3273,10 +3306,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -3297,7 +3330,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -3333,7 +3366,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -3349,7 +3382,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -3363,7 +3396,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -3376,7 +3409,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -3406,7 +3439,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -3571,7 +3604,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -3923,12 +3956,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -3981,7 +4014,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -3995,7 +4028,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -4036,7 +4069,7 @@ export const BulkUpdateAction = z.object({
   detect_noop: z.boolean().describe('If true, the `result` in the response is set to \'noop\' when no changes to the document occur.').optional(),
   doc: z.any().describe('A partial update to an existing document.').optional(),
   doc_as_upsert: z.boolean().describe('Set to `true` to use the contents of `doc` as the value of `upsert`.').optional(),
-  script: z.lazy(() => Script).describe('The script to run to update the document.').optional(),
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('The script to run to update the document.').optional(),
   scripted_upsert: z.boolean().describe('Set to `true` to run the script whether or not the document exists.').optional(),
   _source: SearchSourceConfig.describe('If `false`, source retrieval is turned off. You can also specify a comma-separated list of the fields you want to retrieve.').optional(),
   upsert: z.any().describe('If the document does not already exist, the contents of `upsert` are inserted as a new document. If the document exists, the `script` is run.').optional()

--- a/packages/es-schemas/src/cancel_reindex.ts
+++ b/packages/es-schemas/src/cancel_reindex.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/capabilities.ts
+++ b/packages/es-schemas/src/capabilities.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/cat_aliases.ts
+++ b/packages/es-schemas/src/cat_aliases.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/cat_allocation.ts
+++ b/packages/es-schemas/src/cat_allocation.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/cat_circuit_breaker.ts
+++ b/packages/es-schemas/src/cat_circuit_breaker.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/cat_component_templates.ts
+++ b/packages/es-schemas/src/cat_component_templates.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/cat_count.ts
+++ b/packages/es-schemas/src/cat_count.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/cat_fielddata.ts
+++ b/packages/es-schemas/src/cat_fielddata.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/cat_health.ts
+++ b/packages/es-schemas/src/cat_health.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/cat_help.ts
+++ b/packages/es-schemas/src/cat_help.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/cat_indices.ts
+++ b/packages/es-schemas/src/cat_indices.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/cat_master.ts
+++ b/packages/es-schemas/src/cat_master.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/cat_ml_data_frame_analytics.ts
+++ b/packages/es-schemas/src/cat_ml_data_frame_analytics.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/cat_ml_datafeeds.ts
+++ b/packages/es-schemas/src/cat_ml_datafeeds.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/cat_ml_jobs.ts
+++ b/packages/es-schemas/src/cat_ml_jobs.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/cat_ml_trained_models.ts
+++ b/packages/es-schemas/src/cat_ml_trained_models.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/cat_nodeattrs.ts
+++ b/packages/es-schemas/src/cat_nodeattrs.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/cat_nodes.ts
+++ b/packages/es-schemas/src/cat_nodes.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/cat_pending_tasks.ts
+++ b/packages/es-schemas/src/cat_pending_tasks.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/cat_plugins.ts
+++ b/packages/es-schemas/src/cat_plugins.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/cat_recovery.ts
+++ b/packages/es-schemas/src/cat_recovery.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/cat_repositories.ts
+++ b/packages/es-schemas/src/cat_repositories.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/cat_segments.ts
+++ b/packages/es-schemas/src/cat_segments.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/cat_shards.ts
+++ b/packages/es-schemas/src/cat_shards.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/cat_snapshots.ts
+++ b/packages/es-schemas/src/cat_snapshots.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/cat_tasks.ts
+++ b/packages/es-schemas/src/cat_tasks.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/cat_templates.ts
+++ b/packages/es-schemas/src/cat_templates.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/cat_thread_pool.ts
+++ b/packages/es-schemas/src/cat_thread_pool.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/cat_transforms.ts
+++ b/packages/es-schemas/src/cat_transforms.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -34,7 +35,7 @@ export const CatCatRequestBase = z.object({
 }).meta({ id: 'CatCatRequestBase' })
 export type CatCatRequestBase = z.infer<typeof CatCatRequestBase>
 
-export const CatCatTransformColumn = z.enum(['changes_last_detection_time', 'cldt', 'checkpoint', 'cp', 'checkpoint_duration_time_exp_avg', 'cdtea', 'checkpointTimeExpAvg', 'checkpoint_progress', 'c', 'checkpointProgress', 'create_time', 'ct', 'createTime', 'delete_time', 'dtime', 'description', 'd', 'dest_index', 'di', 'destIndex', 'documents_deleted', 'docd', 'documents_indexed', 'doci', 'docs_per_second', 'dps', 'documents_processed', 'docp', 'frequency', 'f', 'id', 'index_failure', 'if', 'index_time', 'itime', 'index_total', 'it', 'indexed_documents_exp_avg', 'idea', 'last_search_time', 'lst', 'lastSearchTime', 'max_page_search_size', 'mpsz', 'pages_processed', 'pp', 'pipeline', 'p', 'processed_documents_exp_avg', 'pdea', 'processing_time', 'pt', 'reason', 'r', 'search_failure', 'sf', 'search_time', 'stime', 'search_total', 'st', 'source_index', 'si', 'sourceIndex', 'state', 's', 'transform_type', 'tt', 'trigger_count', 'tc', 'version', 'v']).meta({ id: 'CatCatTransformColumn' })
+export const CatCatTransformColumn = z.enum(['changes_last_detection_time', 'cldt', 'checkpoint', 'cp', 'checkpoint_duration_time_exp_avg', 'cdtea', 'checkpointTimeExpAvg', 'checkpoint_progress', 'c', 'checkpointProgress', 'create_time', 'ct', 'createTime', 'delete_time', 'dtime', 'description', 'd', 'dest_index', 'di', 'destIndex', 'documents_deleted', 'docd', 'documents_indexed', 'doci', 'docs_per_second', 'dps', 'documents_processed', 'docp', 'frequency', 'f', 'id', 'index_failure', 'if', 'index_time', 'itime', 'index_total', 'it', 'indexed_documents_exp_avg', 'idea', 'last_search_time', 'lst', 'lastSearchTime', 'max_page_search_size', 'mpsz', 'pages_processed', 'pp', 'pipeline', 'p', 'processed_documents_exp_avg', 'pdea', 'processing_time', 'pt', 'project_routing', 'pr', 'projectRouting', 'reason', 'r', 'search_failure', 'sf', 'search_time', 'stime', 'search_total', 'st', 'source_index', 'si', 'sourceIndex', 'state', 's', 'transform_type', 'tt', 'trigger_count', 'tc', 'version', 'v']).meta({ id: 'CatCatTransformColumn' })
 export type CatCatTransformColumn = z.infer<typeof CatCatTransformColumn>
 
 export const CatCatTransformColumns = z.union([CatCatTransformColumn, z.array(CatCatTransformColumn)]).meta({ id: 'CatCatTransformColumns' })

--- a/packages/es-schemas/src/ccr_delete_auto_follow_pattern.ts
+++ b/packages/es-schemas/src/ccr_delete_auto_follow_pattern.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ccr_follow.ts
+++ b/packages/es-schemas/src/ccr_follow.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4586,7 +4619,7 @@ export const AnalysisConditionTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('condition'),
   filter: z.array(z.string()).describe('Array of token filters. If a token matches the predicate script in the `script` parameter, these filters are applied to the token in the order provided.'),
-  script: z.lazy(() => Script).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
 }).meta({ id: 'AnalysisConditionTokenFilter' })
 export type AnalysisConditionTokenFilter = z.infer<typeof AnalysisConditionTokenFilter>
 
@@ -5067,7 +5100,7 @@ export type AnalysisPorterStemTokenFilter = z.infer<typeof AnalysisPorterStemTok
 export const AnalysisPredicateTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('predicate_token_filter'),
-  script: z.lazy(() => Script).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
 }).meta({ id: 'AnalysisPredicateTokenFilter' })
 export type AnalysisPredicateTokenFilter = z.infer<typeof AnalysisPredicateTokenFilter>
 
@@ -5550,8 +5583,8 @@ export type IndicesSettingsSimilarityLmj = z.infer<typeof IndicesSettingsSimilar
 
 export const IndicesSettingsSimilarityScripted = z.object({
   type: z.literal('scripted'),
-  script: z.lazy(() => Script),
-  weight_script: z.lazy(() => Script).optional()
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]),
+  weight_script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).optional()
 }).meta({ id: 'IndicesSettingsSimilarityScripted' })
 export type IndicesSettingsSimilarityScripted = z.infer<typeof IndicesSettingsSimilarityScripted>
 

--- a/packages/es-schemas/src/ccr_follow_info.ts
+++ b/packages/es-schemas/src/ccr_follow_info.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ccr_follow_stats.ts
+++ b/packages/es-schemas/src/ccr_follow_stats.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ccr_forget_follower.ts
+++ b/packages/es-schemas/src/ccr_forget_follower.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ccr_get_auto_follow_pattern.ts
+++ b/packages/es-schemas/src/ccr_get_auto_follow_pattern.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ccr_pause_auto_follow_pattern.ts
+++ b/packages/es-schemas/src/ccr_pause_auto_follow_pattern.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ccr_pause_follow.ts
+++ b/packages/es-schemas/src/ccr_pause_follow.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ccr_put_auto_follow_pattern.ts
+++ b/packages/es-schemas/src/ccr_put_auto_follow_pattern.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ccr_resume_auto_follow_pattern.ts
+++ b/packages/es-schemas/src/ccr_resume_auto_follow_pattern.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ccr_resume_follow.ts
+++ b/packages/es-schemas/src/ccr_resume_follow.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ccr_stats.ts
+++ b/packages/es-schemas/src/ccr_stats.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ccr_unfollow.ts
+++ b/packages/es-schemas/src/ccr_unfollow.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/clear_scroll.ts
+++ b/packages/es-schemas/src/clear_scroll.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/close_point_in_time.ts
+++ b/packages/es-schemas/src/close_point_in_time.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/cluster_allocation_explain.ts
+++ b/packages/es-schemas/src/cluster_allocation_explain.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/cluster_delete_component_template.ts
+++ b/packages/es-schemas/src/cluster_delete_component_template.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/cluster_delete_voting_config_exclusions.ts
+++ b/packages/es-schemas/src/cluster_delete_voting_config_exclusions.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/cluster_exists_component_template.ts
+++ b/packages/es-schemas/src/cluster_exists_component_template.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/cluster_get_component_template.ts
+++ b/packages/es-schemas/src/cluster_get_component_template.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4592,7 +4625,7 @@ export const AnalysisConditionTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('condition'),
   filter: z.array(z.string()).describe('Array of token filters. If a token matches the predicate script in the `script` parameter, these filters are applied to the token in the order provided.'),
-  script: z.lazy(() => Script).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
 }).meta({ id: 'AnalysisConditionTokenFilter' })
 export type AnalysisConditionTokenFilter = z.infer<typeof AnalysisConditionTokenFilter>
 
@@ -5073,7 +5106,7 @@ export type AnalysisPorterStemTokenFilter = z.infer<typeof AnalysisPorterStemTok
 export const AnalysisPredicateTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('predicate_token_filter'),
-  script: z.lazy(() => Script).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
 }).meta({ id: 'AnalysisPredicateTokenFilter' })
 export type AnalysisPredicateTokenFilter = z.infer<typeof AnalysisPredicateTokenFilter>
 
@@ -5622,7 +5655,7 @@ export const MappingBooleanProperty = z.object({
   index: z.boolean().optional(),
   null_value: z.boolean().optional(),
   ignore_malformed: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('boolean')
@@ -5663,7 +5696,7 @@ export const MappingNumberPropertyBase = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional()
 }).meta({ id: 'MappingNumberPropertyBase' })
@@ -5705,7 +5738,7 @@ export const MappingByteNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('byte'),
@@ -5834,7 +5867,7 @@ export const MappingDateNanosProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -5879,7 +5912,7 @@ export const MappingDateProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -6018,7 +6051,7 @@ export const MappingDoubleNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('double'),
@@ -6107,7 +6140,7 @@ export const MappingDynamicProperty = z.object({
   null_value: FieldValue.optional(),
   boost: double.optional(),
   coerce: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   ignore_malformed: z.boolean().optional(),
   time_series_metric: MappingTimeSeriesMetricType.optional(),
@@ -6271,7 +6304,7 @@ export const MappingFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('float'),
@@ -6345,7 +6378,7 @@ export const MappingGeoPointProperty = z.object({
   null_value: GeoLocation.optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   type: z.literal('geo_point'),
   time_series_metric: MappingGeoPointMetricType.optional()
 }).meta({ id: 'MappingGeoPointProperty' })
@@ -6429,7 +6462,7 @@ export const MappingHalfFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('half_float'),
@@ -6560,7 +6593,7 @@ export const MappingIntegerNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('integer'),
@@ -6634,7 +6667,7 @@ export const MappingIpProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   null_value: z.string().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('ip')
 }).meta({ id: 'MappingIpProperty' })
@@ -6734,7 +6767,7 @@ export const MappingKeywordProperty = z.object({
   eager_global_ordinals: z.boolean().optional(),
   index: z.boolean().optional(),
   index_options: MappingIndexOptions.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   normalizer: z.string().optional(),
   norms: z.boolean().optional(),
@@ -6782,7 +6815,7 @@ export const MappingLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('long'),
@@ -7099,7 +7132,7 @@ export const MappingScaledFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('scaled_float'),
@@ -7224,7 +7257,7 @@ export const MappingShortNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('short'),
@@ -7421,7 +7454,7 @@ export const MappingUnsignedLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('unsigned_long'),
@@ -7483,6 +7516,9 @@ export const MappingWildcardProperty = z.object({
 }).meta({ id: 'MappingWildcardProperty' })
 export type MappingWildcardProperty = z.infer<typeof MappingWildcardProperty>
 
+export const IndicesRetentionSource = z.enum(['data_stream_configuration', 'default_global_retention', 'max_global_retention', 'default_failures_retention']).meta({ id: 'IndicesRetentionSource' })
+export type IndicesRetentionSource = z.infer<typeof IndicesRetentionSource>
+
 export const IndicesDownsamplingRound = z.object({
   after: Duration.describe('The duration since rollover when this downsampling round should execute'),
   fixed_interval: DurationLarge.describe('The downsample interval.')
@@ -7495,6 +7531,8 @@ export type IndicesSamplingMethod = z.infer<typeof IndicesSamplingMethod>
 /** Data stream lifecycle denotes that a data stream is managed by the data stream lifecycle and contains the configuration. */
 export const IndicesDataStreamLifecycle = z.object({
   data_retention: Duration.describe('If defined, every document added to this data stream will be stored at least for this time frame. Any time after this duration the document could be deleted. When empty, every document in this data stream will be stored indefinitely.').optional(),
+  effective_retention: Duration.describe('The least amount of time data should be kept by elasticsearch.').optional(),
+  retention_determined_by: IndicesRetentionSource.describe('Configuration source that can influence the retention of a data stream.').optional(),
   downsampling: z.array(IndicesDownsamplingRound).describe('The list of downsampling rounds to execute as part of this downsampling configuration').optional(),
   downsampling_method: IndicesSamplingMethod.describe('The method used to downsample the data. There are two options `aggregate` and `last_value`. It requires `downsampling` to be defined. Defaults to `aggregate`.').optional(),
   enabled: z.boolean().describe('If defined, it turns data stream lifecycle on/off (`true`/`false`) for this data stream. A data stream lifecycle that\'s disabled (enabled: `false`) will have no effect on the data stream.').optional(),
@@ -7779,8 +7817,8 @@ export type IndicesSettingsSimilarityLmj = z.infer<typeof IndicesSettingsSimilar
 
 export const IndicesSettingsSimilarityScripted = z.object({
   type: z.literal('scripted'),
-  script: z.lazy(() => Script),
-  weight_script: z.lazy(() => Script).optional()
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]),
+  weight_script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).optional()
 }).meta({ id: 'IndicesSettingsSimilarityScripted' })
 export type IndicesSettingsSimilarityScripted = z.infer<typeof IndicesSettingsSimilarityScripted>
 

--- a/packages/es-schemas/src/cluster_get_settings.ts
+++ b/packages/es-schemas/src/cluster_get_settings.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/cluster_health.ts
+++ b/packages/es-schemas/src/cluster_health.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/cluster_info.ts
+++ b/packages/es-schemas/src/cluster_info.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/cluster_pending_tasks.ts
+++ b/packages/es-schemas/src/cluster_pending_tasks.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/cluster_post_voting_config_exclusions.ts
+++ b/packages/es-schemas/src/cluster_post_voting_config_exclusions.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/cluster_put_component_template.ts
+++ b/packages/es-schemas/src/cluster_put_component_template.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4597,7 +4630,7 @@ export const AnalysisConditionTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('condition'),
   filter: z.array(z.string()).describe('Array of token filters. If a token matches the predicate script in the `script` parameter, these filters are applied to the token in the order provided.'),
-  script: z.lazy(() => Script).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
 }).meta({ id: 'AnalysisConditionTokenFilter' })
 export type AnalysisConditionTokenFilter = z.infer<typeof AnalysisConditionTokenFilter>
 
@@ -5078,7 +5111,7 @@ export type AnalysisPorterStemTokenFilter = z.infer<typeof AnalysisPorterStemTok
 export const AnalysisPredicateTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('predicate_token_filter'),
-  script: z.lazy(() => Script).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
 }).meta({ id: 'AnalysisPredicateTokenFilter' })
 export type AnalysisPredicateTokenFilter = z.infer<typeof AnalysisPredicateTokenFilter>
 
@@ -5627,7 +5660,7 @@ export const MappingBooleanProperty = z.object({
   index: z.boolean().optional(),
   null_value: z.boolean().optional(),
   ignore_malformed: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('boolean')
@@ -5668,7 +5701,7 @@ export const MappingNumberPropertyBase = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional()
 }).meta({ id: 'MappingNumberPropertyBase' })
@@ -5710,7 +5743,7 @@ export const MappingByteNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('byte'),
@@ -5839,7 +5872,7 @@ export const MappingDateNanosProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -5884,7 +5917,7 @@ export const MappingDateProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -6023,7 +6056,7 @@ export const MappingDoubleNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('double'),
@@ -6112,7 +6145,7 @@ export const MappingDynamicProperty = z.object({
   null_value: FieldValue.optional(),
   boost: double.optional(),
   coerce: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   ignore_malformed: z.boolean().optional(),
   time_series_metric: MappingTimeSeriesMetricType.optional(),
@@ -6276,7 +6309,7 @@ export const MappingFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('float'),
@@ -6350,7 +6383,7 @@ export const MappingGeoPointProperty = z.object({
   null_value: GeoLocation.optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   type: z.literal('geo_point'),
   time_series_metric: MappingGeoPointMetricType.optional()
 }).meta({ id: 'MappingGeoPointProperty' })
@@ -6434,7 +6467,7 @@ export const MappingHalfFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('half_float'),
@@ -6565,7 +6598,7 @@ export const MappingIntegerNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('integer'),
@@ -6639,7 +6672,7 @@ export const MappingIpProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   null_value: z.string().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('ip')
 }).meta({ id: 'MappingIpProperty' })
@@ -6739,7 +6772,7 @@ export const MappingKeywordProperty = z.object({
   eager_global_ordinals: z.boolean().optional(),
   index: z.boolean().optional(),
   index_options: MappingIndexOptions.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   normalizer: z.string().optional(),
   norms: z.boolean().optional(),
@@ -6787,7 +6820,7 @@ export const MappingLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('long'),
@@ -7104,7 +7137,7 @@ export const MappingScaledFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('scaled_float'),
@@ -7229,7 +7262,7 @@ export const MappingShortNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('short'),
@@ -7426,7 +7459,7 @@ export const MappingUnsignedLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('unsigned_long'),
@@ -7751,8 +7784,8 @@ export type IndicesSettingsSimilarityLmj = z.infer<typeof IndicesSettingsSimilar
 
 export const IndicesSettingsSimilarityScripted = z.object({
   type: z.literal('scripted'),
-  script: z.lazy(() => Script),
-  weight_script: z.lazy(() => Script).optional()
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]),
+  weight_script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).optional()
 }).meta({ id: 'IndicesSettingsSimilarityScripted' })
 export type IndicesSettingsSimilarityScripted = z.infer<typeof IndicesSettingsSimilarityScripted>
 
@@ -7959,6 +7992,9 @@ export const IndicesIndexSettings = z.looseObject({
 }).meta({ id: 'IndicesIndexSettings' })
 export type IndicesIndexSettings = z.infer<typeof IndicesIndexSettings>
 
+export const IndicesRetentionSource = z.enum(['data_stream_configuration', 'default_global_retention', 'max_global_retention', 'default_failures_retention']).meta({ id: 'IndicesRetentionSource' })
+export type IndicesRetentionSource = z.infer<typeof IndicesRetentionSource>
+
 export const IndicesDownsamplingRound = z.object({
   after: Duration.describe('The duration since rollover when this downsampling round should execute'),
   fixed_interval: DurationLarge.describe('The downsample interval.')
@@ -7971,6 +8007,8 @@ export type IndicesSamplingMethod = z.infer<typeof IndicesSamplingMethod>
 /** Data stream lifecycle denotes that a data stream is managed by the data stream lifecycle and contains the configuration. */
 export const IndicesDataStreamLifecycle = z.object({
   data_retention: Duration.describe('If defined, every document added to this data stream will be stored at least for this time frame. Any time after this duration the document could be deleted. When empty, every document in this data stream will be stored indefinitely.').optional(),
+  effective_retention: Duration.describe('The least amount of time data should be kept by elasticsearch.').optional(),
+  retention_determined_by: IndicesRetentionSource.describe('Configuration source that can influence the retention of a data stream.').optional(),
   downsampling: z.array(IndicesDownsamplingRound).describe('The list of downsampling rounds to execute as part of this downsampling configuration').optional(),
   downsampling_method: IndicesSamplingMethod.describe('The method used to downsample the data. There are two options `aggregate` and `last_value`. It requires `downsampling` to be defined. Defaults to `aggregate`.').optional(),
   enabled: z.boolean().describe('If defined, it turns data stream lifecycle on/off (`true`/`false`) for this data stream. A data stream lifecycle that\'s disabled (enabled: `false`) will have no effect on the data stream.').optional(),

--- a/packages/es-schemas/src/cluster_put_settings.ts
+++ b/packages/es-schemas/src/cluster_put_settings.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/cluster_remote_info.ts
+++ b/packages/es-schemas/src/cluster_remote_info.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/cluster_reroute.ts
+++ b/packages/es-schemas/src/cluster_reroute.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/cluster_state.ts
+++ b/packages/es-schemas/src/cluster_state.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/cluster_stats.ts
+++ b/packages/es-schemas/src/cluster_stats.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -294,6 +295,12 @@ export const ClusterStatsFieldTypes = z.object({
 }).meta({ id: 'ClusterStatsFieldTypes' })
 export type ClusterStatsFieldTypes = z.infer<typeof ClusterStatsFieldTypes>
 
+export const ClusterStatsMultipleSynonymGraphFilter = z.object({
+  analyzer_count: integer.describe('Number of analyzers across the cluster whose filter chain contains more than one synonym_graph filter.').optional(),
+  index_count: integer.describe('Number of indices that contain at least one analyzer with more than one synonym_graph filter.').optional()
+}).meta({ id: 'ClusterStatsMultipleSynonymGraphFilter' })
+export type ClusterStatsMultipleSynonymGraphFilter = z.infer<typeof ClusterStatsMultipleSynonymGraphFilter>
+
 export const ClusterStatsSynonymsStats = z.object({
   count: integer,
   index_count: integer
@@ -307,6 +314,7 @@ export const ClusterStatsCharFilterTypes = z.object({
   built_in_filters: z.array(ClusterStatsFieldTypes).describe('Contains statistics about built-in token filters used in selected nodes.'),
   built_in_tokenizers: z.array(ClusterStatsFieldTypes).describe('Contains statistics about built-in tokenizers used in selected nodes.'),
   char_filter_types: z.array(ClusterStatsFieldTypes).describe('Contains statistics about character filter types used in selected nodes.'),
+  multiple_synonym_graph_filters: ClusterStatsMultipleSynonymGraphFilter.optional(),
   filter_types: z.array(ClusterStatsFieldTypes).describe('Contains statistics about token filter types used in selected nodes.'),
   tokenizer_types: z.array(ClusterStatsFieldTypes).describe('Contains statistics about tokenizer types used in selected nodes.'),
   synonyms: z.record(Name, ClusterStatsSynonymsStats).describe('Contains statistics about synonyms types used in selected nodes.')

--- a/packages/es-schemas/src/connector_check_in.ts
+++ b/packages/es-schemas/src/connector_check_in.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/connector_delete.ts
+++ b/packages/es-schemas/src/connector_delete.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/connector_get.ts
+++ b/packages/es-schemas/src/connector_get.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/connector_last_sync.ts
+++ b/packages/es-schemas/src/connector_last_sync.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/connector_list.ts
+++ b/packages/es-schemas/src/connector_list.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/connector_post.ts
+++ b/packages/es-schemas/src/connector_post.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/connector_put.ts
+++ b/packages/es-schemas/src/connector_put.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/connector_secret_delete.ts
+++ b/packages/es-schemas/src/connector_secret_delete.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/connector_secret_get.ts
+++ b/packages/es-schemas/src/connector_secret_get.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/connector_secret_post.ts
+++ b/packages/es-schemas/src/connector_secret_post.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/connector_secret_put.ts
+++ b/packages/es-schemas/src/connector_secret_put.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/connector_sync_job_cancel.ts
+++ b/packages/es-schemas/src/connector_sync_job_cancel.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/connector_sync_job_check_in.ts
+++ b/packages/es-schemas/src/connector_sync_job_check_in.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/connector_sync_job_claim.ts
+++ b/packages/es-schemas/src/connector_sync_job_claim.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/connector_sync_job_delete.ts
+++ b/packages/es-schemas/src/connector_sync_job_delete.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/connector_sync_job_error.ts
+++ b/packages/es-schemas/src/connector_sync_job_error.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/connector_sync_job_get.ts
+++ b/packages/es-schemas/src/connector_sync_job_get.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/connector_sync_job_list.ts
+++ b/packages/es-schemas/src/connector_sync_job_list.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/connector_sync_job_post.ts
+++ b/packages/es-schemas/src/connector_sync_job_post.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/connector_sync_job_update_stats.ts
+++ b/packages/es-schemas/src/connector_sync_job_update_stats.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/connector_update_active_filtering.ts
+++ b/packages/es-schemas/src/connector_update_active_filtering.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/connector_update_api_key_id.ts
+++ b/packages/es-schemas/src/connector_update_api_key_id.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/connector_update_configuration.ts
+++ b/packages/es-schemas/src/connector_update_configuration.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/connector_update_error.ts
+++ b/packages/es-schemas/src/connector_update_error.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/connector_update_features.ts
+++ b/packages/es-schemas/src/connector_update_features.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/connector_update_filtering.ts
+++ b/packages/es-schemas/src/connector_update_filtering.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/connector_update_filtering_validation.ts
+++ b/packages/es-schemas/src/connector_update_filtering_validation.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/connector_update_index_name.ts
+++ b/packages/es-schemas/src/connector_update_index_name.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/connector_update_name.ts
+++ b/packages/es-schemas/src/connector_update_name.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/connector_update_native.ts
+++ b/packages/es-schemas/src/connector_update_native.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/connector_update_pipeline.ts
+++ b/packages/es-schemas/src/connector_update_pipeline.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/connector_update_scheduling.ts
+++ b/packages/es-schemas/src/connector_update_scheduling.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/connector_update_service_type.ts
+++ b/packages/es-schemas/src/connector_update_service_type.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/connector_update_status.ts
+++ b/packages/es-schemas/src/connector_update_status.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/count.ts
+++ b/packages/es-schemas/src/count.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1268,7 +1269,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1289,7 +1290,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1305,7 +1306,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1420,7 +1421,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1497,7 +1498,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1519,7 +1520,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1546,7 +1547,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1578,7 +1579,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1610,12 +1611,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1653,7 +1654,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1750,7 +1751,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1769,7 +1770,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1783,7 +1784,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1824,7 +1825,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -2023,7 +2024,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -2038,7 +2039,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -2062,10 +2063,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -2086,7 +2087,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -2122,7 +2123,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -2138,7 +2139,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -2152,7 +2153,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -2165,7 +2166,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2195,7 +2196,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2305,7 +2306,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -2317,13 +2319,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -2358,6 +2361,36 @@ export type SearchTrackHits = z.infer<typeof SearchTrackHits>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2372,7 +2405,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2439,7 +2472,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2794,12 +2827,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2852,7 +2885,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2866,7 +2899,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2907,7 +2940,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -3085,7 +3118,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3605,7 +3638,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3621,7 +3654,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3784,7 +3817,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3860,7 +3893,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3901,7 +3934,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined

--- a/packages/es-schemas/src/create.ts
+++ b/packages/es-schemas/src/create.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/dangling_indices_delete_dangling_index.ts
+++ b/packages/es-schemas/src/dangling_indices_delete_dangling_index.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/dangling_indices_import_dangling_index.ts
+++ b/packages/es-schemas/src/dangling_indices_import_dangling_index.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/dangling_indices_list_dangling_indices.ts
+++ b/packages/es-schemas/src/dangling_indices_list_dangling_indices.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/delete.ts
+++ b/packages/es-schemas/src/delete.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/delete_by_query.ts
+++ b/packages/es-schemas/src/delete_by_query.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -307,7 +308,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -318,11 +319,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -338,7 +339,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -351,7 +352,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -365,7 +366,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -411,7 +412,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -427,7 +428,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -441,7 +442,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -506,7 +507,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -606,7 +607,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -621,7 +622,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -633,7 +634,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -706,7 +707,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -724,7 +725,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -743,7 +744,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -774,7 +775,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -858,7 +859,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -941,7 +942,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -993,7 +994,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -1009,7 +1010,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1081,7 +1082,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1096,7 +1097,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1202,7 +1203,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1287,7 +1288,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1308,7 +1309,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1324,7 +1325,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1439,7 +1440,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1538,7 +1539,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1565,7 +1566,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1597,7 +1598,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1629,12 +1630,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1672,7 +1673,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1769,7 +1770,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1788,7 +1789,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1802,7 +1803,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1843,7 +1844,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -2042,7 +2043,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -2057,7 +2058,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -2081,10 +2082,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -2105,7 +2106,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -2141,7 +2142,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -2157,7 +2158,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -2171,7 +2172,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -2184,7 +2185,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2214,7 +2215,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2324,7 +2325,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -2336,13 +2338,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -2377,6 +2380,36 @@ export type SearchTrackHits = z.infer<typeof SearchTrackHits>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2391,7 +2424,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2458,7 +2491,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2813,12 +2846,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2871,7 +2904,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2885,7 +2918,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2926,7 +2959,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -3104,7 +3137,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3624,7 +3657,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3640,7 +3673,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3803,7 +3836,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3879,7 +3912,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3920,7 +3953,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined

--- a/packages/es-schemas/src/delete_by_query_rethrottle.ts
+++ b/packages/es-schemas/src/delete_by_query_rethrottle.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/delete_script.ts
+++ b/packages/es-schemas/src/delete_script.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/enrich_delete_policy.ts
+++ b/packages/es-schemas/src/enrich_delete_policy.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/enrich_execute_policy.ts
+++ b/packages/es-schemas/src/enrich_execute_policy.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/enrich_get_policy.ts
+++ b/packages/es-schemas/src/enrich_get_policy.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),

--- a/packages/es-schemas/src/enrich_put_policy.ts
+++ b/packages/es-schemas/src/enrich_put_policy.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),

--- a/packages/es-schemas/src/enrich_stats.ts
+++ b/packages/es-schemas/src/enrich_stats.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/eql_delete.ts
+++ b/packages/es-schemas/src/eql_delete.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/eql_get.ts
+++ b/packages/es-schemas/src/eql_get.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/eql_get_status.ts
+++ b/packages/es-schemas/src/eql_get_status.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/eql_search.ts
+++ b/packages/es-schemas/src/eql_search.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4082,7 +4115,7 @@ export const EqlSearchRequest = z.object({
   allow_partial_search_results: z.boolean().describe('Allow query execution also in case of shard failures. If true, the query will keep running and will return results based on the available shards. For sequences, the behavior can be further refined using allow_partial_sequence_results').optional().meta({ found_in: 'body' }),
   allow_partial_sequence_results: z.boolean().describe('This flag applies only to sequences and has effect only if allow_partial_search_results=true. If true, the sequence query will return results based on the available shards, ignoring the others. If false, the sequence query will return successfully, but will always have empty results.').optional().meta({ found_in: 'body' }),
   size: uint.describe('For basic queries, the maximum number of matching events to return. Defaults to 10').optional().meta({ found_in: 'body' }),
-  fields: z.union([QueryDslFieldAndFormat, z.array(QueryDslFieldAndFormat)]).describe('Array of wildcard (*) patterns. The response returns values for field names matching these patterns in the fields property of each hit.').optional().meta({ found_in: 'body' }),
+  fields: z.union([z.union([QueryDslFieldAndFormat, Field]), z.array(z.union([QueryDslFieldAndFormat, Field]))]).describe('Array of wildcard (*) patterns. The response returns values for field names matching these patterns in the fields property of each hit.').optional().meta({ found_in: 'body' }),
   result_position: EqlSearchResultPosition.optional().meta({ found_in: 'body' }),
   runtime_mappings: z.lazy(() => MappingRuntimeFields).optional().meta({ found_in: 'body' }),
   max_samples_per_key: integer.describe('By default, the response of a sample query contains up to `10` samples, with one sample per unique set of join keys. Use the `size` parameter to get a smaller or larger set of samples. To retrieve more than one sample per set of join keys, use the `max_samples_per_key` parameter. Pipes are not supported for sample queries.').optional().meta({ found_in: 'body' })

--- a/packages/es-schemas/src/esql_async_query.ts
+++ b/packages/es-schemas/src/esql_async_query.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),

--- a/packages/es-schemas/src/esql_async_query_delete.ts
+++ b/packages/es-schemas/src/esql_async_query_delete.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/esql_async_query_get.ts
+++ b/packages/es-schemas/src/esql_async_query_get.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/esql_async_query_stop.ts
+++ b/packages/es-schemas/src/esql_async_query_stop.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/esql_delete_view.ts
+++ b/packages/es-schemas/src/esql_delete_view.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -24,6 +25,9 @@ export type AcknowledgedResponseBase = z.infer<typeof AcknowledgedResponseBase>
 export const Id = z.string().meta({ id: 'Id' })
 export type Id = z.infer<typeof Id>
 
+export const Ids = z.union([Id, z.array(Id)]).meta({ id: 'Ids' })
+export type Ids = z.infer<typeof Ids>
+
 export const RequestBase = z.object({
 }).meta({ id: 'RequestBase' })
 export type RequestBase = z.infer<typeof RequestBase>
@@ -35,7 +39,7 @@ export type RequestBase = z.infer<typeof RequestBase>
  */
 export const EsqlDeleteViewRequest = z.object({
   ...RequestBase.shape,
-  name: Id.describe('The view name to remove.').meta({ found_in: 'path' })
+  name: Ids.describe('The view name to remove.').meta({ found_in: 'path' })
 }).meta({ id: 'EsqlDeleteViewRequest' })
 export type EsqlDeleteViewRequest = z.infer<typeof EsqlDeleteViewRequest>
 

--- a/packages/es-schemas/src/esql_get_query.ts
+++ b/packages/es-schemas/src/esql_get_query.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/esql_get_view.ts
+++ b/packages/es-schemas/src/esql_get_view.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/esql_list_queries.ts
+++ b/packages/es-schemas/src/esql_list_queries.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/esql_put_view.ts
+++ b/packages/es-schemas/src/esql_put_view.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/esql_query.ts
+++ b/packages/es-schemas/src/esql_query.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),

--- a/packages/es-schemas/src/exists.ts
+++ b/packages/es-schemas/src/exists.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/exists_source.ts
+++ b/packages/es-schemas/src/exists_source.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/explain.ts
+++ b/packages/es-schemas/src/explain.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -297,7 +298,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -308,11 +309,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -328,7 +329,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -341,7 +342,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -355,7 +356,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -401,7 +402,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -417,7 +418,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -431,7 +432,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -496,7 +497,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -596,7 +597,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -611,7 +612,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -623,7 +624,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -696,7 +697,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -714,7 +715,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -733,7 +734,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -771,7 +772,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -855,7 +856,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -938,7 +939,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -1006,7 +1007,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1078,7 +1079,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1093,7 +1094,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1199,7 +1200,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1281,7 +1282,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1302,7 +1303,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1318,7 +1319,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1433,7 +1434,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1510,7 +1511,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1532,7 +1533,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1559,7 +1560,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1591,7 +1592,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1623,12 +1624,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1666,7 +1667,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1763,7 +1764,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1782,7 +1783,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1796,7 +1797,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1837,7 +1838,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -2036,7 +2037,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -2051,7 +2052,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -2075,10 +2076,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -2099,7 +2100,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -2135,7 +2136,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -2151,7 +2152,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -2165,7 +2166,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -2178,7 +2179,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2208,7 +2209,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2318,7 +2319,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -2330,13 +2332,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -2371,6 +2374,36 @@ export type SearchTrackHits = z.infer<typeof SearchTrackHits>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2385,7 +2418,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2452,7 +2485,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2804,12 +2837,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2862,7 +2895,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2876,7 +2909,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2917,7 +2950,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -3095,7 +3128,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3615,7 +3648,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3631,7 +3664,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3794,7 +3827,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3870,7 +3903,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3911,7 +3944,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined

--- a/packages/es-schemas/src/features_get_features.ts
+++ b/packages/es-schemas/src/features_get_features.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/features_reset_features.ts
+++ b/packages/es-schemas/src/features_reset_features.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/field_caps.ts
+++ b/packages/es-schemas/src/field_caps.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -299,7 +300,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -310,11 +311,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -330,7 +331,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -343,7 +344,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -357,7 +358,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -403,7 +404,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -419,7 +420,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -433,7 +434,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -498,7 +499,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -598,7 +599,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -613,7 +614,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -625,7 +626,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -698,7 +699,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -716,7 +717,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -735,7 +736,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -773,7 +774,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -857,7 +858,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -940,7 +941,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -992,7 +993,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -1008,7 +1009,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1080,7 +1081,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1095,7 +1096,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1201,7 +1202,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1283,7 +1284,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1304,7 +1305,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1320,7 +1321,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1435,7 +1436,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1512,7 +1513,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1534,7 +1535,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1561,7 +1562,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1593,7 +1594,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1625,12 +1626,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1668,7 +1669,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1765,7 +1766,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1784,7 +1785,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1798,7 +1799,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1839,7 +1840,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -2038,7 +2039,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -2053,7 +2054,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -2077,10 +2078,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -2101,7 +2102,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -2137,7 +2138,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -2153,7 +2154,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -2167,7 +2168,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -2180,7 +2181,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2210,7 +2211,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2320,7 +2321,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -2332,13 +2334,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -2373,6 +2376,36 @@ export type SearchTrackHits = z.infer<typeof SearchTrackHits>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2387,7 +2420,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2454,7 +2487,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2809,12 +2842,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2867,7 +2900,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2881,7 +2914,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2922,7 +2955,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -3100,7 +3133,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3624,7 +3657,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3640,7 +3673,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3803,7 +3836,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3879,7 +3912,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3920,7 +3953,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined

--- a/packages/es-schemas/src/fleet_delete_secret.ts
+++ b/packages/es-schemas/src/fleet_delete_secret.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/fleet_get_secret.ts
+++ b/packages/es-schemas/src/fleet_get_secret.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/fleet_global_checkpoints.ts
+++ b/packages/es-schemas/src/fleet_global_checkpoints.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/fleet_msearch.ts
+++ b/packages/es-schemas/src/fleet_msearch.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -572,168 +573,6 @@ export const SearchShardProfile = z.object({
 }).meta({ id: 'SearchShardProfile' })
 export type SearchShardProfile = z.infer<typeof SearchShardProfile>
 
-export const SearchProfile = z.object({
-  shards: z.array(SearchShardProfile)
-}).meta({ id: 'SearchProfile' })
-export type SearchProfile = z.infer<typeof SearchProfile>
-
-export const ScrollId = z.string().meta({ id: 'ScrollId' })
-export type ScrollId = z.infer<typeof ScrollId>
-
-/**
- * The suggestion name as returned from the server. Depending whether typed_keys is specified this could come back
- * in the form of `name#type` instead of simply `name`
- */
-export const SuggestionName = z.string().meta({ id: 'SuggestionName' })
-export type SuggestionName = z.infer<typeof SuggestionName>
-
-export const SearchSuggestBase = z.object({
-  length: integer,
-  offset: integer,
-  text: z.string()
-}).meta({ id: 'SearchSuggestBase' })
-export type SearchSuggestBase = z.infer<typeof SearchSuggestBase>
-
-export const LatLonGeoLocation = z.object({
-  lat: double.describe('Latitude'),
-  lon: double.describe('Longitude')
-}).meta({ id: 'LatLonGeoLocation' })
-export type LatLonGeoLocation = z.infer<typeof LatLonGeoLocation>
-
-export const GeoHash = z.string().meta({ id: 'GeoHash' })
-export type GeoHash = z.infer<typeof GeoHash>
-
-export const GeoHashLocation = z.object({
-  geohash: GeoHash
-}).meta({ id: 'GeoHashLocation' })
-export type GeoHashLocation = z.infer<typeof GeoHashLocation>
-
-/**
- * A latitude/longitude as a 2 dimensional point. It can be represented in various ways:
- * - as a `{lat, long}` object
- * - as a geo hash value
- * - as a `[lon, lat]` array
- * - as a string in `"<lat>, <lon>"` or WKT point formats
- */
-export const GeoLocation = z.union([LatLonGeoLocation, GeoHashLocation, z.array(double), z.string()]).meta({ id: 'GeoLocation' })
-export type GeoLocation = z.infer<typeof GeoLocation>
-
-/** Text or location that we want similar documents for or a lookup to a document's field for the text. */
-export const SearchContext = z.union([z.string(), GeoLocation]).meta({ id: 'SearchContext' })
-export type SearchContext = z.infer<typeof SearchContext>
-
-export const SearchCompletionSuggestOption = z.object({
-  collate_match: z.boolean().optional(),
-  contexts: z.record(z.string(), z.array(SearchContext)).optional(),
-  fields: z.record(z.string(), z.any()).optional(),
-  _id: z.string().optional(),
-  _index: IndexName.optional(),
-  _routing: z.string().optional(),
-  _score: double.optional(),
-  _source: z.any().optional(),
-  text: z.string(),
-  score: double.optional()
-}).meta({ id: 'SearchCompletionSuggestOption' })
-export type SearchCompletionSuggestOption = z.infer<typeof SearchCompletionSuggestOption>
-
-export const SearchCompletionSuggest = z.object({
-  ...SearchSuggestBase.shape,
-  options: z.union([SearchCompletionSuggestOption, z.array(SearchCompletionSuggestOption)])
-}).meta({ id: 'SearchCompletionSuggest' })
-export type SearchCompletionSuggest = z.infer<typeof SearchCompletionSuggest>
-
-export const SearchPhraseSuggestOption = z.object({
-  text: z.string(),
-  score: double,
-  highlighted: z.string().optional(),
-  collate_match: z.boolean().optional()
-}).meta({ id: 'SearchPhraseSuggestOption' })
-export type SearchPhraseSuggestOption = z.infer<typeof SearchPhraseSuggestOption>
-
-export const SearchPhraseSuggest = z.object({
-  ...SearchSuggestBase.shape,
-  options: z.union([SearchPhraseSuggestOption, z.array(SearchPhraseSuggestOption)])
-}).meta({ id: 'SearchPhraseSuggest' })
-export type SearchPhraseSuggest = z.infer<typeof SearchPhraseSuggest>
-
-export const SearchTermSuggestOption = z.object({
-  text: z.string(),
-  score: double,
-  freq: long,
-  highlighted: z.string().optional(),
-  collate_match: z.boolean().optional()
-}).meta({ id: 'SearchTermSuggestOption' })
-export type SearchTermSuggestOption = z.infer<typeof SearchTermSuggestOption>
-
-export const SearchTermSuggest = z.object({
-  ...SearchSuggestBase.shape,
-  options: z.union([SearchTermSuggestOption, z.array(SearchTermSuggestOption)])
-}).meta({ id: 'SearchTermSuggest' })
-export type SearchTermSuggest = z.infer<typeof SearchTermSuggest>
-
-export const SearchSuggest = z.union([SearchCompletionSuggest, SearchPhraseSuggest, SearchTermSuggest]).meta({ id: 'SearchSuggest' })
-export type SearchSuggest = z.infer<typeof SearchSuggest>
-
-export const SearchResponseBody = z.object({
-  took: long.describe('The number of milliseconds it took Elasticsearch to run the request. This value is calculated by measuring the time elapsed between receipt of a request on the coordinating node and the time at which the coordinating node is ready to send the response. It includes: * Communication time between the coordinating node and data nodes * Time the request spends in the search thread pool, queued for execution * Actual run time It does not include: * Time needed to send the request to Elasticsearch * Time needed to serialize the JSON response * Time needed to send the response to a client'),
-  timed_out: z.boolean().describe('If `true`, the request timed out before completion; returned results may be partial or empty.'),
-  _shards: ShardStatistics.describe('A count of shards used for the request.'),
-  hits: z.lazy(() => SearchHitsMetadata).describe('The returned documents and metadata.'),
-  aggregations: z.any().optional(),
-  _clusters: ClusterStatistics.optional(),
-  fields: z.record(z.string(), z.any()).optional(),
-  max_score: double.optional(),
-  num_reduce_phases: long.optional(),
-  profile: SearchProfile.optional(),
-  pit_id: Id.optional(),
-  _scroll_id: ScrollId.describe('The identifier for the search and its search context. You can use this scroll ID with the scroll API to retrieve the next batch of search results for the request. This property is returned only if the `scroll` query parameter is specified in the request.').optional(),
-  suggest: z.record(SuggestionName, z.array(SearchSuggest)).optional(),
-  terminated_early: z.boolean().optional()
-}).meta({ id: 'SearchResponseBody' })
-export type SearchResponseBody = z.infer<typeof SearchResponseBody>
-
-export const MsearchMultiSearchItem = z.object({
-  ...SearchResponseBody.shape,
-  status: integer.optional()
-}).meta({ id: 'MsearchMultiSearchItem' })
-export type MsearchMultiSearchItem = z.infer<typeof MsearchMultiSearchItem>
-
-export const ExpandWildcard = z.enum(['all', 'open', 'closed', 'hidden', 'none']).meta({ id: 'ExpandWildcard' })
-export type ExpandWildcard = z.infer<typeof ExpandWildcard>
-
-export const ExpandWildcards = z.union([ExpandWildcard, z.array(ExpandWildcard)]).meta({ id: 'ExpandWildcards' })
-export type ExpandWildcards = z.infer<typeof ExpandWildcards>
-
-export const Indices = z.union([IndexName, z.array(IndexName)]).meta({ id: 'Indices' })
-export type Indices = z.infer<typeof Indices>
-
-export const ProjectRouting = z.string().meta({ id: 'ProjectRouting' })
-export type ProjectRouting = z.infer<typeof ProjectRouting>
-
-/** Only to be used in query and path parameters, as the array form is actually a csv */
-export const Routing = z.union([z.string(), z.array(z.string())]).meta({ id: 'Routing' })
-export type Routing = z.infer<typeof Routing>
-
-export const SearchType = z.enum(['query_then_fetch', 'dfs_query_then_fetch']).meta({ id: 'SearchType' })
-export type SearchType = z.infer<typeof SearchType>
-
-/** Contains parameters used to limit or change the subsequent search body request. */
-export const MsearchMultisearchHeader = z.object({
-  allow_no_indices: z.boolean().describe('A setting that does two separate checks on the index expression. If `false`, the request returns an error (1) if any wildcard expression (including `_all` and `*`) resolves to zero matching indices or (2) if the complete set of resolved indices, aliases or data streams is empty after all expressions are evaluated. If `true`, index expressions that resolve to no indices are allowed and the request returns an empty result.').optional(),
-  expand_wildcards: ExpandWildcards.optional(),
-  ignore_unavailable: z.boolean().describe('If `false`, the request returns an error if it targets a concrete (non-wildcarded) index, alias, or data stream that is missing, closed, or otherwise unavailable. If `true`, unavailable concrete targets are silently ignored.').optional(),
-  index: Indices.optional(),
-  preference: z.string().optional(),
-  project_routing: ProjectRouting.optional(),
-  request_cache: z.boolean().optional(),
-  routing: Routing.optional(),
-  search_type: SearchType.optional(),
-  ccs_minimize_roundtrips: z.boolean().optional(),
-  allow_partial_search_results: z.boolean().optional(),
-  ignore_throttled: z.boolean().optional()
-}).meta({ id: 'MsearchMultisearchHeader' })
-export type MsearchMultisearchHeader = z.infer<typeof MsearchMultisearchHeader>
-
 export const Metadata = z.record(z.string(), z.any()).meta({ id: 'Metadata' })
 export type Metadata = z.infer<typeof Metadata>
 
@@ -959,7 +798,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -1059,6 +898,9 @@ export type QueryDslGeoDistanceQuery = z.infer<typeof QueryDslGeoDistanceQuery>
 /** A map tile reference, represented as `{zoom}/{x}/{y}` */
 export const GeoTile = z.string().meta({ id: 'GeoTile' })
 export type GeoTile = z.infer<typeof GeoTile>
+
+export const GeoHash = z.string().meta({ id: 'GeoHash' })
+export type GeoHash = z.infer<typeof GeoHash>
 
 /** A map hex cell (H3) reference */
 export const GeoHexCell = z.string().meta({ id: 'GeoHexCell' })
@@ -1287,7 +1129,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1350,7 +1192,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -1389,7 +1231,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface SearchInnerHitsShape {
@@ -1403,7 +1245,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -1415,13 +1258,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -1489,7 +1333,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -1621,6 +1465,36 @@ export type QueryDslIntervalsQuery = z.infer<typeof QueryDslIntervalsQuery>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -1635,7 +1509,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -1736,6 +1610,10 @@ export const QueryDslMatchPhrasePrefixQuery = z.object({
   zero_terms_query: QueryDslZeroTermsQuery.describe('Indicates whether no documents are returned if the analyzer removes all tokens, such as when using a `stop` filter.').optional()
 }).meta({ id: 'QueryDslMatchPhrasePrefixQuery' })
 export type QueryDslMatchPhrasePrefixQuery = z.infer<typeof QueryDslMatchPhrasePrefixQuery>
+
+/** Only to be used in query and path parameters, as the array form is actually a csv */
+export const Routing = z.union([z.string(), z.array(z.string())]).meta({ id: 'Routing' })
+export type Routing = z.infer<typeof Routing>
 
 export const VersionType = z.enum(['internal', 'external', 'external_gte']).meta({ id: 'VersionType' })
 export type VersionType = z.infer<typeof VersionType>
@@ -2036,7 +1914,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -2052,7 +1930,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -2215,7 +2093,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -2291,7 +2169,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -2332,7 +2210,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -2429,7 +2307,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -2440,11 +2318,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -2460,7 +2338,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -2473,7 +2351,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -2487,7 +2365,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -2533,7 +2411,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -2549,7 +2427,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -2563,7 +2441,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -2638,7 +2516,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -2653,7 +2531,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -2665,7 +2543,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -2731,7 +2609,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -2749,7 +2627,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -2768,7 +2646,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -2799,7 +2677,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -2817,6 +2695,27 @@ export const CoordsGeoBounds = z.object({
   right: double
 }).meta({ id: 'CoordsGeoBounds' })
 export type CoordsGeoBounds = z.infer<typeof CoordsGeoBounds>
+
+export const LatLonGeoLocation = z.object({
+  lat: double.describe('Latitude'),
+  lon: double.describe('Longitude')
+}).meta({ id: 'LatLonGeoLocation' })
+export type LatLonGeoLocation = z.infer<typeof LatLonGeoLocation>
+
+export const GeoHashLocation = z.object({
+  geohash: GeoHash
+}).meta({ id: 'GeoHashLocation' })
+export type GeoHashLocation = z.infer<typeof GeoHashLocation>
+
+/**
+ * A latitude/longitude as a 2 dimensional point. It can be represented in various ways:
+ * - as a `{lat, long}` object
+ * - as a geo hash value
+ * - as a `[lon, lat]` array
+ * - as a string in `"<lat>, <lon>"` or WKT point formats
+ */
+export const GeoLocation = z.union([LatLonGeoLocation, GeoHashLocation, z.array(double), z.string()]).meta({ id: 'GeoLocation' })
+export type GeoLocation = z.infer<typeof GeoLocation>
 
 export const TopLeftBottomRightGeoBounds = z.object({
   top_left: GeoLocation,
@@ -2859,7 +2758,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -2942,7 +2841,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -2994,7 +2893,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -3010,7 +2909,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -3082,7 +2981,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -3097,7 +2996,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -3203,7 +3102,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -3282,7 +3181,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -3303,7 +3202,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -3319,7 +3218,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -3434,7 +3333,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -3511,7 +3410,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -3533,7 +3432,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -3560,7 +3459,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -3592,7 +3491,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -3624,12 +3523,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -3667,7 +3566,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -3764,7 +3663,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -3783,7 +3682,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -3797,7 +3696,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -3838,7 +3737,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -3875,10 +3774,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -3899,7 +3798,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -3935,7 +3834,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -3951,7 +3850,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -3965,7 +3864,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -3978,7 +3877,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -4008,7 +3907,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -4173,7 +4072,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -4522,12 +4421,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -4580,7 +4479,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -4594,7 +4493,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -4607,6 +4506,151 @@ export const SearchSearchRequestBody = z.object({
   stats: z.array(z.string()).describe('The stats groups to associate with the search. Each group maintains a statistics aggregation for its associated searches. You can retrieve these stats using the indices stats API.').optional()
 }).meta({ id: 'SearchSearchRequestBody' })
 export type SearchSearchRequestBody = z.infer<typeof SearchSearchRequestBody>
+
+/**
+ * Coordinator snapshot of the original search request, serialized under `profile.request` when profiling is enabled.
+ * Introduced in Elasticsearch 9.5; omitted when the cluster contains mixed-version nodes that do not serialize this metadata.
+ */
+export const SearchSearchRequestCoordinatorMetadata = z.object({
+  source: z.lazy(() => SearchSearchRequestBody).describe('Original query source from the search request (`SearchSourceBuilder` as JSON).').optional(),
+  indices: z.array(IndexName).describe('Target index expressions from the request (before index resolution).').optional()
+}).meta({ id: 'SearchSearchRequestCoordinatorMetadata' })
+export type SearchSearchRequestCoordinatorMetadata = z.infer<typeof SearchSearchRequestCoordinatorMetadata>
+
+export const SearchProfile = z.object({
+  shards: z.array(SearchShardProfile),
+  request: SearchSearchRequestCoordinatorMetadata.describe('When profiling is enabled, the original query source and target indices from the coordinating request.').optional()
+}).meta({ id: 'SearchProfile' })
+export type SearchProfile = z.infer<typeof SearchProfile>
+
+export const ScrollId = z.string().meta({ id: 'ScrollId' })
+export type ScrollId = z.infer<typeof ScrollId>
+
+/**
+ * The suggestion name as returned from the server. Depending whether typed_keys is specified this could come back
+ * in the form of `name#type` instead of simply `name`
+ */
+export const SuggestionName = z.string().meta({ id: 'SuggestionName' })
+export type SuggestionName = z.infer<typeof SuggestionName>
+
+export const SearchSuggestBase = z.object({
+  length: integer,
+  offset: integer,
+  text: z.string()
+}).meta({ id: 'SearchSuggestBase' })
+export type SearchSuggestBase = z.infer<typeof SearchSuggestBase>
+
+/** Text or location that we want similar documents for or a lookup to a document's field for the text. */
+export const SearchContext = z.union([z.string(), GeoLocation]).meta({ id: 'SearchContext' })
+export type SearchContext = z.infer<typeof SearchContext>
+
+export const SearchCompletionSuggestOption = z.object({
+  collate_match: z.boolean().optional(),
+  contexts: z.record(z.string(), z.array(SearchContext)).optional(),
+  fields: z.record(z.string(), z.any()).optional(),
+  _id: z.string().optional(),
+  _index: IndexName.optional(),
+  _routing: z.string().optional(),
+  _score: double.optional(),
+  _source: z.any().optional(),
+  text: z.string(),
+  score: double.optional()
+}).meta({ id: 'SearchCompletionSuggestOption' })
+export type SearchCompletionSuggestOption = z.infer<typeof SearchCompletionSuggestOption>
+
+export const SearchCompletionSuggest = z.object({
+  ...SearchSuggestBase.shape,
+  options: z.union([SearchCompletionSuggestOption, z.array(SearchCompletionSuggestOption)])
+}).meta({ id: 'SearchCompletionSuggest' })
+export type SearchCompletionSuggest = z.infer<typeof SearchCompletionSuggest>
+
+export const SearchPhraseSuggestOption = z.object({
+  text: z.string(),
+  score: double,
+  highlighted: z.string().optional(),
+  collate_match: z.boolean().optional()
+}).meta({ id: 'SearchPhraseSuggestOption' })
+export type SearchPhraseSuggestOption = z.infer<typeof SearchPhraseSuggestOption>
+
+export const SearchPhraseSuggest = z.object({
+  ...SearchSuggestBase.shape,
+  options: z.union([SearchPhraseSuggestOption, z.array(SearchPhraseSuggestOption)])
+}).meta({ id: 'SearchPhraseSuggest' })
+export type SearchPhraseSuggest = z.infer<typeof SearchPhraseSuggest>
+
+export const SearchTermSuggestOption = z.object({
+  text: z.string(),
+  score: double,
+  freq: long,
+  highlighted: z.string().optional(),
+  collate_match: z.boolean().optional()
+}).meta({ id: 'SearchTermSuggestOption' })
+export type SearchTermSuggestOption = z.infer<typeof SearchTermSuggestOption>
+
+export const SearchTermSuggest = z.object({
+  ...SearchSuggestBase.shape,
+  options: z.union([SearchTermSuggestOption, z.array(SearchTermSuggestOption)])
+}).meta({ id: 'SearchTermSuggest' })
+export type SearchTermSuggest = z.infer<typeof SearchTermSuggest>
+
+export const SearchSuggest = z.union([SearchCompletionSuggest, SearchPhraseSuggest, SearchTermSuggest]).meta({ id: 'SearchSuggest' })
+export type SearchSuggest = z.infer<typeof SearchSuggest>
+
+export const SearchResponseBody = z.object({
+  took: long.describe('The number of milliseconds it took Elasticsearch to run the request. This value is calculated by measuring the time elapsed between receipt of a request on the coordinating node and the time at which the coordinating node is ready to send the response. It includes: * Communication time between the coordinating node and data nodes * Time the request spends in the search thread pool, queued for execution * Actual run time It does not include: * Time needed to send the request to Elasticsearch * Time needed to serialize the JSON response * Time needed to send the response to a client'),
+  timed_out: z.boolean().describe('If `true`, the request timed out before completion; returned results may be partial or empty.'),
+  _shards: ShardStatistics.describe('A count of shards used for the request.'),
+  hits: z.lazy(() => SearchHitsMetadata).describe('The returned documents and metadata.'),
+  aggregations: z.any().optional(),
+  _clusters: ClusterStatistics.optional(),
+  fields: z.record(z.string(), z.any()).optional(),
+  max_score: double.optional(),
+  num_reduce_phases: long.optional(),
+  profile: SearchProfile.optional(),
+  pit_id: Id.optional(),
+  _scroll_id: ScrollId.describe('The identifier for the search and its search context. You can use this scroll ID with the scroll API to retrieve the next batch of search results for the request. This property is returned only if the `scroll` query parameter is specified in the request.').optional(),
+  suggest: z.record(SuggestionName, z.array(SearchSuggest)).optional(),
+  terminated_early: z.boolean().optional()
+}).meta({ id: 'SearchResponseBody' })
+export type SearchResponseBody = z.infer<typeof SearchResponseBody>
+
+export const MsearchMultiSearchItem = z.object({
+  ...SearchResponseBody.shape,
+  status: integer.optional()
+}).meta({ id: 'MsearchMultiSearchItem' })
+export type MsearchMultiSearchItem = z.infer<typeof MsearchMultiSearchItem>
+
+export const ExpandWildcard = z.enum(['all', 'open', 'closed', 'hidden', 'none']).meta({ id: 'ExpandWildcard' })
+export type ExpandWildcard = z.infer<typeof ExpandWildcard>
+
+export const ExpandWildcards = z.union([ExpandWildcard, z.array(ExpandWildcard)]).meta({ id: 'ExpandWildcards' })
+export type ExpandWildcards = z.infer<typeof ExpandWildcards>
+
+export const Indices = z.union([IndexName, z.array(IndexName)]).meta({ id: 'Indices' })
+export type Indices = z.infer<typeof Indices>
+
+export const ProjectRouting = z.string().meta({ id: 'ProjectRouting' })
+export type ProjectRouting = z.infer<typeof ProjectRouting>
+
+export const SearchType = z.enum(['query_then_fetch', 'dfs_query_then_fetch']).meta({ id: 'SearchType' })
+export type SearchType = z.infer<typeof SearchType>
+
+/** Contains parameters used to limit or change the subsequent search body request. */
+export const MsearchMultisearchHeader = z.object({
+  allow_no_indices: z.boolean().describe('A setting that does two separate checks on the index expression. If `false`, the request returns an error (1) if any wildcard expression (including `_all` and `*`) resolves to zero matching indices or (2) if the complete set of resolved indices, aliases or data streams is empty after all expressions are evaluated. If `true`, index expressions that resolve to no indices are allowed and the request returns an empty result.').optional(),
+  expand_wildcards: ExpandWildcards.optional(),
+  ignore_unavailable: z.boolean().describe('If `false`, the request returns an error if it targets a concrete (non-wildcarded) index, alias, or data stream that is missing, closed, or otherwise unavailable. If `true`, unavailable concrete targets are silently ignored.').optional(),
+  index: Indices.optional(),
+  preference: z.string().optional(),
+  project_routing: ProjectRouting.optional(),
+  request_cache: z.boolean().optional(),
+  routing: Routing.optional(),
+  search_type: SearchType.optional(),
+  ccs_minimize_roundtrips: z.boolean().optional(),
+  allow_partial_search_results: z.boolean().optional(),
+  ignore_throttled: z.boolean().optional()
+}).meta({ id: 'MsearchMultisearchHeader' })
+export type MsearchMultisearchHeader = z.infer<typeof MsearchMultisearchHeader>
 
 export const MsearchRequestItem = z.union([MsearchMultisearchHeader, z.lazy(() => SearchSearchRequestBody)]).meta({ id: 'MsearchRequestItem' })
 export type MsearchRequestItem = z.infer<typeof MsearchRequestItem>

--- a/packages/es-schemas/src/fleet_post_secret.ts
+++ b/packages/es-schemas/src/fleet_post_secret.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/fleet_search.ts
+++ b/packages/es-schemas/src/fleet_search.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -636,7 +637,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -647,11 +648,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -667,7 +668,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -680,7 +681,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -694,7 +695,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -740,7 +741,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -756,7 +757,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -770,7 +771,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -835,7 +836,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -935,7 +936,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -950,7 +951,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -962,7 +963,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -1035,7 +1036,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -1053,7 +1054,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -1072,7 +1073,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -1103,7 +1104,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -1163,7 +1164,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -1246,7 +1247,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -1298,7 +1299,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -1314,7 +1315,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1386,7 +1387,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1401,7 +1402,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1507,7 +1508,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1589,7 +1590,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1610,7 +1611,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1626,7 +1627,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1741,7 +1742,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1818,7 +1819,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1840,7 +1841,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1867,7 +1868,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1899,7 +1900,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1931,12 +1932,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1974,7 +1975,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -2071,7 +2072,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -2090,7 +2091,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -2104,7 +2105,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -2145,7 +2146,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -2166,7 +2167,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -2181,7 +2182,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -2205,10 +2206,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -2229,7 +2230,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -2265,7 +2266,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -2281,7 +2282,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -2295,7 +2296,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -2308,7 +2309,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2338,7 +2339,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2449,6 +2450,36 @@ export type SearchTrackHits = z.infer<typeof SearchTrackHits>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2463,7 +2494,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2530,7 +2561,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2885,12 +2916,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2943,7 +2974,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2957,7 +2988,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2998,7 +3029,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -3176,7 +3207,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3700,7 +3731,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3716,7 +3747,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3879,7 +3910,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3955,7 +3986,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3996,7 +4027,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -4237,7 +4268,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -4249,13 +4281,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4445,8 +4478,19 @@ export const SearchShardProfile = z.object({
 }).meta({ id: 'SearchShardProfile' })
 export type SearchShardProfile = z.infer<typeof SearchShardProfile>
 
+/**
+ * Coordinator snapshot of the original search request, serialized under `profile.request` when profiling is enabled.
+ * Introduced in Elasticsearch 9.5; omitted when the cluster contains mixed-version nodes that do not serialize this metadata.
+ */
+export const SearchSearchRequestCoordinatorMetadata = z.object({
+  source: z.lazy(() => SearchSearchRequestBody).describe('Original query source from the search request (`SearchSourceBuilder` as JSON).').optional(),
+  indices: z.array(IndexName).describe('Target index expressions from the request (before index resolution).').optional()
+}).meta({ id: 'SearchSearchRequestCoordinatorMetadata' })
+export type SearchSearchRequestCoordinatorMetadata = z.infer<typeof SearchSearchRequestCoordinatorMetadata>
+
 export const SearchProfile = z.object({
-  shards: z.array(SearchShardProfile)
+  shards: z.array(SearchShardProfile),
+  request: SearchSearchRequestCoordinatorMetadata.describe('When profiling is enabled, the original query source and target indices from the coordinating request.').optional()
 }).meta({ id: 'SearchProfile' })
 export type SearchProfile = z.infer<typeof SearchProfile>
 
@@ -5306,7 +5350,7 @@ export const FleetSearchRequest = z.object({
   highlight: z.lazy(() => SearchHighlight).optional().meta({ found_in: 'body' }),
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If true, the exact number of hits is returned at the cost of some performance. If false, the response does not include the total number of hits matching the query. Defaults to 10,000 hits.').optional().meta({ found_in: 'body' }),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boosts the _score of documents from specified indices.').optional().meta({ found_in: 'body' }),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns doc values for field names matching these patterns in the hits.fields property of the response.').optional().meta({ found_in: 'body' }),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns doc values for field names matching these patterns in the hits.fields property of the response.').optional().meta({ found_in: 'body' }),
   min_score: double.describe('Minimum _score for matching documents. Documents with a lower _score are not included in search results and results collected by aggregations.').optional().meta({ found_in: 'body' }),
   post_filter: z.lazy(() => QueryDslQueryContainer).optional().meta({ found_in: 'body' }),
   profile: z.boolean().optional().meta({ found_in: 'body' }),
@@ -5318,7 +5362,7 @@ export const FleetSearchRequest = z.object({
   slice: SlicedScroll.optional().meta({ found_in: 'body' }),
   sort: z.lazy(() => Sort).optional().meta({ found_in: 'body' }),
   _source: SearchSourceConfig.describe('Indicates which source fields are returned for matching documents. These fields are returned in the hits._source property of the search response.').optional().meta({ found_in: 'body' }),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional().meta({ found_in: 'body' }),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional().meta({ found_in: 'body' }),
   suggest: SearchSuggester.optional().meta({ found_in: 'body' }),
   terminate_after: long.describe('Maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. Defaults to 0, which does not terminate query execution early.').optional().meta({ found_in: 'body' }),
   timeout: z.string().describe('Specifies the period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional().meta({ found_in: 'body' }),

--- a/packages/es-schemas/src/get.ts
+++ b/packages/es-schemas/src/get.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/get_reindex.ts
+++ b/packages/es-schemas/src/get_reindex.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/get_script.ts
+++ b/packages/es-schemas/src/get_script.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -279,7 +280,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -610,7 +611,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -673,7 +674,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -712,7 +713,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface SearchInnerHitsShape {
@@ -726,7 +727,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -738,13 +740,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -812,7 +815,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -944,6 +947,36 @@ export type QueryDslIntervalsQuery = z.infer<typeof QueryDslIntervalsQuery>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -958,7 +991,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -1369,7 +1402,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -1385,7 +1418,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -1552,7 +1585,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -1628,7 +1661,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -1669,7 +1702,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -1766,7 +1799,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -1777,11 +1810,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -1797,7 +1830,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -1810,7 +1843,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -1824,7 +1857,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -1870,7 +1903,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -1886,7 +1919,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -1900,7 +1933,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -1975,7 +2008,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -1990,7 +2023,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -2002,7 +2035,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -2068,7 +2101,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -2086,7 +2119,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -2105,7 +2138,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -2136,7 +2169,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -2217,7 +2250,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -2300,7 +2333,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -2352,7 +2385,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -2368,7 +2401,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -2440,7 +2473,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -2455,7 +2488,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -2561,7 +2594,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -2640,7 +2673,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -2661,7 +2694,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -2677,7 +2710,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -2792,7 +2825,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -2869,7 +2902,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -2891,7 +2924,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -2918,7 +2951,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -2950,7 +2983,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -2982,12 +3015,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -3025,7 +3058,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -3122,7 +3155,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -3141,7 +3174,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -3155,7 +3188,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -3196,7 +3229,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -3233,10 +3266,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -3257,7 +3290,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -3293,7 +3326,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -3309,7 +3342,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -3323,7 +3356,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -3336,7 +3369,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -3366,7 +3399,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -3531,7 +3564,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -3883,12 +3916,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -3941,7 +3974,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -3955,7 +3988,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),

--- a/packages/es-schemas/src/get_script_context.ts
+++ b/packages/es-schemas/src/get_script_context.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/get_script_languages.ts
+++ b/packages/es-schemas/src/get_script_languages.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/get_source.ts
+++ b/packages/es-schemas/src/get_source.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/graph_explore.ts
+++ b/packages/es-schemas/src/graph_explore.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4030,7 +4063,7 @@ export type GraphVertexInclude = z.infer<typeof GraphVertexInclude>
 export const GraphVertexDefinition = z.object({
   exclude: z.array(z.string()).describe('Prevents the specified terms from being included in the results.').optional(),
   field: Field.describe('Identifies a field in the documents of interest.'),
-  include: z.array(GraphVertexInclude).describe('Identifies the terms of interest that form the starting points from which you want to spider out.').optional(),
+  include: z.array(z.union([GraphVertexInclude, z.string()])).describe('Identifies the terms of interest that form the starting points from which you want to spider out.').optional(),
   min_doc_count: long.describe('Specifies how many documents must contain a pair of terms before it is considered to be a useful connection. This setting acts as a certainty threshold.').optional(),
   shard_min_doc_count: long.describe('Controls how many documents on a particular shard have to contain a pair of terms before the connection is returned for global consideration.').optional(),
   size: integer.describe('Specifies the maximum number of vertex terms returned for each field.').optional()

--- a/packages/es-schemas/src/health_report.ts
+++ b/packages/es-schemas/src/health_report.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ilm_delete_lifecycle.ts
+++ b/packages/es-schemas/src/ilm_delete_lifecycle.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ilm_explain_lifecycle.ts
+++ b/packages/es-schemas/src/ilm_explain_lifecycle.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ilm_get_lifecycle.ts
+++ b/packages/es-schemas/src/ilm_get_lifecycle.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ilm_get_status.ts
+++ b/packages/es-schemas/src/ilm_get_status.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ilm_migrate_to_data_tiers.ts
+++ b/packages/es-schemas/src/ilm_migrate_to_data_tiers.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ilm_move_to_step.ts
+++ b/packages/es-schemas/src/ilm_move_to_step.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ilm_put_lifecycle.ts
+++ b/packages/es-schemas/src/ilm_put_lifecycle.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ilm_remove_policy.ts
+++ b/packages/es-schemas/src/ilm_remove_policy.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ilm_retry.ts
+++ b/packages/es-schemas/src/ilm_retry.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ilm_start.ts
+++ b/packages/es-schemas/src/ilm_start.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ilm_stop.ts
+++ b/packages/es-schemas/src/ilm_stop.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/index.ts
+++ b/packages/es-schemas/src/index.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/indices_add_block.ts
+++ b/packages/es-schemas/src/indices_add_block.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/indices_analyze.ts
+++ b/packages/es-schemas/src/indices_analyze.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4142,7 +4175,7 @@ export const AnalysisConditionTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('condition'),
   filter: z.array(z.string()).describe('Array of token filters. If a token matches the predicate script in the `script` parameter, these filters are applied to the token in the order provided.'),
-  script: z.lazy(() => Script).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
 }).meta({ id: 'AnalysisConditionTokenFilter' })
 export type AnalysisConditionTokenFilter = z.infer<typeof AnalysisConditionTokenFilter>
 
@@ -4614,7 +4647,7 @@ export type AnalysisPorterStemTokenFilter = z.infer<typeof AnalysisPorterStemTok
 export const AnalysisPredicateTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('predicate_token_filter'),
-  script: z.lazy(() => Script).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
 }).meta({ id: 'AnalysisPredicateTokenFilter' })
 export type AnalysisPredicateTokenFilter = z.infer<typeof AnalysisPredicateTokenFilter>
 

--- a/packages/es-schemas/src/indices_cancel_migrate_reindex.ts
+++ b/packages/es-schemas/src/indices_cancel_migrate_reindex.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/indices_clear_cache.ts
+++ b/packages/es-schemas/src/indices_clear_cache.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/indices_clone.ts
+++ b/packages/es-schemas/src/indices_clone.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),

--- a/packages/es-schemas/src/indices_close.ts
+++ b/packages/es-schemas/src/indices_close.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/indices_create.ts
+++ b/packages/es-schemas/src/indices_create.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4598,7 +4631,7 @@ export const AnalysisConditionTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('condition'),
   filter: z.array(z.string()).describe('Array of token filters. If a token matches the predicate script in the `script` parameter, these filters are applied to the token in the order provided.'),
-  script: z.lazy(() => Script).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
 }).meta({ id: 'AnalysisConditionTokenFilter' })
 export type AnalysisConditionTokenFilter = z.infer<typeof AnalysisConditionTokenFilter>
 
@@ -5079,7 +5112,7 @@ export type AnalysisPorterStemTokenFilter = z.infer<typeof AnalysisPorterStemTok
 export const AnalysisPredicateTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('predicate_token_filter'),
-  script: z.lazy(() => Script).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
 }).meta({ id: 'AnalysisPredicateTokenFilter' })
 export type AnalysisPredicateTokenFilter = z.infer<typeof AnalysisPredicateTokenFilter>
 
@@ -5628,7 +5661,7 @@ export const MappingBooleanProperty = z.object({
   index: z.boolean().optional(),
   null_value: z.boolean().optional(),
   ignore_malformed: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('boolean')
@@ -5669,7 +5702,7 @@ export const MappingNumberPropertyBase = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional()
 }).meta({ id: 'MappingNumberPropertyBase' })
@@ -5711,7 +5744,7 @@ export const MappingByteNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('byte'),
@@ -5840,7 +5873,7 @@ export const MappingDateNanosProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -5885,7 +5918,7 @@ export const MappingDateProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -6024,7 +6057,7 @@ export const MappingDoubleNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('double'),
@@ -6113,7 +6146,7 @@ export const MappingDynamicProperty = z.object({
   null_value: FieldValue.optional(),
   boost: double.optional(),
   coerce: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   ignore_malformed: z.boolean().optional(),
   time_series_metric: MappingTimeSeriesMetricType.optional(),
@@ -6277,7 +6310,7 @@ export const MappingFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('float'),
@@ -6351,7 +6384,7 @@ export const MappingGeoPointProperty = z.object({
   null_value: GeoLocation.optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   type: z.literal('geo_point'),
   time_series_metric: MappingGeoPointMetricType.optional()
 }).meta({ id: 'MappingGeoPointProperty' })
@@ -6435,7 +6468,7 @@ export const MappingHalfFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('half_float'),
@@ -6566,7 +6599,7 @@ export const MappingIntegerNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('integer'),
@@ -6640,7 +6673,7 @@ export const MappingIpProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   null_value: z.string().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('ip')
 }).meta({ id: 'MappingIpProperty' })
@@ -6740,7 +6773,7 @@ export const MappingKeywordProperty = z.object({
   eager_global_ordinals: z.boolean().optional(),
   index: z.boolean().optional(),
   index_options: MappingIndexOptions.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   normalizer: z.string().optional(),
   norms: z.boolean().optional(),
@@ -6788,7 +6821,7 @@ export const MappingLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('long'),
@@ -7105,7 +7138,7 @@ export const MappingScaledFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('scaled_float'),
@@ -7230,7 +7263,7 @@ export const MappingShortNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('short'),
@@ -7427,7 +7460,7 @@ export const MappingUnsignedLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('unsigned_long'),
@@ -7752,8 +7785,8 @@ export type IndicesSettingsSimilarityLmj = z.infer<typeof IndicesSettingsSimilar
 
 export const IndicesSettingsSimilarityScripted = z.object({
   type: z.literal('scripted'),
-  script: z.lazy(() => Script),
-  weight_script: z.lazy(() => Script).optional()
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]),
+  weight_script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).optional()
 }).meta({ id: 'IndicesSettingsSimilarityScripted' })
 export type IndicesSettingsSimilarityScripted = z.infer<typeof IndicesSettingsSimilarityScripted>
 

--- a/packages/es-schemas/src/indices_create_data_stream.ts
+++ b/packages/es-schemas/src/indices_create_data_stream.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/indices_create_from.ts
+++ b/packages/es-schemas/src/indices_create_from.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4592,7 +4625,7 @@ export const AnalysisConditionTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('condition'),
   filter: z.array(z.string()).describe('Array of token filters. If a token matches the predicate script in the `script` parameter, these filters are applied to the token in the order provided.'),
-  script: z.lazy(() => Script).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
 }).meta({ id: 'AnalysisConditionTokenFilter' })
 export type AnalysisConditionTokenFilter = z.infer<typeof AnalysisConditionTokenFilter>
 
@@ -5073,7 +5106,7 @@ export type AnalysisPorterStemTokenFilter = z.infer<typeof AnalysisPorterStemTok
 export const AnalysisPredicateTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('predicate_token_filter'),
-  script: z.lazy(() => Script).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
 }).meta({ id: 'AnalysisPredicateTokenFilter' })
 export type AnalysisPredicateTokenFilter = z.infer<typeof AnalysisPredicateTokenFilter>
 
@@ -5622,7 +5655,7 @@ export const MappingBooleanProperty = z.object({
   index: z.boolean().optional(),
   null_value: z.boolean().optional(),
   ignore_malformed: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('boolean')
@@ -5663,7 +5696,7 @@ export const MappingNumberPropertyBase = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional()
 }).meta({ id: 'MappingNumberPropertyBase' })
@@ -5705,7 +5738,7 @@ export const MappingByteNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('byte'),
@@ -5834,7 +5867,7 @@ export const MappingDateNanosProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -5879,7 +5912,7 @@ export const MappingDateProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -6018,7 +6051,7 @@ export const MappingDoubleNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('double'),
@@ -6107,7 +6140,7 @@ export const MappingDynamicProperty = z.object({
   null_value: FieldValue.optional(),
   boost: double.optional(),
   coerce: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   ignore_malformed: z.boolean().optional(),
   time_series_metric: MappingTimeSeriesMetricType.optional(),
@@ -6271,7 +6304,7 @@ export const MappingFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('float'),
@@ -6345,7 +6378,7 @@ export const MappingGeoPointProperty = z.object({
   null_value: GeoLocation.optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   type: z.literal('geo_point'),
   time_series_metric: MappingGeoPointMetricType.optional()
 }).meta({ id: 'MappingGeoPointProperty' })
@@ -6429,7 +6462,7 @@ export const MappingHalfFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('half_float'),
@@ -6560,7 +6593,7 @@ export const MappingIntegerNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('integer'),
@@ -6634,7 +6667,7 @@ export const MappingIpProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   null_value: z.string().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('ip')
 }).meta({ id: 'MappingIpProperty' })
@@ -6734,7 +6767,7 @@ export const MappingKeywordProperty = z.object({
   eager_global_ordinals: z.boolean().optional(),
   index: z.boolean().optional(),
   index_options: MappingIndexOptions.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   normalizer: z.string().optional(),
   norms: z.boolean().optional(),
@@ -6782,7 +6815,7 @@ export const MappingLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('long'),
@@ -7099,7 +7132,7 @@ export const MappingScaledFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('scaled_float'),
@@ -7224,7 +7257,7 @@ export const MappingShortNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('short'),
@@ -7421,7 +7454,7 @@ export const MappingUnsignedLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('unsigned_long'),
@@ -7736,8 +7769,8 @@ export type IndicesSettingsSimilarityLmj = z.infer<typeof IndicesSettingsSimilar
 
 export const IndicesSettingsSimilarityScripted = z.object({
   type: z.literal('scripted'),
-  script: z.lazy(() => Script),
-  weight_script: z.lazy(() => Script).optional()
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]),
+  weight_script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).optional()
 }).meta({ id: 'IndicesSettingsSimilarityScripted' })
 export type IndicesSettingsSimilarityScripted = z.infer<typeof IndicesSettingsSimilarityScripted>
 

--- a/packages/es-schemas/src/indices_data_streams_stats.ts
+++ b/packages/es-schemas/src/indices_data_streams_stats.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/indices_delete.ts
+++ b/packages/es-schemas/src/indices_delete.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/indices_delete_alias.ts
+++ b/packages/es-schemas/src/indices_delete_alias.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/indices_delete_data_lifecycle.ts
+++ b/packages/es-schemas/src/indices_delete_data_lifecycle.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/indices_delete_data_stream.ts
+++ b/packages/es-schemas/src/indices_delete_data_stream.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/indices_delete_data_stream_options.ts
+++ b/packages/es-schemas/src/indices_delete_data_stream_options.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/indices_delete_index_template.ts
+++ b/packages/es-schemas/src/indices_delete_index_template.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/indices_delete_template.ts
+++ b/packages/es-schemas/src/indices_delete_template.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/indices_disk_usage.ts
+++ b/packages/es-schemas/src/indices_disk_usage.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/indices_downsample.ts
+++ b/packages/es-schemas/src/indices_downsample.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/indices_exists.ts
+++ b/packages/es-schemas/src/indices_exists.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/indices_exists_alias.ts
+++ b/packages/es-schemas/src/indices_exists_alias.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/indices_exists_index_template.ts
+++ b/packages/es-schemas/src/indices_exists_index_template.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/indices_exists_template.ts
+++ b/packages/es-schemas/src/indices_exists_template.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/indices_explain_data_lifecycle.ts
+++ b/packages/es-schemas/src/indices_explain_data_lifecycle.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -49,6 +50,9 @@ export const RequestBase = z.object({
 }).meta({ id: 'RequestBase' })
 export type RequestBase = z.infer<typeof RequestBase>
 
+export const IndicesRetentionSource = z.enum(['data_stream_configuration', 'default_global_retention', 'max_global_retention', 'default_failures_retention']).meta({ id: 'IndicesRetentionSource' })
+export type IndicesRetentionSource = z.infer<typeof IndicesRetentionSource>
+
 export const IndicesDownsamplingRound = z.object({
   after: Duration.describe('The duration since rollover when this downsampling round should execute'),
   fixed_interval: DurationLarge.describe('The downsample interval.')
@@ -61,6 +65,8 @@ export type IndicesSamplingMethod = z.infer<typeof IndicesSamplingMethod>
 /** Data stream lifecycle denotes that a data stream is managed by the data stream lifecycle and contains the configuration. */
 export const IndicesDataStreamLifecycle = z.object({
   data_retention: Duration.describe('If defined, every document added to this data stream will be stored at least for this time frame. Any time after this duration the document could be deleted. When empty, every document in this data stream will be stored indefinitely.').optional(),
+  effective_retention: Duration.describe('The least amount of time data should be kept by elasticsearch.').optional(),
+  retention_determined_by: IndicesRetentionSource.describe('Configuration source that can influence the retention of a data stream.').optional(),
   downsampling: z.array(IndicesDownsamplingRound).describe('The list of downsampling rounds to execute as part of this downsampling configuration').optional(),
   downsampling_method: IndicesSamplingMethod.describe('The method used to downsample the data. There are two options `aggregate` and `last_value`. It requires `downsampling` to be defined. Defaults to `aggregate`.').optional(),
   enabled: z.boolean().describe('If defined, it turns data stream lifecycle on/off (`true`/`false`) for this data stream. A data stream lifecycle that\'s disabled (enabled: `false`) will have no effect on the data stream.').optional(),

--- a/packages/es-schemas/src/indices_field_usage_stats.ts
+++ b/packages/es-schemas/src/indices_field_usage_stats.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/indices_flush.ts
+++ b/packages/es-schemas/src/indices_flush.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/indices_forcemerge.ts
+++ b/packages/es-schemas/src/indices_forcemerge.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/indices_get.ts
+++ b/packages/es-schemas/src/indices_get.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4604,7 +4637,7 @@ export const AnalysisConditionTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('condition'),
   filter: z.array(z.string()).describe('Array of token filters. If a token matches the predicate script in the `script` parameter, these filters are applied to the token in the order provided.'),
-  script: z.lazy(() => Script).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
 }).meta({ id: 'AnalysisConditionTokenFilter' })
 export type AnalysisConditionTokenFilter = z.infer<typeof AnalysisConditionTokenFilter>
 
@@ -5085,7 +5118,7 @@ export type AnalysisPorterStemTokenFilter = z.infer<typeof AnalysisPorterStemTok
 export const AnalysisPredicateTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('predicate_token_filter'),
-  script: z.lazy(() => Script).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
 }).meta({ id: 'AnalysisPredicateTokenFilter' })
 export type AnalysisPredicateTokenFilter = z.infer<typeof AnalysisPredicateTokenFilter>
 
@@ -5634,7 +5667,7 @@ export const MappingBooleanProperty = z.object({
   index: z.boolean().optional(),
   null_value: z.boolean().optional(),
   ignore_malformed: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('boolean')
@@ -5675,7 +5708,7 @@ export const MappingNumberPropertyBase = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional()
 }).meta({ id: 'MappingNumberPropertyBase' })
@@ -5717,7 +5750,7 @@ export const MappingByteNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('byte'),
@@ -5846,7 +5879,7 @@ export const MappingDateNanosProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -5891,7 +5924,7 @@ export const MappingDateProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -6030,7 +6063,7 @@ export const MappingDoubleNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('double'),
@@ -6119,7 +6152,7 @@ export const MappingDynamicProperty = z.object({
   null_value: FieldValue.optional(),
   boost: double.optional(),
   coerce: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   ignore_malformed: z.boolean().optional(),
   time_series_metric: MappingTimeSeriesMetricType.optional(),
@@ -6283,7 +6316,7 @@ export const MappingFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('float'),
@@ -6357,7 +6390,7 @@ export const MappingGeoPointProperty = z.object({
   null_value: GeoLocation.optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   type: z.literal('geo_point'),
   time_series_metric: MappingGeoPointMetricType.optional()
 }).meta({ id: 'MappingGeoPointProperty' })
@@ -6441,7 +6474,7 @@ export const MappingHalfFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('half_float'),
@@ -6572,7 +6605,7 @@ export const MappingIntegerNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('integer'),
@@ -6646,7 +6679,7 @@ export const MappingIpProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   null_value: z.string().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('ip')
 }).meta({ id: 'MappingIpProperty' })
@@ -6746,7 +6779,7 @@ export const MappingKeywordProperty = z.object({
   eager_global_ordinals: z.boolean().optional(),
   index: z.boolean().optional(),
   index_options: MappingIndexOptions.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   normalizer: z.string().optional(),
   norms: z.boolean().optional(),
@@ -6794,7 +6827,7 @@ export const MappingLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('long'),
@@ -7111,7 +7144,7 @@ export const MappingScaledFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('scaled_float'),
@@ -7236,7 +7269,7 @@ export const MappingShortNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('short'),
@@ -7433,7 +7466,7 @@ export const MappingUnsignedLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('unsigned_long'),
@@ -7510,6 +7543,9 @@ export const IndicesCacheQueries = z.object({
 }).meta({ id: 'IndicesCacheQueries' })
 export type IndicesCacheQueries = z.infer<typeof IndicesCacheQueries>
 
+export const IndicesRetentionSource = z.enum(['data_stream_configuration', 'default_global_retention', 'max_global_retention', 'default_failures_retention']).meta({ id: 'IndicesRetentionSource' })
+export type IndicesRetentionSource = z.infer<typeof IndicesRetentionSource>
+
 export const IndicesDownsamplingRound = z.object({
   after: Duration.describe('The duration since rollover when this downsampling round should execute'),
   fixed_interval: DurationLarge.describe('The downsample interval.')
@@ -7522,6 +7558,8 @@ export type IndicesSamplingMethod = z.infer<typeof IndicesSamplingMethod>
 /** Data stream lifecycle denotes that a data stream is managed by the data stream lifecycle and contains the configuration. */
 export const IndicesDataStreamLifecycle = z.object({
   data_retention: Duration.describe('If defined, every document added to this data stream will be stored at least for this time frame. Any time after this duration the document could be deleted. When empty, every document in this data stream will be stored indefinitely.').optional(),
+  effective_retention: Duration.describe('The least amount of time data should be kept by elasticsearch.').optional(),
+  retention_determined_by: IndicesRetentionSource.describe('Configuration source that can influence the retention of a data stream.').optional(),
   downsampling: z.array(IndicesDownsamplingRound).describe('The list of downsampling rounds to execute as part of this downsampling configuration').optional(),
   downsampling_method: IndicesSamplingMethod.describe('The method used to downsample the data. There are two options `aggregate` and `last_value`. It requires `downsampling` to be defined. Defaults to `aggregate`.').optional(),
   enabled: z.boolean().describe('If defined, it turns data stream lifecycle on/off (`true`/`false`) for this data stream. A data stream lifecycle that\'s disabled (enabled: `false`) will have no effect on the data stream.').optional(),
@@ -7777,8 +7815,8 @@ export type IndicesSettingsSimilarityLmj = z.infer<typeof IndicesSettingsSimilar
 
 export const IndicesSettingsSimilarityScripted = z.object({
   type: z.literal('scripted'),
-  script: z.lazy(() => Script),
-  weight_script: z.lazy(() => Script).optional()
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]),
+  weight_script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).optional()
 }).meta({ id: 'IndicesSettingsSimilarityScripted' })
 export type IndicesSettingsSimilarityScripted = z.infer<typeof IndicesSettingsSimilarityScripted>
 

--- a/packages/es-schemas/src/indices_get_alias.ts
+++ b/packages/es-schemas/src/indices_get_alias.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),

--- a/packages/es-schemas/src/indices_get_data_lifecycle.ts
+++ b/packages/es-schemas/src/indices_get_data_lifecycle.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -52,6 +53,9 @@ export const RequestBase = z.object({
 }).meta({ id: 'RequestBase' })
 export type RequestBase = z.infer<typeof RequestBase>
 
+export const IndicesRetentionSource = z.enum(['data_stream_configuration', 'default_global_retention', 'max_global_retention', 'default_failures_retention']).meta({ id: 'IndicesRetentionSource' })
+export type IndicesRetentionSource = z.infer<typeof IndicesRetentionSource>
+
 export const IndicesDownsamplingRound = z.object({
   after: Duration.describe('The duration since rollover when this downsampling round should execute'),
   fixed_interval: DurationLarge.describe('The downsample interval.')
@@ -64,6 +68,8 @@ export type IndicesSamplingMethod = z.infer<typeof IndicesSamplingMethod>
 /** Data stream lifecycle denotes that a data stream is managed by the data stream lifecycle and contains the configuration. */
 export const IndicesDataStreamLifecycle = z.object({
   data_retention: Duration.describe('If defined, every document added to this data stream will be stored at least for this time frame. Any time after this duration the document could be deleted. When empty, every document in this data stream will be stored indefinitely.').optional(),
+  effective_retention: Duration.describe('The least amount of time data should be kept by elasticsearch.').optional(),
+  retention_determined_by: IndicesRetentionSource.describe('Configuration source that can influence the retention of a data stream.').optional(),
   downsampling: z.array(IndicesDownsamplingRound).describe('The list of downsampling rounds to execute as part of this downsampling configuration').optional(),
   downsampling_method: IndicesSamplingMethod.describe('The method used to downsample the data. There are two options `aggregate` and `last_value`. It requires `downsampling` to be defined. Defaults to `aggregate`.').optional(),
   enabled: z.boolean().describe('If defined, it turns data stream lifecycle on/off (`true`/`false`) for this data stream. A data stream lifecycle that\'s disabled (enabled: `false`) will have no effect on the data stream.').optional(),
@@ -115,7 +121,14 @@ export const IndicesGetDataLifecycleRequest = z.object({
 }).meta({ id: 'IndicesGetDataLifecycleRequest' })
 export type IndicesGetDataLifecycleRequest = z.infer<typeof IndicesGetDataLifecycleRequest>
 
+export const IndicesGetDataLifecycleGlobalRetention = z.object({
+  max_retention: Duration.optional(),
+  default_retention: Duration.optional()
+}).meta({ id: 'IndicesGetDataLifecycleGlobalRetention' })
+export type IndicesGetDataLifecycleGlobalRetention = z.infer<typeof IndicesGetDataLifecycleGlobalRetention>
+
 export const IndicesGetDataLifecycleResponse = z.object({
-  data_streams: z.array(IndicesGetDataLifecycleDataStreamWithLifecycle)
+  data_streams: z.array(IndicesGetDataLifecycleDataStreamWithLifecycle),
+  global_retention: IndicesGetDataLifecycleGlobalRetention
 }).meta({ id: 'IndicesGetDataLifecycleResponse' })
 export type IndicesGetDataLifecycleResponse = z.infer<typeof IndicesGetDataLifecycleResponse>

--- a/packages/es-schemas/src/indices_get_data_lifecycle_stats.ts
+++ b/packages/es-schemas/src/indices_get_data_lifecycle_stats.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/indices_get_data_stream.ts
+++ b/packages/es-schemas/src/indices_get_data_stream.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4607,7 +4640,7 @@ export const AnalysisConditionTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('condition'),
   filter: z.array(z.string()).describe('Array of token filters. If a token matches the predicate script in the `script` parameter, these filters are applied to the token in the order provided.'),
-  script: z.lazy(() => Script).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
 }).meta({ id: 'AnalysisConditionTokenFilter' })
 export type AnalysisConditionTokenFilter = z.infer<typeof AnalysisConditionTokenFilter>
 
@@ -5088,7 +5121,7 @@ export type AnalysisPorterStemTokenFilter = z.infer<typeof AnalysisPorterStemTok
 export const AnalysisPredicateTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('predicate_token_filter'),
-  script: z.lazy(() => Script).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
 }).meta({ id: 'AnalysisPredicateTokenFilter' })
 export type AnalysisPredicateTokenFilter = z.infer<typeof AnalysisPredicateTokenFilter>
 
@@ -5637,7 +5670,7 @@ export const MappingBooleanProperty = z.object({
   index: z.boolean().optional(),
   null_value: z.boolean().optional(),
   ignore_malformed: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('boolean')
@@ -5678,7 +5711,7 @@ export const MappingNumberPropertyBase = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional()
 }).meta({ id: 'MappingNumberPropertyBase' })
@@ -5720,7 +5753,7 @@ export const MappingByteNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('byte'),
@@ -5849,7 +5882,7 @@ export const MappingDateNanosProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -5894,7 +5927,7 @@ export const MappingDateProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -6033,7 +6066,7 @@ export const MappingDoubleNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('double'),
@@ -6122,7 +6155,7 @@ export const MappingDynamicProperty = z.object({
   null_value: FieldValue.optional(),
   boost: double.optional(),
   coerce: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   ignore_malformed: z.boolean().optional(),
   time_series_metric: MappingTimeSeriesMetricType.optional(),
@@ -6286,7 +6319,7 @@ export const MappingFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('float'),
@@ -6360,7 +6393,7 @@ export const MappingGeoPointProperty = z.object({
   null_value: GeoLocation.optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   type: z.literal('geo_point'),
   time_series_metric: MappingGeoPointMetricType.optional()
 }).meta({ id: 'MappingGeoPointProperty' })
@@ -6444,7 +6477,7 @@ export const MappingHalfFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('half_float'),
@@ -6575,7 +6608,7 @@ export const MappingIntegerNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('integer'),
@@ -6649,7 +6682,7 @@ export const MappingIpProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   null_value: z.string().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('ip')
 }).meta({ id: 'MappingIpProperty' })
@@ -6749,7 +6782,7 @@ export const MappingKeywordProperty = z.object({
   eager_global_ordinals: z.boolean().optional(),
   index: z.boolean().optional(),
   index_options: MappingIndexOptions.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   normalizer: z.string().optional(),
   norms: z.boolean().optional(),
@@ -6797,7 +6830,7 @@ export const MappingLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('long'),
@@ -7114,7 +7147,7 @@ export const MappingScaledFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('scaled_float'),
@@ -7239,7 +7272,7 @@ export const MappingShortNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('short'),
@@ -7436,7 +7469,7 @@ export const MappingUnsignedLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('unsigned_long'),
@@ -7526,6 +7559,9 @@ export const IndicesFailureStore = z.object({
 }).meta({ id: 'IndicesFailureStore' })
 export type IndicesFailureStore = z.infer<typeof IndicesFailureStore>
 
+export const IndicesRetentionSource = z.enum(['data_stream_configuration', 'default_global_retention', 'max_global_retention', 'default_failures_retention']).meta({ id: 'IndicesRetentionSource' })
+export type IndicesRetentionSource = z.infer<typeof IndicesRetentionSource>
+
 export const IndicesDownsamplingRound = z.object({
   after: Duration.describe('The duration since rollover when this downsampling round should execute'),
   fixed_interval: DurationLarge.describe('The downsample interval.')
@@ -7538,6 +7574,8 @@ export type IndicesSamplingMethod = z.infer<typeof IndicesSamplingMethod>
 /** Data stream lifecycle denotes that a data stream is managed by the data stream lifecycle and contains the configuration. */
 export const IndicesDataStreamLifecycle = z.object({
   data_retention: Duration.describe('If defined, every document added to this data stream will be stored at least for this time frame. Any time after this duration the document could be deleted. When empty, every document in this data stream will be stored indefinitely.').optional(),
+  effective_retention: Duration.describe('The least amount of time data should be kept by elasticsearch.').optional(),
+  retention_determined_by: IndicesRetentionSource.describe('Configuration source that can influence the retention of a data stream.').optional(),
   downsampling: z.array(IndicesDownsamplingRound).describe('The list of downsampling rounds to execute as part of this downsampling configuration').optional(),
   downsampling_method: IndicesSamplingMethod.describe('The method used to downsample the data. There are two options `aggregate` and `last_value`. It requires `downsampling` to be defined. Defaults to `aggregate`.').optional(),
   enabled: z.boolean().describe('If defined, it turns data stream lifecycle on/off (`true`/`false`) for this data stream. A data stream lifecycle that\'s disabled (enabled: `false`) will have no effect on the data stream.').optional(),
@@ -7817,8 +7855,8 @@ export type IndicesSettingsSimilarityLmj = z.infer<typeof IndicesSettingsSimilar
 
 export const IndicesSettingsSimilarityScripted = z.object({
   type: z.literal('scripted'),
-  script: z.lazy(() => Script),
-  weight_script: z.lazy(() => Script).optional()
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]),
+  weight_script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).optional()
 }).meta({ id: 'IndicesSettingsSimilarityScripted' })
 export type IndicesSettingsSimilarityScripted = z.infer<typeof IndicesSettingsSimilarityScripted>
 

--- a/packages/es-schemas/src/indices_get_data_stream_mappings.ts
+++ b/packages/es-schemas/src/indices_get_data_stream_mappings.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4307,7 +4340,7 @@ export const MappingBooleanProperty = z.object({
   index: z.boolean().optional(),
   null_value: z.boolean().optional(),
   ignore_malformed: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('boolean')
@@ -4348,7 +4381,7 @@ export const MappingNumberPropertyBase = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional()
 }).meta({ id: 'MappingNumberPropertyBase' })
@@ -4390,7 +4423,7 @@ export const MappingByteNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('byte'),
@@ -4519,7 +4552,7 @@ export const MappingDateNanosProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -4564,7 +4597,7 @@ export const MappingDateProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -4703,7 +4736,7 @@ export const MappingDoubleNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('double'),
@@ -4792,7 +4825,7 @@ export const MappingDynamicProperty = z.object({
   null_value: FieldValue.optional(),
   boost: double.optional(),
   coerce: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   ignore_malformed: z.boolean().optional(),
   time_series_metric: MappingTimeSeriesMetricType.optional(),
@@ -4956,7 +4989,7 @@ export const MappingFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('float'),
@@ -5030,7 +5063,7 @@ export const MappingGeoPointProperty = z.object({
   null_value: GeoLocation.optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   type: z.literal('geo_point'),
   time_series_metric: MappingGeoPointMetricType.optional()
 }).meta({ id: 'MappingGeoPointProperty' })
@@ -5114,7 +5147,7 @@ export const MappingHalfFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('half_float'),
@@ -5245,7 +5278,7 @@ export const MappingIntegerNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('integer'),
@@ -5319,7 +5352,7 @@ export const MappingIpProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   null_value: z.string().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('ip')
 }).meta({ id: 'MappingIpProperty' })
@@ -5419,7 +5452,7 @@ export const MappingKeywordProperty = z.object({
   eager_global_ordinals: z.boolean().optional(),
   index: z.boolean().optional(),
   index_options: MappingIndexOptions.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   normalizer: z.string().optional(),
   norms: z.boolean().optional(),
@@ -5467,7 +5500,7 @@ export const MappingLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('long'),
@@ -5784,7 +5817,7 @@ export const MappingScaledFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('scaled_float'),
@@ -5909,7 +5942,7 @@ export const MappingShortNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('short'),
@@ -6106,7 +6139,7 @@ export const MappingUnsignedLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('unsigned_long'),

--- a/packages/es-schemas/src/indices_get_data_stream_options.ts
+++ b/packages/es-schemas/src/indices_get_data_stream_options.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/indices_get_data_stream_settings.ts
+++ b/packages/es-schemas/src/indices_get_data_stream_settings.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4583,7 +4616,7 @@ export const AnalysisConditionTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('condition'),
   filter: z.array(z.string()).describe('Array of token filters. If a token matches the predicate script in the `script` parameter, these filters are applied to the token in the order provided.'),
-  script: z.lazy(() => Script).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
 }).meta({ id: 'AnalysisConditionTokenFilter' })
 export type AnalysisConditionTokenFilter = z.infer<typeof AnalysisConditionTokenFilter>
 
@@ -5064,7 +5097,7 @@ export type AnalysisPorterStemTokenFilter = z.infer<typeof AnalysisPorterStemTok
 export const AnalysisPredicateTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('predicate_token_filter'),
-  script: z.lazy(() => Script).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
 }).meta({ id: 'AnalysisPredicateTokenFilter' })
 export type AnalysisPredicateTokenFilter = z.infer<typeof AnalysisPredicateTokenFilter>
 
@@ -5547,8 +5580,8 @@ export type IndicesSettingsSimilarityLmj = z.infer<typeof IndicesSettingsSimilar
 
 export const IndicesSettingsSimilarityScripted = z.object({
   type: z.literal('scripted'),
-  script: z.lazy(() => Script),
-  weight_script: z.lazy(() => Script).optional()
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]),
+  weight_script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).optional()
 }).meta({ id: 'IndicesSettingsSimilarityScripted' })
 export type IndicesSettingsSimilarityScripted = z.infer<typeof IndicesSettingsSimilarityScripted>
 

--- a/packages/es-schemas/src/indices_get_field_mapping.ts
+++ b/packages/es-schemas/src/indices_get_field_mapping.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4299,7 +4332,7 @@ export const MappingBooleanProperty = z.object({
   index: z.boolean().optional(),
   null_value: z.boolean().optional(),
   ignore_malformed: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('boolean')
@@ -4340,7 +4373,7 @@ export const MappingNumberPropertyBase = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional()
 }).meta({ id: 'MappingNumberPropertyBase' })
@@ -4382,7 +4415,7 @@ export const MappingByteNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('byte'),
@@ -4506,7 +4539,7 @@ export const MappingDateNanosProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -4551,7 +4584,7 @@ export const MappingDateProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -4690,7 +4723,7 @@ export const MappingDoubleNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('double'),
@@ -4779,7 +4812,7 @@ export const MappingDynamicProperty = z.object({
   null_value: FieldValue.optional(),
   boost: double.optional(),
   coerce: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   ignore_malformed: z.boolean().optional(),
   time_series_metric: MappingTimeSeriesMetricType.optional(),
@@ -4926,7 +4959,7 @@ export const MappingFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('float'),
@@ -5000,7 +5033,7 @@ export const MappingGeoPointProperty = z.object({
   null_value: GeoLocation.optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   type: z.literal('geo_point'),
   time_series_metric: MappingGeoPointMetricType.optional()
 }).meta({ id: 'MappingGeoPointProperty' })
@@ -5084,7 +5117,7 @@ export const MappingHalfFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('half_float'),
@@ -5210,7 +5243,7 @@ export const MappingIntegerNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('integer'),
@@ -5284,7 +5317,7 @@ export const MappingIpProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   null_value: z.string().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('ip')
 }).meta({ id: 'MappingIpProperty' })
@@ -5384,7 +5417,7 @@ export const MappingKeywordProperty = z.object({
   eager_global_ordinals: z.boolean().optional(),
   index: z.boolean().optional(),
   index_options: MappingIndexOptions.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   normalizer: z.string().optional(),
   norms: z.boolean().optional(),
@@ -5432,7 +5465,7 @@ export const MappingLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('long'),
@@ -5744,7 +5777,7 @@ export const MappingScaledFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('scaled_float'),
@@ -5869,7 +5902,7 @@ export const MappingShortNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('short'),
@@ -6027,7 +6060,7 @@ export const MappingUnsignedLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('unsigned_long'),

--- a/packages/es-schemas/src/indices_get_index_template.ts
+++ b/packages/es-schemas/src/indices_get_index_template.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4595,7 +4628,7 @@ export const AnalysisConditionTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('condition'),
   filter: z.array(z.string()).describe('Array of token filters. If a token matches the predicate script in the `script` parameter, these filters are applied to the token in the order provided.'),
-  script: z.lazy(() => Script).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
 }).meta({ id: 'AnalysisConditionTokenFilter' })
 export type AnalysisConditionTokenFilter = z.infer<typeof AnalysisConditionTokenFilter>
 
@@ -5076,7 +5109,7 @@ export type AnalysisPorterStemTokenFilter = z.infer<typeof AnalysisPorterStemTok
 export const AnalysisPredicateTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('predicate_token_filter'),
-  script: z.lazy(() => Script).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
 }).meta({ id: 'AnalysisPredicateTokenFilter' })
 export type AnalysisPredicateTokenFilter = z.infer<typeof AnalysisPredicateTokenFilter>
 
@@ -5625,7 +5658,7 @@ export const MappingBooleanProperty = z.object({
   index: z.boolean().optional(),
   null_value: z.boolean().optional(),
   ignore_malformed: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('boolean')
@@ -5666,7 +5699,7 @@ export const MappingNumberPropertyBase = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional()
 }).meta({ id: 'MappingNumberPropertyBase' })
@@ -5708,7 +5741,7 @@ export const MappingByteNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('byte'),
@@ -5837,7 +5870,7 @@ export const MappingDateNanosProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -5882,7 +5915,7 @@ export const MappingDateProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -6021,7 +6054,7 @@ export const MappingDoubleNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('double'),
@@ -6110,7 +6143,7 @@ export const MappingDynamicProperty = z.object({
   null_value: FieldValue.optional(),
   boost: double.optional(),
   coerce: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   ignore_malformed: z.boolean().optional(),
   time_series_metric: MappingTimeSeriesMetricType.optional(),
@@ -6274,7 +6307,7 @@ export const MappingFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('float'),
@@ -6348,7 +6381,7 @@ export const MappingGeoPointProperty = z.object({
   null_value: GeoLocation.optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   type: z.literal('geo_point'),
   time_series_metric: MappingGeoPointMetricType.optional()
 }).meta({ id: 'MappingGeoPointProperty' })
@@ -6432,7 +6465,7 @@ export const MappingHalfFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('half_float'),
@@ -6563,7 +6596,7 @@ export const MappingIntegerNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('integer'),
@@ -6637,7 +6670,7 @@ export const MappingIpProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   null_value: z.string().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('ip')
 }).meta({ id: 'MappingIpProperty' })
@@ -6737,7 +6770,7 @@ export const MappingKeywordProperty = z.object({
   eager_global_ordinals: z.boolean().optional(),
   index: z.boolean().optional(),
   index_options: MappingIndexOptions.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   normalizer: z.string().optional(),
   norms: z.boolean().optional(),
@@ -6785,7 +6818,7 @@ export const MappingLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('long'),
@@ -7102,7 +7135,7 @@ export const MappingScaledFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('scaled_float'),
@@ -7227,7 +7260,7 @@ export const MappingShortNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('short'),
@@ -7424,7 +7457,7 @@ export const MappingUnsignedLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('unsigned_long'),
@@ -7515,6 +7548,9 @@ export const IndicesDataStreamFailureStore = z.object({
 }).meta({ id: 'IndicesDataStreamFailureStore' })
 export type IndicesDataStreamFailureStore = z.infer<typeof IndicesDataStreamFailureStore>
 
+export const IndicesRetentionSource = z.enum(['data_stream_configuration', 'default_global_retention', 'max_global_retention', 'default_failures_retention']).meta({ id: 'IndicesRetentionSource' })
+export type IndicesRetentionSource = z.infer<typeof IndicesRetentionSource>
+
 export const IndicesDownsamplingRound = z.object({
   after: Duration.describe('The duration since rollover when this downsampling round should execute'),
   fixed_interval: DurationLarge.describe('The downsample interval.')
@@ -7527,6 +7563,8 @@ export type IndicesSamplingMethod = z.infer<typeof IndicesSamplingMethod>
 /** Data stream lifecycle denotes that a data stream is managed by the data stream lifecycle and contains the configuration. */
 export const IndicesDataStreamLifecycle = z.object({
   data_retention: Duration.describe('If defined, every document added to this data stream will be stored at least for this time frame. Any time after this duration the document could be deleted. When empty, every document in this data stream will be stored indefinitely.').optional(),
+  effective_retention: Duration.describe('The least amount of time data should be kept by elasticsearch.').optional(),
+  retention_determined_by: IndicesRetentionSource.describe('Configuration source that can influence the retention of a data stream.').optional(),
   downsampling: z.array(IndicesDownsamplingRound).describe('The list of downsampling rounds to execute as part of this downsampling configuration').optional(),
   downsampling_method: IndicesSamplingMethod.describe('The method used to downsample the data. There are two options `aggregate` and `last_value`. It requires `downsampling` to be defined. Defaults to `aggregate`.').optional(),
   enabled: z.boolean().describe('If defined, it turns data stream lifecycle on/off (`true`/`false`) for this data stream. A data stream lifecycle that\'s disabled (enabled: `false`) will have no effect on the data stream.').optional(),
@@ -7815,8 +7853,8 @@ export type IndicesSettingsSimilarityLmj = z.infer<typeof IndicesSettingsSimilar
 
 export const IndicesSettingsSimilarityScripted = z.object({
   type: z.literal('scripted'),
-  script: z.lazy(() => Script),
-  weight_script: z.lazy(() => Script).optional()
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]),
+  weight_script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).optional()
 }).meta({ id: 'IndicesSettingsSimilarityScripted' })
 export type IndicesSettingsSimilarityScripted = z.infer<typeof IndicesSettingsSimilarityScripted>
 

--- a/packages/es-schemas/src/indices_get_mapping.ts
+++ b/packages/es-schemas/src/indices_get_mapping.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4313,7 +4346,7 @@ export const MappingBooleanProperty = z.object({
   index: z.boolean().optional(),
   null_value: z.boolean().optional(),
   ignore_malformed: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('boolean')
@@ -4354,7 +4387,7 @@ export const MappingNumberPropertyBase = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional()
 }).meta({ id: 'MappingNumberPropertyBase' })
@@ -4396,7 +4429,7 @@ export const MappingByteNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('byte'),
@@ -4525,7 +4558,7 @@ export const MappingDateNanosProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -4570,7 +4603,7 @@ export const MappingDateProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -4709,7 +4742,7 @@ export const MappingDoubleNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('double'),
@@ -4798,7 +4831,7 @@ export const MappingDynamicProperty = z.object({
   null_value: FieldValue.optional(),
   boost: double.optional(),
   coerce: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   ignore_malformed: z.boolean().optional(),
   time_series_metric: MappingTimeSeriesMetricType.optional(),
@@ -4962,7 +4995,7 @@ export const MappingFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('float'),
@@ -5036,7 +5069,7 @@ export const MappingGeoPointProperty = z.object({
   null_value: GeoLocation.optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   type: z.literal('geo_point'),
   time_series_metric: MappingGeoPointMetricType.optional()
 }).meta({ id: 'MappingGeoPointProperty' })
@@ -5120,7 +5153,7 @@ export const MappingHalfFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('half_float'),
@@ -5251,7 +5284,7 @@ export const MappingIntegerNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('integer'),
@@ -5325,7 +5358,7 @@ export const MappingIpProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   null_value: z.string().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('ip')
 }).meta({ id: 'MappingIpProperty' })
@@ -5425,7 +5458,7 @@ export const MappingKeywordProperty = z.object({
   eager_global_ordinals: z.boolean().optional(),
   index: z.boolean().optional(),
   index_options: MappingIndexOptions.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   normalizer: z.string().optional(),
   norms: z.boolean().optional(),
@@ -5473,7 +5506,7 @@ export const MappingLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('long'),
@@ -5790,7 +5823,7 @@ export const MappingScaledFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('scaled_float'),
@@ -5915,7 +5948,7 @@ export const MappingShortNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('short'),
@@ -6112,7 +6145,7 @@ export const MappingUnsignedLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('unsigned_long'),

--- a/packages/es-schemas/src/indices_get_migrate_reindex_status.ts
+++ b/packages/es-schemas/src/indices_get_migrate_reindex_status.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/indices_get_settings.ts
+++ b/packages/es-schemas/src/indices_get_settings.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4607,7 +4640,7 @@ export const AnalysisConditionTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('condition'),
   filter: z.array(z.string()).describe('Array of token filters. If a token matches the predicate script in the `script` parameter, these filters are applied to the token in the order provided.'),
-  script: z.lazy(() => Script).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
 }).meta({ id: 'AnalysisConditionTokenFilter' })
 export type AnalysisConditionTokenFilter = z.infer<typeof AnalysisConditionTokenFilter>
 
@@ -5088,7 +5121,7 @@ export type AnalysisPorterStemTokenFilter = z.infer<typeof AnalysisPorterStemTok
 export const AnalysisPredicateTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('predicate_token_filter'),
-  script: z.lazy(() => Script).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
 }).meta({ id: 'AnalysisPredicateTokenFilter' })
 export type AnalysisPredicateTokenFilter = z.infer<typeof AnalysisPredicateTokenFilter>
 
@@ -5637,7 +5670,7 @@ export const MappingBooleanProperty = z.object({
   index: z.boolean().optional(),
   null_value: z.boolean().optional(),
   ignore_malformed: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('boolean')
@@ -5678,7 +5711,7 @@ export const MappingNumberPropertyBase = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional()
 }).meta({ id: 'MappingNumberPropertyBase' })
@@ -5720,7 +5753,7 @@ export const MappingByteNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('byte'),
@@ -5849,7 +5882,7 @@ export const MappingDateNanosProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -5894,7 +5927,7 @@ export const MappingDateProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -6033,7 +6066,7 @@ export const MappingDoubleNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('double'),
@@ -6122,7 +6155,7 @@ export const MappingDynamicProperty = z.object({
   null_value: FieldValue.optional(),
   boost: double.optional(),
   coerce: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   ignore_malformed: z.boolean().optional(),
   time_series_metric: MappingTimeSeriesMetricType.optional(),
@@ -6286,7 +6319,7 @@ export const MappingFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('float'),
@@ -6360,7 +6393,7 @@ export const MappingGeoPointProperty = z.object({
   null_value: GeoLocation.optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   type: z.literal('geo_point'),
   time_series_metric: MappingGeoPointMetricType.optional()
 }).meta({ id: 'MappingGeoPointProperty' })
@@ -6444,7 +6477,7 @@ export const MappingHalfFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('half_float'),
@@ -6575,7 +6608,7 @@ export const MappingIntegerNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('integer'),
@@ -6649,7 +6682,7 @@ export const MappingIpProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   null_value: z.string().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('ip')
 }).meta({ id: 'MappingIpProperty' })
@@ -6749,7 +6782,7 @@ export const MappingKeywordProperty = z.object({
   eager_global_ordinals: z.boolean().optional(),
   index: z.boolean().optional(),
   index_options: MappingIndexOptions.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   normalizer: z.string().optional(),
   norms: z.boolean().optional(),
@@ -6797,7 +6830,7 @@ export const MappingLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('long'),
@@ -7114,7 +7147,7 @@ export const MappingScaledFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('scaled_float'),
@@ -7239,7 +7272,7 @@ export const MappingShortNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('short'),
@@ -7436,7 +7469,7 @@ export const MappingUnsignedLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('unsigned_long'),
@@ -7513,6 +7546,9 @@ export const IndicesCacheQueries = z.object({
 }).meta({ id: 'IndicesCacheQueries' })
 export type IndicesCacheQueries = z.infer<typeof IndicesCacheQueries>
 
+export const IndicesRetentionSource = z.enum(['data_stream_configuration', 'default_global_retention', 'max_global_retention', 'default_failures_retention']).meta({ id: 'IndicesRetentionSource' })
+export type IndicesRetentionSource = z.infer<typeof IndicesRetentionSource>
+
 export const IndicesDownsamplingRound = z.object({
   after: Duration.describe('The duration since rollover when this downsampling round should execute'),
   fixed_interval: DurationLarge.describe('The downsample interval.')
@@ -7525,6 +7561,8 @@ export type IndicesSamplingMethod = z.infer<typeof IndicesSamplingMethod>
 /** Data stream lifecycle denotes that a data stream is managed by the data stream lifecycle and contains the configuration. */
 export const IndicesDataStreamLifecycle = z.object({
   data_retention: Duration.describe('If defined, every document added to this data stream will be stored at least for this time frame. Any time after this duration the document could be deleted. When empty, every document in this data stream will be stored indefinitely.').optional(),
+  effective_retention: Duration.describe('The least amount of time data should be kept by elasticsearch.').optional(),
+  retention_determined_by: IndicesRetentionSource.describe('Configuration source that can influence the retention of a data stream.').optional(),
   downsampling: z.array(IndicesDownsamplingRound).describe('The list of downsampling rounds to execute as part of this downsampling configuration').optional(),
   downsampling_method: IndicesSamplingMethod.describe('The method used to downsample the data. There are two options `aggregate` and `last_value`. It requires `downsampling` to be defined. Defaults to `aggregate`.').optional(),
   enabled: z.boolean().describe('If defined, it turns data stream lifecycle on/off (`true`/`false`) for this data stream. A data stream lifecycle that\'s disabled (enabled: `false`) will have no effect on the data stream.').optional(),
@@ -7780,8 +7818,8 @@ export type IndicesSettingsSimilarityLmj = z.infer<typeof IndicesSettingsSimilar
 
 export const IndicesSettingsSimilarityScripted = z.object({
   type: z.literal('scripted'),
-  script: z.lazy(() => Script),
-  weight_script: z.lazy(() => Script).optional()
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]),
+  weight_script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).optional()
 }).meta({ id: 'IndicesSettingsSimilarityScripted' })
 export type IndicesSettingsSimilarityScripted = z.infer<typeof IndicesSettingsSimilarityScripted>
 

--- a/packages/es-schemas/src/indices_get_template.ts
+++ b/packages/es-schemas/src/indices_get_template.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4307,7 +4340,7 @@ export const MappingBooleanProperty = z.object({
   index: z.boolean().optional(),
   null_value: z.boolean().optional(),
   ignore_malformed: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('boolean')
@@ -4348,7 +4381,7 @@ export const MappingNumberPropertyBase = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional()
 }).meta({ id: 'MappingNumberPropertyBase' })
@@ -4390,7 +4423,7 @@ export const MappingByteNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('byte'),
@@ -4519,7 +4552,7 @@ export const MappingDateNanosProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -4564,7 +4597,7 @@ export const MappingDateProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -4703,7 +4736,7 @@ export const MappingDoubleNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('double'),
@@ -4792,7 +4825,7 @@ export const MappingDynamicProperty = z.object({
   null_value: FieldValue.optional(),
   boost: double.optional(),
   coerce: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   ignore_malformed: z.boolean().optional(),
   time_series_metric: MappingTimeSeriesMetricType.optional(),
@@ -4956,7 +4989,7 @@ export const MappingFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('float'),
@@ -5030,7 +5063,7 @@ export const MappingGeoPointProperty = z.object({
   null_value: GeoLocation.optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   type: z.literal('geo_point'),
   time_series_metric: MappingGeoPointMetricType.optional()
 }).meta({ id: 'MappingGeoPointProperty' })
@@ -5114,7 +5147,7 @@ export const MappingHalfFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('half_float'),
@@ -5245,7 +5278,7 @@ export const MappingIntegerNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('integer'),
@@ -5319,7 +5352,7 @@ export const MappingIpProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   null_value: z.string().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('ip')
 }).meta({ id: 'MappingIpProperty' })
@@ -5419,7 +5452,7 @@ export const MappingKeywordProperty = z.object({
   eager_global_ordinals: z.boolean().optional(),
   index: z.boolean().optional(),
   index_options: MappingIndexOptions.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   normalizer: z.string().optional(),
   norms: z.boolean().optional(),
@@ -5467,7 +5500,7 @@ export const MappingLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('long'),
@@ -5784,7 +5817,7 @@ export const MappingScaledFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('scaled_float'),
@@ -5909,7 +5942,7 @@ export const MappingShortNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('short'),
@@ -6106,7 +6139,7 @@ export const MappingUnsignedLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('unsigned_long'),

--- a/packages/es-schemas/src/indices_migrate_reindex.ts
+++ b/packages/es-schemas/src/indices_migrate_reindex.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/indices_migrate_to_data_stream.ts
+++ b/packages/es-schemas/src/indices_migrate_to_data_stream.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/indices_modify_data_stream.ts
+++ b/packages/es-schemas/src/indices_modify_data_stream.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/indices_open.ts
+++ b/packages/es-schemas/src/indices_open.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/indices_promote_data_stream.ts
+++ b/packages/es-schemas/src/indices_promote_data_stream.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/indices_put_alias.ts
+++ b/packages/es-schemas/src/indices_put_alias.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),

--- a/packages/es-schemas/src/indices_put_data_lifecycle.ts
+++ b/packages/es-schemas/src/indices_put_data_lifecycle.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/indices_put_data_stream_mappings.ts
+++ b/packages/es-schemas/src/indices_put_data_stream_mappings.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4307,7 +4340,7 @@ export const MappingBooleanProperty = z.object({
   index: z.boolean().optional(),
   null_value: z.boolean().optional(),
   ignore_malformed: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('boolean')
@@ -4348,7 +4381,7 @@ export const MappingNumberPropertyBase = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional()
 }).meta({ id: 'MappingNumberPropertyBase' })
@@ -4390,7 +4423,7 @@ export const MappingByteNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('byte'),
@@ -4519,7 +4552,7 @@ export const MappingDateNanosProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -4564,7 +4597,7 @@ export const MappingDateProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -4703,7 +4736,7 @@ export const MappingDoubleNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('double'),
@@ -4792,7 +4825,7 @@ export const MappingDynamicProperty = z.object({
   null_value: FieldValue.optional(),
   boost: double.optional(),
   coerce: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   ignore_malformed: z.boolean().optional(),
   time_series_metric: MappingTimeSeriesMetricType.optional(),
@@ -4956,7 +4989,7 @@ export const MappingFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('float'),
@@ -5030,7 +5063,7 @@ export const MappingGeoPointProperty = z.object({
   null_value: GeoLocation.optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   type: z.literal('geo_point'),
   time_series_metric: MappingGeoPointMetricType.optional()
 }).meta({ id: 'MappingGeoPointProperty' })
@@ -5114,7 +5147,7 @@ export const MappingHalfFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('half_float'),
@@ -5245,7 +5278,7 @@ export const MappingIntegerNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('integer'),
@@ -5319,7 +5352,7 @@ export const MappingIpProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   null_value: z.string().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('ip')
 }).meta({ id: 'MappingIpProperty' })
@@ -5419,7 +5452,7 @@ export const MappingKeywordProperty = z.object({
   eager_global_ordinals: z.boolean().optional(),
   index: z.boolean().optional(),
   index_options: MappingIndexOptions.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   normalizer: z.string().optional(),
   norms: z.boolean().optional(),
@@ -5467,7 +5500,7 @@ export const MappingLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('long'),
@@ -5784,7 +5817,7 @@ export const MappingScaledFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('scaled_float'),
@@ -5909,7 +5942,7 @@ export const MappingShortNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('short'),
@@ -6106,7 +6139,7 @@ export const MappingUnsignedLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('unsigned_long'),

--- a/packages/es-schemas/src/indices_put_data_stream_options.ts
+++ b/packages/es-schemas/src/indices_put_data_stream_options.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/indices_put_data_stream_settings.ts
+++ b/packages/es-schemas/src/indices_put_data_stream_settings.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4583,7 +4616,7 @@ export const AnalysisConditionTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('condition'),
   filter: z.array(z.string()).describe('Array of token filters. If a token matches the predicate script in the `script` parameter, these filters are applied to the token in the order provided.'),
-  script: z.lazy(() => Script).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
 }).meta({ id: 'AnalysisConditionTokenFilter' })
 export type AnalysisConditionTokenFilter = z.infer<typeof AnalysisConditionTokenFilter>
 
@@ -5064,7 +5097,7 @@ export type AnalysisPorterStemTokenFilter = z.infer<typeof AnalysisPorterStemTok
 export const AnalysisPredicateTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('predicate_token_filter'),
-  script: z.lazy(() => Script).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
 }).meta({ id: 'AnalysisPredicateTokenFilter' })
 export type AnalysisPredicateTokenFilter = z.infer<typeof AnalysisPredicateTokenFilter>
 
@@ -5547,8 +5580,8 @@ export type IndicesSettingsSimilarityLmj = z.infer<typeof IndicesSettingsSimilar
 
 export const IndicesSettingsSimilarityScripted = z.object({
   type: z.literal('scripted'),
-  script: z.lazy(() => Script),
-  weight_script: z.lazy(() => Script).optional()
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]),
+  weight_script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).optional()
 }).meta({ id: 'IndicesSettingsSimilarityScripted' })
 export type IndicesSettingsSimilarityScripted = z.infer<typeof IndicesSettingsSimilarityScripted>
 

--- a/packages/es-schemas/src/indices_put_index_template.ts
+++ b/packages/es-schemas/src/indices_put_index_template.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4600,7 +4633,7 @@ export const AnalysisConditionTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('condition'),
   filter: z.array(z.string()).describe('Array of token filters. If a token matches the predicate script in the `script` parameter, these filters are applied to the token in the order provided.'),
-  script: z.lazy(() => Script).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
 }).meta({ id: 'AnalysisConditionTokenFilter' })
 export type AnalysisConditionTokenFilter = z.infer<typeof AnalysisConditionTokenFilter>
 
@@ -5081,7 +5114,7 @@ export type AnalysisPorterStemTokenFilter = z.infer<typeof AnalysisPorterStemTok
 export const AnalysisPredicateTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('predicate_token_filter'),
-  script: z.lazy(() => Script).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
 }).meta({ id: 'AnalysisPredicateTokenFilter' })
 export type AnalysisPredicateTokenFilter = z.infer<typeof AnalysisPredicateTokenFilter>
 
@@ -5630,7 +5663,7 @@ export const MappingBooleanProperty = z.object({
   index: z.boolean().optional(),
   null_value: z.boolean().optional(),
   ignore_malformed: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('boolean')
@@ -5671,7 +5704,7 @@ export const MappingNumberPropertyBase = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional()
 }).meta({ id: 'MappingNumberPropertyBase' })
@@ -5713,7 +5746,7 @@ export const MappingByteNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('byte'),
@@ -5842,7 +5875,7 @@ export const MappingDateNanosProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -5887,7 +5920,7 @@ export const MappingDateProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -6026,7 +6059,7 @@ export const MappingDoubleNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('double'),
@@ -6115,7 +6148,7 @@ export const MappingDynamicProperty = z.object({
   null_value: FieldValue.optional(),
   boost: double.optional(),
   coerce: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   ignore_malformed: z.boolean().optional(),
   time_series_metric: MappingTimeSeriesMetricType.optional(),
@@ -6279,7 +6312,7 @@ export const MappingFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('float'),
@@ -6353,7 +6386,7 @@ export const MappingGeoPointProperty = z.object({
   null_value: GeoLocation.optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   type: z.literal('geo_point'),
   time_series_metric: MappingGeoPointMetricType.optional()
 }).meta({ id: 'MappingGeoPointProperty' })
@@ -6437,7 +6470,7 @@ export const MappingHalfFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('half_float'),
@@ -6568,7 +6601,7 @@ export const MappingIntegerNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('integer'),
@@ -6642,7 +6675,7 @@ export const MappingIpProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   null_value: z.string().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('ip')
 }).meta({ id: 'MappingIpProperty' })
@@ -6742,7 +6775,7 @@ export const MappingKeywordProperty = z.object({
   eager_global_ordinals: z.boolean().optional(),
   index: z.boolean().optional(),
   index_options: MappingIndexOptions.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   normalizer: z.string().optional(),
   norms: z.boolean().optional(),
@@ -6790,7 +6823,7 @@ export const MappingLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('long'),
@@ -7107,7 +7140,7 @@ export const MappingScaledFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('scaled_float'),
@@ -7232,7 +7265,7 @@ export const MappingShortNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('short'),
@@ -7429,7 +7462,7 @@ export const MappingUnsignedLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('unsigned_long'),
@@ -7520,6 +7553,9 @@ export const IndicesDataStreamFailureStoreTemplate = z.object({
 }).meta({ id: 'IndicesDataStreamFailureStoreTemplate' })
 export type IndicesDataStreamFailureStoreTemplate = z.infer<typeof IndicesDataStreamFailureStoreTemplate>
 
+export const IndicesRetentionSource = z.enum(['data_stream_configuration', 'default_global_retention', 'max_global_retention', 'default_failures_retention']).meta({ id: 'IndicesRetentionSource' })
+export type IndicesRetentionSource = z.infer<typeof IndicesRetentionSource>
+
 export const IndicesDownsamplingRound = z.object({
   after: Duration.describe('The duration since rollover when this downsampling round should execute'),
   fixed_interval: DurationLarge.describe('The downsample interval.')
@@ -7532,6 +7568,8 @@ export type IndicesSamplingMethod = z.infer<typeof IndicesSamplingMethod>
 /** Data stream lifecycle denotes that a data stream is managed by the data stream lifecycle and contains the configuration. */
 export const IndicesDataStreamLifecycle = z.object({
   data_retention: Duration.describe('If defined, every document added to this data stream will be stored at least for this time frame. Any time after this duration the document could be deleted. When empty, every document in this data stream will be stored indefinitely.').optional(),
+  effective_retention: Duration.describe('The least amount of time data should be kept by elasticsearch.').optional(),
+  retention_determined_by: IndicesRetentionSource.describe('Configuration source that can influence the retention of a data stream.').optional(),
   downsampling: z.array(IndicesDownsamplingRound).describe('The list of downsampling rounds to execute as part of this downsampling configuration').optional(),
   downsampling_method: IndicesSamplingMethod.describe('The method used to downsample the data. There are two options `aggregate` and `last_value`. It requires `downsampling` to be defined. Defaults to `aggregate`.').optional(),
   enabled: z.boolean().describe('If defined, it turns data stream lifecycle on/off (`true`/`false`) for this data stream. A data stream lifecycle that\'s disabled (enabled: `false`) will have no effect on the data stream.').optional(),
@@ -7800,8 +7838,8 @@ export type IndicesSettingsSimilarityLmj = z.infer<typeof IndicesSettingsSimilar
 
 export const IndicesSettingsSimilarityScripted = z.object({
   type: z.literal('scripted'),
-  script: z.lazy(() => Script),
-  weight_script: z.lazy(() => Script).optional()
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]),
+  weight_script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).optional()
 }).meta({ id: 'IndicesSettingsSimilarityScripted' })
 export type IndicesSettingsSimilarityScripted = z.infer<typeof IndicesSettingsSimilarityScripted>
 

--- a/packages/es-schemas/src/indices_put_mapping.ts
+++ b/packages/es-schemas/src/indices_put_mapping.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4357,7 +4390,7 @@ export const MappingBooleanProperty = z.object({
   index: z.boolean().optional(),
   null_value: z.boolean().optional(),
   ignore_malformed: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('boolean')
@@ -4398,7 +4431,7 @@ export const MappingNumberPropertyBase = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional()
 }).meta({ id: 'MappingNumberPropertyBase' })
@@ -4440,7 +4473,7 @@ export const MappingByteNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('byte'),
@@ -4564,7 +4597,7 @@ export const MappingDateNanosProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -4609,7 +4642,7 @@ export const MappingDateProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -4748,7 +4781,7 @@ export const MappingDoubleNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('double'),
@@ -4837,7 +4870,7 @@ export const MappingDynamicProperty = z.object({
   null_value: FieldValue.optional(),
   boost: double.optional(),
   coerce: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   ignore_malformed: z.boolean().optional(),
   time_series_metric: MappingTimeSeriesMetricType.optional(),
@@ -5001,7 +5034,7 @@ export const MappingFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('float'),
@@ -5075,7 +5108,7 @@ export const MappingGeoPointProperty = z.object({
   null_value: GeoLocation.optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   type: z.literal('geo_point'),
   time_series_metric: MappingGeoPointMetricType.optional()
 }).meta({ id: 'MappingGeoPointProperty' })
@@ -5159,7 +5192,7 @@ export const MappingHalfFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('half_float'),
@@ -5285,7 +5318,7 @@ export const MappingIntegerNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('integer'),
@@ -5359,7 +5392,7 @@ export const MappingIpProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   null_value: z.string().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('ip')
 }).meta({ id: 'MappingIpProperty' })
@@ -5459,7 +5492,7 @@ export const MappingKeywordProperty = z.object({
   eager_global_ordinals: z.boolean().optional(),
   index: z.boolean().optional(),
   index_options: MappingIndexOptions.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   normalizer: z.string().optional(),
   norms: z.boolean().optional(),
@@ -5507,7 +5540,7 @@ export const MappingLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('long'),
@@ -5824,7 +5857,7 @@ export const MappingScaledFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('scaled_float'),
@@ -5949,7 +5982,7 @@ export const MappingShortNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('short'),
@@ -6120,7 +6153,7 @@ export const MappingUnsignedLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('unsigned_long'),

--- a/packages/es-schemas/src/indices_put_settings.ts
+++ b/packages/es-schemas/src/indices_put_settings.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4594,7 +4627,7 @@ export const AnalysisConditionTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('condition'),
   filter: z.array(z.string()).describe('Array of token filters. If a token matches the predicate script in the `script` parameter, these filters are applied to the token in the order provided.'),
-  script: z.lazy(() => Script).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
 }).meta({ id: 'AnalysisConditionTokenFilter' })
 export type AnalysisConditionTokenFilter = z.infer<typeof AnalysisConditionTokenFilter>
 
@@ -5075,7 +5108,7 @@ export type AnalysisPorterStemTokenFilter = z.infer<typeof AnalysisPorterStemTok
 export const AnalysisPredicateTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('predicate_token_filter'),
-  script: z.lazy(() => Script).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
 }).meta({ id: 'AnalysisPredicateTokenFilter' })
 export type AnalysisPredicateTokenFilter = z.infer<typeof AnalysisPredicateTokenFilter>
 
@@ -5558,8 +5591,8 @@ export type IndicesSettingsSimilarityLmj = z.infer<typeof IndicesSettingsSimilar
 
 export const IndicesSettingsSimilarityScripted = z.object({
   type: z.literal('scripted'),
-  script: z.lazy(() => Script),
-  weight_script: z.lazy(() => Script).optional()
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]),
+  weight_script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).optional()
 }).meta({ id: 'IndicesSettingsSimilarityScripted' })
 export type IndicesSettingsSimilarityScripted = z.infer<typeof IndicesSettingsSimilarityScripted>
 

--- a/packages/es-schemas/src/indices_put_template.ts
+++ b/packages/es-schemas/src/indices_put_template.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4597,7 +4630,7 @@ export const AnalysisConditionTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('condition'),
   filter: z.array(z.string()).describe('Array of token filters. If a token matches the predicate script in the `script` parameter, these filters are applied to the token in the order provided.'),
-  script: z.lazy(() => Script).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
 }).meta({ id: 'AnalysisConditionTokenFilter' })
 export type AnalysisConditionTokenFilter = z.infer<typeof AnalysisConditionTokenFilter>
 
@@ -5078,7 +5111,7 @@ export type AnalysisPorterStemTokenFilter = z.infer<typeof AnalysisPorterStemTok
 export const AnalysisPredicateTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('predicate_token_filter'),
-  script: z.lazy(() => Script).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
 }).meta({ id: 'AnalysisPredicateTokenFilter' })
 export type AnalysisPredicateTokenFilter = z.infer<typeof AnalysisPredicateTokenFilter>
 
@@ -5627,7 +5660,7 @@ export const MappingBooleanProperty = z.object({
   index: z.boolean().optional(),
   null_value: z.boolean().optional(),
   ignore_malformed: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('boolean')
@@ -5668,7 +5701,7 @@ export const MappingNumberPropertyBase = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional()
 }).meta({ id: 'MappingNumberPropertyBase' })
@@ -5710,7 +5743,7 @@ export const MappingByteNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('byte'),
@@ -5839,7 +5872,7 @@ export const MappingDateNanosProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -5884,7 +5917,7 @@ export const MappingDateProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -6023,7 +6056,7 @@ export const MappingDoubleNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('double'),
@@ -6112,7 +6145,7 @@ export const MappingDynamicProperty = z.object({
   null_value: FieldValue.optional(),
   boost: double.optional(),
   coerce: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   ignore_malformed: z.boolean().optional(),
   time_series_metric: MappingTimeSeriesMetricType.optional(),
@@ -6276,7 +6309,7 @@ export const MappingFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('float'),
@@ -6350,7 +6383,7 @@ export const MappingGeoPointProperty = z.object({
   null_value: GeoLocation.optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   type: z.literal('geo_point'),
   time_series_metric: MappingGeoPointMetricType.optional()
 }).meta({ id: 'MappingGeoPointProperty' })
@@ -6434,7 +6467,7 @@ export const MappingHalfFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('half_float'),
@@ -6565,7 +6598,7 @@ export const MappingIntegerNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('integer'),
@@ -6639,7 +6672,7 @@ export const MappingIpProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   null_value: z.string().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('ip')
 }).meta({ id: 'MappingIpProperty' })
@@ -6739,7 +6772,7 @@ export const MappingKeywordProperty = z.object({
   eager_global_ordinals: z.boolean().optional(),
   index: z.boolean().optional(),
   index_options: MappingIndexOptions.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   normalizer: z.string().optional(),
   norms: z.boolean().optional(),
@@ -6787,7 +6820,7 @@ export const MappingLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('long'),
@@ -7104,7 +7137,7 @@ export const MappingScaledFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('scaled_float'),
@@ -7229,7 +7262,7 @@ export const MappingShortNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('short'),
@@ -7426,7 +7459,7 @@ export const MappingUnsignedLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('unsigned_long'),
@@ -7751,8 +7784,8 @@ export type IndicesSettingsSimilarityLmj = z.infer<typeof IndicesSettingsSimilar
 
 export const IndicesSettingsSimilarityScripted = z.object({
   type: z.literal('scripted'),
-  script: z.lazy(() => Script),
-  weight_script: z.lazy(() => Script).optional()
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]),
+  weight_script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).optional()
 }).meta({ id: 'IndicesSettingsSimilarityScripted' })
 export type IndicesSettingsSimilarityScripted = z.infer<typeof IndicesSettingsSimilarityScripted>
 

--- a/packages/es-schemas/src/indices_recovery.ts
+++ b/packages/es-schemas/src/indices_recovery.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/indices_refresh.ts
+++ b/packages/es-schemas/src/indices_refresh.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/indices_reload_search_analyzers.ts
+++ b/packages/es-schemas/src/indices_reload_search_analyzers.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/indices_remove_block.ts
+++ b/packages/es-schemas/src/indices_remove_block.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/indices_resolve_cluster.ts
+++ b/packages/es-schemas/src/indices_resolve_cluster.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/indices_resolve_index.ts
+++ b/packages/es-schemas/src/indices_resolve_index.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/indices_rollover.ts
+++ b/packages/es-schemas/src/indices_rollover.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4319,7 +4352,7 @@ export const MappingBooleanProperty = z.object({
   index: z.boolean().optional(),
   null_value: z.boolean().optional(),
   ignore_malformed: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('boolean')
@@ -4360,7 +4393,7 @@ export const MappingNumberPropertyBase = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional()
 }).meta({ id: 'MappingNumberPropertyBase' })
@@ -4402,7 +4435,7 @@ export const MappingByteNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('byte'),
@@ -4531,7 +4564,7 @@ export const MappingDateNanosProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -4576,7 +4609,7 @@ export const MappingDateProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -4715,7 +4748,7 @@ export const MappingDoubleNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('double'),
@@ -4804,7 +4837,7 @@ export const MappingDynamicProperty = z.object({
   null_value: FieldValue.optional(),
   boost: double.optional(),
   coerce: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   ignore_malformed: z.boolean().optional(),
   time_series_metric: MappingTimeSeriesMetricType.optional(),
@@ -4968,7 +5001,7 @@ export const MappingFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('float'),
@@ -5042,7 +5075,7 @@ export const MappingGeoPointProperty = z.object({
   null_value: GeoLocation.optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   type: z.literal('geo_point'),
   time_series_metric: MappingGeoPointMetricType.optional()
 }).meta({ id: 'MappingGeoPointProperty' })
@@ -5126,7 +5159,7 @@ export const MappingHalfFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('half_float'),
@@ -5257,7 +5290,7 @@ export const MappingIntegerNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('integer'),
@@ -5331,7 +5364,7 @@ export const MappingIpProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   null_value: z.string().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('ip')
 }).meta({ id: 'MappingIpProperty' })
@@ -5431,7 +5464,7 @@ export const MappingKeywordProperty = z.object({
   eager_global_ordinals: z.boolean().optional(),
   index: z.boolean().optional(),
   index_options: MappingIndexOptions.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   normalizer: z.string().optional(),
   norms: z.boolean().optional(),
@@ -5479,7 +5512,7 @@ export const MappingLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('long'),
@@ -5796,7 +5829,7 @@ export const MappingScaledFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('scaled_float'),
@@ -5921,7 +5954,7 @@ export const MappingShortNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('short'),
@@ -6118,7 +6151,7 @@ export const MappingUnsignedLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('unsigned_long'),

--- a/packages/es-schemas/src/indices_segments.ts
+++ b/packages/es-schemas/src/indices_segments.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/indices_shard_stores.ts
+++ b/packages/es-schemas/src/indices_shard_stores.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/indices_shrink.ts
+++ b/packages/es-schemas/src/indices_shrink.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),

--- a/packages/es-schemas/src/indices_simulate_index_template.ts
+++ b/packages/es-schemas/src/indices_simulate_index_template.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4595,7 +4628,7 @@ export const AnalysisConditionTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('condition'),
   filter: z.array(z.string()).describe('Array of token filters. If a token matches the predicate script in the `script` parameter, these filters are applied to the token in the order provided.'),
-  script: z.lazy(() => Script).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
 }).meta({ id: 'AnalysisConditionTokenFilter' })
 export type AnalysisConditionTokenFilter = z.infer<typeof AnalysisConditionTokenFilter>
 
@@ -5076,7 +5109,7 @@ export type AnalysisPorterStemTokenFilter = z.infer<typeof AnalysisPorterStemTok
 export const AnalysisPredicateTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('predicate_token_filter'),
-  script: z.lazy(() => Script).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
 }).meta({ id: 'AnalysisPredicateTokenFilter' })
 export type AnalysisPredicateTokenFilter = z.infer<typeof AnalysisPredicateTokenFilter>
 
@@ -5625,7 +5658,7 @@ export const MappingBooleanProperty = z.object({
   index: z.boolean().optional(),
   null_value: z.boolean().optional(),
   ignore_malformed: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('boolean')
@@ -5666,7 +5699,7 @@ export const MappingNumberPropertyBase = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional()
 }).meta({ id: 'MappingNumberPropertyBase' })
@@ -5708,7 +5741,7 @@ export const MappingByteNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('byte'),
@@ -5837,7 +5870,7 @@ export const MappingDateNanosProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -5882,7 +5915,7 @@ export const MappingDateProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -6021,7 +6054,7 @@ export const MappingDoubleNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('double'),
@@ -6110,7 +6143,7 @@ export const MappingDynamicProperty = z.object({
   null_value: FieldValue.optional(),
   boost: double.optional(),
   coerce: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   ignore_malformed: z.boolean().optional(),
   time_series_metric: MappingTimeSeriesMetricType.optional(),
@@ -6274,7 +6307,7 @@ export const MappingFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('float'),
@@ -6348,7 +6381,7 @@ export const MappingGeoPointProperty = z.object({
   null_value: GeoLocation.optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   type: z.literal('geo_point'),
   time_series_metric: MappingGeoPointMetricType.optional()
 }).meta({ id: 'MappingGeoPointProperty' })
@@ -6432,7 +6465,7 @@ export const MappingHalfFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('half_float'),
@@ -6563,7 +6596,7 @@ export const MappingIntegerNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('integer'),
@@ -6637,7 +6670,7 @@ export const MappingIpProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   null_value: z.string().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('ip')
 }).meta({ id: 'MappingIpProperty' })
@@ -6737,7 +6770,7 @@ export const MappingKeywordProperty = z.object({
   eager_global_ordinals: z.boolean().optional(),
   index: z.boolean().optional(),
   index_options: MappingIndexOptions.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   normalizer: z.string().optional(),
   norms: z.boolean().optional(),
@@ -6785,7 +6818,7 @@ export const MappingLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('long'),
@@ -7102,7 +7135,7 @@ export const MappingScaledFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('scaled_float'),
@@ -7227,7 +7260,7 @@ export const MappingShortNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('short'),
@@ -7424,7 +7457,7 @@ export const MappingUnsignedLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('unsigned_long'),
@@ -7515,6 +7548,9 @@ export const IndicesDataStreamFailureStore = z.object({
 }).meta({ id: 'IndicesDataStreamFailureStore' })
 export type IndicesDataStreamFailureStore = z.infer<typeof IndicesDataStreamFailureStore>
 
+export const IndicesRetentionSource = z.enum(['data_stream_configuration', 'default_global_retention', 'max_global_retention', 'default_failures_retention']).meta({ id: 'IndicesRetentionSource' })
+export type IndicesRetentionSource = z.infer<typeof IndicesRetentionSource>
+
 export const IndicesDownsamplingRound = z.object({
   after: Duration.describe('The duration since rollover when this downsampling round should execute'),
   fixed_interval: DurationLarge.describe('The downsample interval.')
@@ -7527,6 +7563,8 @@ export type IndicesSamplingMethod = z.infer<typeof IndicesSamplingMethod>
 /** Data stream lifecycle denotes that a data stream is managed by the data stream lifecycle and contains the configuration. */
 export const IndicesDataStreamLifecycle = z.object({
   data_retention: Duration.describe('If defined, every document added to this data stream will be stored at least for this time frame. Any time after this duration the document could be deleted. When empty, every document in this data stream will be stored indefinitely.').optional(),
+  effective_retention: Duration.describe('The least amount of time data should be kept by elasticsearch.').optional(),
+  retention_determined_by: IndicesRetentionSource.describe('Configuration source that can influence the retention of a data stream.').optional(),
   downsampling: z.array(IndicesDownsamplingRound).describe('The list of downsampling rounds to execute as part of this downsampling configuration').optional(),
   downsampling_method: IndicesSamplingMethod.describe('The method used to downsample the data. There are two options `aggregate` and `last_value`. It requires `downsampling` to be defined. Defaults to `aggregate`.').optional(),
   enabled: z.boolean().describe('If defined, it turns data stream lifecycle on/off (`true`/`false`) for this data stream. A data stream lifecycle that\'s disabled (enabled: `false`) will have no effect on the data stream.').optional(),
@@ -7791,8 +7829,8 @@ export type IndicesSettingsSimilarityLmj = z.infer<typeof IndicesSettingsSimilar
 
 export const IndicesSettingsSimilarityScripted = z.object({
   type: z.literal('scripted'),
-  script: z.lazy(() => Script),
-  weight_script: z.lazy(() => Script).optional()
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]),
+  weight_script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).optional()
 }).meta({ id: 'IndicesSettingsSimilarityScripted' })
 export type IndicesSettingsSimilarityScripted = z.infer<typeof IndicesSettingsSimilarityScripted>
 

--- a/packages/es-schemas/src/indices_simulate_template.ts
+++ b/packages/es-schemas/src/indices_simulate_template.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4595,7 +4628,7 @@ export const AnalysisConditionTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('condition'),
   filter: z.array(z.string()).describe('Array of token filters. If a token matches the predicate script in the `script` parameter, these filters are applied to the token in the order provided.'),
-  script: z.lazy(() => Script).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
 }).meta({ id: 'AnalysisConditionTokenFilter' })
 export type AnalysisConditionTokenFilter = z.infer<typeof AnalysisConditionTokenFilter>
 
@@ -5076,7 +5109,7 @@ export type AnalysisPorterStemTokenFilter = z.infer<typeof AnalysisPorterStemTok
 export const AnalysisPredicateTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('predicate_token_filter'),
-  script: z.lazy(() => Script).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
 }).meta({ id: 'AnalysisPredicateTokenFilter' })
 export type AnalysisPredicateTokenFilter = z.infer<typeof AnalysisPredicateTokenFilter>
 
@@ -5625,7 +5658,7 @@ export const MappingBooleanProperty = z.object({
   index: z.boolean().optional(),
   null_value: z.boolean().optional(),
   ignore_malformed: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('boolean')
@@ -5666,7 +5699,7 @@ export const MappingNumberPropertyBase = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional()
 }).meta({ id: 'MappingNumberPropertyBase' })
@@ -5708,7 +5741,7 @@ export const MappingByteNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('byte'),
@@ -5837,7 +5870,7 @@ export const MappingDateNanosProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -5882,7 +5915,7 @@ export const MappingDateProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -6021,7 +6054,7 @@ export const MappingDoubleNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('double'),
@@ -6110,7 +6143,7 @@ export const MappingDynamicProperty = z.object({
   null_value: FieldValue.optional(),
   boost: double.optional(),
   coerce: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   ignore_malformed: z.boolean().optional(),
   time_series_metric: MappingTimeSeriesMetricType.optional(),
@@ -6274,7 +6307,7 @@ export const MappingFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('float'),
@@ -6348,7 +6381,7 @@ export const MappingGeoPointProperty = z.object({
   null_value: GeoLocation.optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   type: z.literal('geo_point'),
   time_series_metric: MappingGeoPointMetricType.optional()
 }).meta({ id: 'MappingGeoPointProperty' })
@@ -6432,7 +6465,7 @@ export const MappingHalfFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('half_float'),
@@ -6563,7 +6596,7 @@ export const MappingIntegerNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('integer'),
@@ -6637,7 +6670,7 @@ export const MappingIpProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   null_value: z.string().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('ip')
 }).meta({ id: 'MappingIpProperty' })
@@ -6737,7 +6770,7 @@ export const MappingKeywordProperty = z.object({
   eager_global_ordinals: z.boolean().optional(),
   index: z.boolean().optional(),
   index_options: MappingIndexOptions.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   normalizer: z.string().optional(),
   norms: z.boolean().optional(),
@@ -6785,7 +6818,7 @@ export const MappingLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('long'),
@@ -7102,7 +7135,7 @@ export const MappingScaledFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('scaled_float'),
@@ -7227,7 +7260,7 @@ export const MappingShortNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('short'),
@@ -7424,7 +7457,7 @@ export const MappingUnsignedLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('unsigned_long'),
@@ -7515,6 +7548,9 @@ export const IndicesDataStreamFailureStoreTemplate = z.object({
 }).meta({ id: 'IndicesDataStreamFailureStoreTemplate' })
 export type IndicesDataStreamFailureStoreTemplate = z.infer<typeof IndicesDataStreamFailureStoreTemplate>
 
+export const IndicesRetentionSource = z.enum(['data_stream_configuration', 'default_global_retention', 'max_global_retention', 'default_failures_retention']).meta({ id: 'IndicesRetentionSource' })
+export type IndicesRetentionSource = z.infer<typeof IndicesRetentionSource>
+
 export const IndicesDownsamplingRound = z.object({
   after: Duration.describe('The duration since rollover when this downsampling round should execute'),
   fixed_interval: DurationLarge.describe('The downsample interval.')
@@ -7527,6 +7563,8 @@ export type IndicesSamplingMethod = z.infer<typeof IndicesSamplingMethod>
 /** Data stream lifecycle denotes that a data stream is managed by the data stream lifecycle and contains the configuration. */
 export const IndicesDataStreamLifecycle = z.object({
   data_retention: Duration.describe('If defined, every document added to this data stream will be stored at least for this time frame. Any time after this duration the document could be deleted. When empty, every document in this data stream will be stored indefinitely.').optional(),
+  effective_retention: Duration.describe('The least amount of time data should be kept by elasticsearch.').optional(),
+  retention_determined_by: IndicesRetentionSource.describe('Configuration source that can influence the retention of a data stream.').optional(),
   downsampling: z.array(IndicesDownsamplingRound).describe('The list of downsampling rounds to execute as part of this downsampling configuration').optional(),
   downsampling_method: IndicesSamplingMethod.describe('The method used to downsample the data. There are two options `aggregate` and `last_value`. It requires `downsampling` to be defined. Defaults to `aggregate`.').optional(),
   enabled: z.boolean().describe('If defined, it turns data stream lifecycle on/off (`true`/`false`) for this data stream. A data stream lifecycle that\'s disabled (enabled: `false`) will have no effect on the data stream.').optional(),
@@ -7795,8 +7833,8 @@ export type IndicesSettingsSimilarityLmj = z.infer<typeof IndicesSettingsSimilar
 
 export const IndicesSettingsSimilarityScripted = z.object({
   type: z.literal('scripted'),
-  script: z.lazy(() => Script),
-  weight_script: z.lazy(() => Script).optional()
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]),
+  weight_script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).optional()
 }).meta({ id: 'IndicesSettingsSimilarityScripted' })
 export type IndicesSettingsSimilarityScripted = z.infer<typeof IndicesSettingsSimilarityScripted>
 

--- a/packages/es-schemas/src/indices_split.ts
+++ b/packages/es-schemas/src/indices_split.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4011,6 +4044,7 @@ export type IndicesAlias = z.infer<typeof IndicesAlias>
  * * The target index must not exist.
  * * The source index must have fewer primary shards than the target index.
  * * The number of primary shards in the target index must be a multiple of the number of primary shards in the source index.
+ * * The number of primary shards in the target index must be a divisor of the source index's `index.number_of_routing_shards`.
  * * The node handling the split process must have sufficient free disk space to accommodate a second copy of the existing index.
  */
 export const IndicesSplitRequest = z.object({

--- a/packages/es-schemas/src/indices_stats.ts
+++ b/packages/es-schemas/src/indices_stats.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/indices_update_aliases.ts
+++ b/packages/es-schemas/src/indices_update_aliases.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),

--- a/packages/es-schemas/src/indices_validate_query.ts
+++ b/packages/es-schemas/src/indices_validate_query.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),

--- a/packages/es-schemas/src/inference_chat_completion_unified.ts
+++ b/packages/es-schemas/src/inference_chat_completion_unified.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/inference_completion.ts
+++ b/packages/es-schemas/src/inference_completion.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/inference_delete.ts
+++ b/packages/es-schemas/src/inference_delete.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/inference_embedding.ts
+++ b/packages/es-schemas/src/inference_embedding.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -65,20 +66,24 @@ export type InferenceDenseEmbeddingResult = z.infer<typeof InferenceDenseEmbeddi
 export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
 export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
 
-export const InferenceEmbeddingContentType = z.enum(['text', 'image']).meta({ id: 'InferenceEmbeddingContentType' })
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
 export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
 
-/** An object containing the input data for the model to embed. */
-export const InferenceEmbeddingContentObjectContents = z.object({
-  type: InferenceEmbeddingContentType.describe('The type of input to embed.'),
-  format: InferenceEmbeddingContentFormat.describe('The format of the input. For the `text` type this must be `text`. For the `image` type, this must be `base64`. If not specified, this will default to `text` for the `text` type and `base64` for the `image` type.').optional(),
+/** An object containing the input data for a single item for the model to embed. */
+export const InferenceEmbeddingContentObjectItem = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of input to embed. Not all models support all input types.'),
+  format: InferenceEmbeddingContentFormat.describe('The format of the input. For the `text` type this must be `text`. For all other types, this must be `base64`. If not specified, this will default to `text` for the `text` type and `base64` for all other types.').optional(),
   value: z.string().describe('The value of the input to embed. For images, this must be a base64-encoded data URI, i.e. "data:content/type;base64,..."')
-}).meta({ id: 'InferenceEmbeddingContentObjectContents' })
-export type InferenceEmbeddingContentObjectContents = z.infer<typeof InferenceEmbeddingContentObjectContents>
+}).meta({ id: 'InferenceEmbeddingContentObjectItem' })
+export type InferenceEmbeddingContentObjectItem = z.infer<typeof InferenceEmbeddingContentObjectItem>
+
+/** Allows specifying one or multiple items for the `embedding` task, which should result in a single embedding vector. */
+export const InferenceEmbeddingContentObjectGroup = z.union([InferenceEmbeddingContentObjectItem, z.array(InferenceEmbeddingContentObjectItem)]).meta({ id: 'InferenceEmbeddingContentObjectGroup' })
+export type InferenceEmbeddingContentObjectGroup = z.infer<typeof InferenceEmbeddingContentObjectGroup>
 
 /** A wrapper object which contains the fields required to specify multimodal inputs */
 export const InferenceEmbeddingContentObject = z.object({
-  content: InferenceEmbeddingContentObjectContents.describe('An object containing the input data for the model to embed')
+  content: InferenceEmbeddingContentObjectGroup.describe('An object or an array of objects containing the input data for the model to embed')
 }).meta({ id: 'InferenceEmbeddingContentObject' })
 export type InferenceEmbeddingContentObject = z.infer<typeof InferenceEmbeddingContentObject>
 
@@ -107,7 +112,7 @@ export const InferenceTaskSettings = z.any().meta({ id: 'InferenceTaskSettings' 
 export type InferenceTaskSettings = z.infer<typeof InferenceTaskSettings>
 
 export const InferenceRequestEmbedding = z.object({
-  input: InferenceEmbeddingInput.describe('Inference input. Either a string, an array of strings, a `content` object, or an array of `content` objects. string example: ``` "input": "Some text" ``` string array example: ``` "input": ["Some text", "Some more text"] ``` `content` object example: ``` "input": {     "content": {       "type": "image",       "format": "base64",       "value": "data:image/jpeg;base64,..."     }   } ``` `content` object array example: ``` "input": [   {     "content": {       "type": "text",       "format": "text",       "value": "Some text to generate an embedding"     }   },   {     "content": {       "type": "image",       "format": "base64",       "value": "data:image/jpeg;base64,..."     }   } ] ```'),
+  input: InferenceEmbeddingInput.describe('Inference input. Either a string, an array of strings, a `content` object, or an array of `content` objects. `content` objects may contain a single item or an array of items. Models that support multiple items per `content` object will return a single embedding for each `content` object, regardless of how many items it contains. string example: ``` "input": "Some text" ``` string array example: ``` "input": ["Some text", "Some more text"] ``` `content` object example: ``` "input": {     "content": {       "type": "image",       "format": "base64",       "value": "data:image/jpeg;base64,..."     }   } ``` `content` object array example: ``` "input": [   {     "content": {       "type": "text",       "format": "text",       "value": "Some text to generate an embedding"     }   },   {     "content": {       "type": "image",       "format": "base64",       "value": "data:image/jpeg;base64,..."     }   } ] ``` Multiple items in one `content` object example: ``` "input": [   {     "content": [       {         "type": "image",         "format": "base64",         "value": "data:image/jpeg;base64,..."       },       {         "type": "text",         "value": "Some text to create an embedding"       }     ]   } ] ```'),
   input_type: z.string().describe('The input data type for the embedding model. Possible values include: * `SEARCH` * `INGEST` * `CLASSIFICATION` * `CLUSTERING` Not all models support all values. Unsupported values will trigger a validation exception. Accepted values depend on the configured inference service, refer to the relevant service-specific documentation for more info. > info > The `input_type` parameter specified on the root level of the request body will take precedence over the `input_type` parameter specified in `task_settings`.').optional(),
   task_settings: InferenceTaskSettings.describe('Task settings for the individual inference request. These settings are specific to the <task_type> you specified and override the task settings specified when initializing the service.').optional()
 }).meta({ id: 'InferenceRequestEmbedding' })

--- a/packages/es-schemas/src/inference_get.ts
+++ b/packages/es-schemas/src/inference_get.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/inference_inference.ts
+++ b/packages/es-schemas/src/inference_inference.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/inference_put.ts
+++ b/packages/es-schemas/src/inference_put.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/inference_put_ai21.ts
+++ b/packages/es-schemas/src/inference_put_ai21.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/inference_put_alibabacloud.ts
+++ b/packages/es-schemas/src/inference_put_alibabacloud.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/inference_put_amazonbedrock.ts
+++ b/packages/es-schemas/src/inference_put_amazonbedrock.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/inference_put_amazonsagemaker.ts
+++ b/packages/es-schemas/src/inference_put_amazonsagemaker.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/inference_put_anthropic.ts
+++ b/packages/es-schemas/src/inference_put_anthropic.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/inference_put_azureaistudio.ts
+++ b/packages/es-schemas/src/inference_put_azureaistudio.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/inference_put_azureopenai.ts
+++ b/packages/es-schemas/src/inference_put_azureopenai.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/inference_put_cohere.ts
+++ b/packages/es-schemas/src/inference_put_cohere.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/inference_put_contextualai.ts
+++ b/packages/es-schemas/src/inference_put_contextualai.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/inference_put_custom.ts
+++ b/packages/es-schemas/src/inference_put_custom.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/inference_put_deepseek.ts
+++ b/packages/es-schemas/src/inference_put_deepseek.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/inference_put_elasticsearch.ts
+++ b/packages/es-schemas/src/inference_put_elasticsearch.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/inference_put_elser.ts
+++ b/packages/es-schemas/src/inference_put_elser.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/inference_put_fireworksai.ts
+++ b/packages/es-schemas/src/inference_put_fireworksai.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/inference_put_googleaistudio.ts
+++ b/packages/es-schemas/src/inference_put_googleaistudio.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/inference_put_googlevertexai.ts
+++ b/packages/es-schemas/src/inference_put_googlevertexai.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/inference_put_groq.ts
+++ b/packages/es-schemas/src/inference_put_groq.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/inference_put_hugging_face.ts
+++ b/packages/es-schemas/src/inference_put_hugging_face.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/inference_put_jinaai.ts
+++ b/packages/es-schemas/src/inference_put_jinaai.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/inference_put_llama.ts
+++ b/packages/es-schemas/src/inference_put_llama.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/inference_put_mistral.ts
+++ b/packages/es-schemas/src/inference_put_mistral.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/inference_put_nvidia.ts
+++ b/packages/es-schemas/src/inference_put_nvidia.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/inference_put_openai.ts
+++ b/packages/es-schemas/src/inference_put_openai.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -59,7 +60,7 @@ export const InferenceInferenceEndpoint = z.object({
 }).meta({ id: 'InferenceInferenceEndpoint' })
 export type InferenceInferenceEndpoint = z.infer<typeof InferenceInferenceEndpoint>
 
-export const InferenceTaskTypeOpenAI = z.enum(['text_embedding', 'chat_completion', 'completion']).meta({ id: 'InferenceTaskTypeOpenAI' })
+export const InferenceTaskTypeOpenAI = z.enum(['text_embedding', 'chat_completion', 'completion', 'embedding']).meta({ id: 'InferenceTaskTypeOpenAI' })
 export type InferenceTaskTypeOpenAI = z.infer<typeof InferenceTaskTypeOpenAI>
 
 export const InferenceInferenceEndpointInfoOpenAI = z.object({
@@ -80,12 +81,12 @@ export type InferenceOpenAISimilarityType = z.infer<typeof InferenceOpenAISimila
 
 export const InferenceOpenAIServiceSettings = z.object({
   api_key: z.string().describe('A valid API key of your OpenAI account. You can find your OpenAI API keys in your OpenAI account under the API keys section. IMPORTANT: You need to provide the API key only once, during the inference model creation. The get inference endpoint API does not retrieve your API key.'),
-  dimensions: integer.describe('The number of dimensions the resulting output embeddings should have. It is supported only in `text-embedding-3` and later models. If it is not set, the OpenAI defined default for the model is used.').optional(),
+  dimensions: integer.describe('For a `text_embedding` or `embedding` task, the number of dimensions the resulting output embeddings should have. It is supported only in `text-embedding-3` and later models. If it is not set, the OpenAI defined default for the model is used.').optional(),
   model_id: z.string().describe('The name of the model to use for the inference task. Refer to the OpenAI documentation for the list of available text embedding models.'),
   organization_id: z.string().describe('The unique identifier for your organization. You can find the Organization ID in your OpenAI account under *Settings > Organizations*.').optional(),
-  rate_limit: InferenceRateLimitSetting.describe('This setting helps to minimize the number of rate limit errors returned from OpenAI. The `openai` service sets a default number of requests allowed per minute depending on the task type. For `text_embedding`, it is set to `3000`. For `completion`, it is set to `500`.').optional(),
-  similarity: InferenceOpenAISimilarityType.describe('For a `text_embedding` task, the similarity measure. One of cosine, dot_product, l2_norm. Defaults to `dot_product`.').optional(),
-  url: z.string().describe('The URL endpoint to use for the requests. It can be changed for testing purposes.').optional()
+  rate_limit: InferenceRateLimitSetting.describe('This setting helps to minimize the number of rate limit errors returned from OpenAI. The `openai` service sets a default number of requests allowed per minute depending on the task type. For `text_embedding` and `embedding`, it is set to `3000`. For `completion` and `chat_completion`, it is set to `500`.').optional(),
+  similarity: InferenceOpenAISimilarityType.describe('For a `text_embedding` or `embedding` task, the similarity measure. One of `cosine`, `dot_product`, `l2_norm`. Defaults to `dot_product`.').optional(),
+  url: z.string().describe('The URL endpoint to use for the requests. It can be changed for testing purposes. Default value is `https://api.openai.com/v1/embeddings` for a `text_embedding` or `embedding` task, `https://api.openai.com/v1/chat/completions` for a `completion` or `chat_completion` task.').optional()
 }).meta({ id: 'InferenceOpenAIServiceSettings' })
 export type InferenceOpenAIServiceSettings = z.infer<typeof InferenceOpenAIServiceSettings>
 
@@ -98,7 +99,7 @@ export const InferenceOpenAITaskSettings = z.object({
 }).meta({ id: 'InferenceOpenAITaskSettings' })
 export type InferenceOpenAITaskSettings = z.infer<typeof InferenceOpenAITaskSettings>
 
-export const InferenceOpenAITaskType = z.enum(['chat_completion', 'completion', 'text_embedding']).meta({ id: 'InferenceOpenAITaskType' })
+export const InferenceOpenAITaskType = z.enum(['chat_completion', 'completion', 'text_embedding', 'embedding']).meta({ id: 'InferenceOpenAITaskType' })
 export type InferenceOpenAITaskType = z.infer<typeof InferenceOpenAITaskType>
 
 /**

--- a/packages/es-schemas/src/inference_put_openshift_ai.ts
+++ b/packages/es-schemas/src/inference_put_openshift_ai.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/inference_put_voyageai.ts
+++ b/packages/es-schemas/src/inference_put_voyageai.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/inference_put_watsonx.ts
+++ b/packages/es-schemas/src/inference_put_watsonx.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/inference_rerank.ts
+++ b/packages/es-schemas/src/inference_rerank.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/inference_sparse_embedding.ts
+++ b/packages/es-schemas/src/inference_sparse_embedding.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/inference_stream_completion.ts
+++ b/packages/es-schemas/src/inference_stream_completion.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/inference_text_embedding.ts
+++ b/packages/es-schemas/src/inference_text_embedding.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/inference_update.ts
+++ b/packages/es-schemas/src/inference_update.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/info.ts
+++ b/packages/es-schemas/src/info.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ingest_delete_geoip_database.ts
+++ b/packages/es-schemas/src/ingest_delete_geoip_database.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ingest_delete_ip_location_database.ts
+++ b/packages/es-schemas/src/ingest_delete_ip_location_database.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ingest_delete_pipeline.ts
+++ b/packages/es-schemas/src/ingest_delete_pipeline.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ingest_geo_ip_stats.ts
+++ b/packages/es-schemas/src/ingest_geo_ip_stats.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ingest_get_geoip_database.ts
+++ b/packages/es-schemas/src/ingest_get_geoip_database.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ingest_get_ip_location_database.ts
+++ b/packages/es-schemas/src/ingest_get_ip_location_database.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ingest_get_pipeline.ts
+++ b/packages/es-schemas/src/ingest_get_pipeline.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -3956,6 +3989,9 @@ export const SearchFieldCollapse = z.object({
   get collapse () { return SearchFieldCollapse.optional() }
 }).meta({ id: 'SearchFieldCollapse' })
 export type SearchFieldCollapse = z.infer<typeof SearchFieldCollapse>
+
+export const ByteSize = z.union([long, z.string()]).meta({ id: 'ByteSize' })
+export type ByteSize = z.infer<typeof ByteSize>
 
 export const GeoShapeRelation = z.enum(['intersects', 'disjoint', 'within', 'contains']).meta({ id: 'GeoShapeRelation' })
 export type GeoShapeRelation = z.infer<typeof GeoShapeRelation>
@@ -4076,7 +4112,7 @@ export interface IngestProcessorBaseShape {
 }
 export const IngestProcessorBase = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional()
@@ -4098,7 +4134,7 @@ export interface IngestAppendProcessorShape {
 }
 export const IngestAppendProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4121,6 +4157,7 @@ export interface IngestAttachmentProcessorShape {
   ignore_missing?: boolean | undefined
   indexed_chars?: long | undefined
   indexed_chars_field?: Field | undefined
+  max_field_bytes?: ByteSize | undefined
   properties?: string[] | undefined
   target_field?: Field | undefined
   remove_binary?: boolean | undefined
@@ -4128,7 +4165,7 @@ export interface IngestAttachmentProcessorShape {
 }
 export const IngestAttachmentProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4136,6 +4173,7 @@ export const IngestAttachmentProcessor = z.object({
   ignore_missing: z.boolean().describe('If `true` and field does not exist, the processor quietly exits without modifying the document.').optional(),
   indexed_chars: long.describe('The number of chars being used for extraction to prevent huge fields. Use `-1` for no limit.').optional(),
   indexed_chars_field: Field.describe('Field name from which you can overwrite the number of chars being used for extraction.').optional(),
+  max_field_bytes: ByteSize.describe('Maximum allowed size of the attachment `field` value in bytes: length of a string (if base64 in JSON, checked before base64 decoding) or byte array length for binary (for example, CBOR). If set to `-1`, there is no per-processor limit. The node setting `ingest.attachment.max_field_size` also applies.').optional(),
   properties: z.array(z.string()).describe('Array of properties to select to be stored. Can be `content`, `title`, `name`, `author`, `keywords`, `date`, `content_type`, `content_length`, `language`.').optional(),
   target_field: Field.describe('The field that will hold the attachment information.').optional(),
   remove_binary: z.boolean().describe('If true, the binary field will be removed from the document').optional(),
@@ -4155,7 +4193,7 @@ export interface IngestBytesProcessorShape {
 }
 export const IngestBytesProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4179,7 +4217,7 @@ export interface IngestCefProcessorShape {
 }
 export const IngestCefProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4205,7 +4243,7 @@ export interface IngestCircleProcessorShape {
 }
 export const IngestCircleProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4237,7 +4275,7 @@ export interface IngestCommunityIDProcessorShape {
 }
 export const IngestCommunityIDProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4268,7 +4306,7 @@ export interface IngestConvertProcessorShape {
 }
 export const IngestConvertProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4295,7 +4333,7 @@ export interface IngestCsvProcessorShape {
 }
 export const IngestCsvProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4325,7 +4363,7 @@ export interface IngestDateIndexNameProcessorShape {
 }
 export const IngestDateIndexNameProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4354,7 +4392,7 @@ export interface IngestDateProcessorShape {
 }
 export const IngestDateProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4380,7 +4418,7 @@ export interface IngestDissectProcessorShape {
 }
 export const IngestDissectProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4403,7 +4441,7 @@ export interface IngestDotExpanderProcessorShape {
 }
 export const IngestDotExpanderProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4422,7 +4460,7 @@ export interface IngestDropProcessorShape {
 }
 export const IngestDropProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional()
@@ -4445,7 +4483,7 @@ export interface IngestEnrichProcessorShape {
 }
 export const IngestEnrichProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4469,7 +4507,7 @@ export interface IngestFailProcessorShape {
 }
 export const IngestFailProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4494,7 +4532,7 @@ export interface IngestFingerprintProcessorShape {
 }
 export const IngestFingerprintProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4518,7 +4556,7 @@ export interface IngestForeachProcessorShape {
 }
 export const IngestForeachProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4546,7 +4584,7 @@ export interface IngestGeoGridProcessorShape {
 }
 export const IngestGeoGridProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4578,7 +4616,7 @@ export interface IngestGeoIpProcessorShape {
 }
 export const IngestGeoIpProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4608,7 +4646,7 @@ export interface IngestGrokProcessorShape {
 }
 export const IngestGrokProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4636,7 +4674,7 @@ export interface IngestGsubProcessorShape {
 }
 export const IngestGsubProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4660,7 +4698,7 @@ export interface IngestHtmlStripProcessorShape {
 }
 export const IngestHtmlStripProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4685,7 +4723,7 @@ export interface IngestInferenceProcessorShape {
 }
 export const IngestInferenceProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4714,7 +4752,7 @@ export interface IngestIpLocationProcessorShape {
 }
 export const IngestIpLocationProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4740,7 +4778,7 @@ export interface IngestJoinProcessorShape {
 }
 export const IngestJoinProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4764,7 +4802,7 @@ export interface IngestJsonProcessorShape {
 }
 export const IngestJsonProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4796,7 +4834,7 @@ export interface IngestKeyValueProcessorShape {
 }
 export const IngestKeyValueProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4826,7 +4864,7 @@ export interface IngestLowercaseProcessorShape {
 }
 export const IngestLowercaseProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4851,7 +4889,7 @@ export interface IngestNetworkDirectionProcessorShape {
 }
 export const IngestNetworkDirectionProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4890,7 +4928,7 @@ export interface IngestPipelineProcessorShape {
 }
 export const IngestPipelineProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4916,7 +4954,7 @@ export interface IngestRedactProcessorShape {
 }
 export const IngestRedactProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4943,7 +4981,7 @@ export interface IngestRegisteredDomainProcessorShape {
 }
 export const IngestRegisteredDomainProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4965,7 +5003,7 @@ export interface IngestRemoveProcessorShape {
 }
 export const IngestRemoveProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4987,7 +5025,7 @@ export interface IngestRenameProcessorShape {
 }
 export const IngestRenameProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -5009,7 +5047,7 @@ export interface IngestRerouteProcessorShape {
 }
 export const IngestRerouteProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -5032,7 +5070,7 @@ export interface IngestScriptProcessorShape {
 }
 export const IngestScriptProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -5058,7 +5096,7 @@ export interface IngestSetProcessorShape {
 }
 export const IngestSetProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -5082,7 +5120,7 @@ export interface IngestSetSecurityUserProcessorShape {
 }
 export const IngestSetSecurityUserProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -5103,7 +5141,7 @@ export interface IngestSortProcessorShape {
 }
 export const IngestSortProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -5127,7 +5165,7 @@ export interface IngestSplitProcessorShape {
 }
 export const IngestSplitProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -5148,7 +5186,7 @@ export interface IngestTerminateProcessorShape {
 }
 export const IngestTerminateProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional()
@@ -5167,7 +5205,7 @@ export interface IngestTrimProcessorShape {
 }
 export const IngestTrimProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -5189,7 +5227,7 @@ export interface IngestUppercaseProcessorShape {
 }
 export const IngestUppercaseProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -5213,7 +5251,7 @@ export interface IngestUriPartsProcessorShape {
 }
 export const IngestUriPartsProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -5237,7 +5275,7 @@ export interface IngestUrlDecodeProcessorShape {
 }
 export const IngestUrlDecodeProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -5262,7 +5300,7 @@ export interface IngestUserAgentProcessorShape {
 }
 export const IngestUserAgentProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),

--- a/packages/es-schemas/src/ingest_processor_grok.ts
+++ b/packages/es-schemas/src/ingest_processor_grok.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ingest_put_geoip_database.ts
+++ b/packages/es-schemas/src/ingest_put_geoip_database.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ingest_put_ip_location_database.ts
+++ b/packages/es-schemas/src/ingest_put_ip_location_database.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ingest_put_pipeline.ts
+++ b/packages/es-schemas/src/ingest_put_pipeline.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -3961,6 +3994,9 @@ export const AcknowledgedResponseBase = z.object({
   acknowledged: z.boolean().describe('For a successful response, this value is always true. On failure, an exception is returned instead.')
 }).meta({ id: 'AcknowledgedResponseBase' })
 export type AcknowledgedResponseBase = z.infer<typeof AcknowledgedResponseBase>
+
+export const ByteSize = z.union([long, z.string()]).meta({ id: 'ByteSize' })
+export type ByteSize = z.infer<typeof ByteSize>
 
 export const GeoShapeRelation = z.enum(['intersects', 'disjoint', 'within', 'contains']).meta({ id: 'GeoShapeRelation' })
 export type GeoShapeRelation = z.infer<typeof GeoShapeRelation>
@@ -4081,7 +4117,7 @@ export interface IngestProcessorBaseShape {
 }
 export const IngestProcessorBase = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional()
@@ -4103,7 +4139,7 @@ export interface IngestAppendProcessorShape {
 }
 export const IngestAppendProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4126,6 +4162,7 @@ export interface IngestAttachmentProcessorShape {
   ignore_missing?: boolean | undefined
   indexed_chars?: long | undefined
   indexed_chars_field?: Field | undefined
+  max_field_bytes?: ByteSize | undefined
   properties?: string[] | undefined
   target_field?: Field | undefined
   remove_binary?: boolean | undefined
@@ -4133,7 +4170,7 @@ export interface IngestAttachmentProcessorShape {
 }
 export const IngestAttachmentProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4141,6 +4178,7 @@ export const IngestAttachmentProcessor = z.object({
   ignore_missing: z.boolean().describe('If `true` and field does not exist, the processor quietly exits without modifying the document.').optional(),
   indexed_chars: long.describe('The number of chars being used for extraction to prevent huge fields. Use `-1` for no limit.').optional(),
   indexed_chars_field: Field.describe('Field name from which you can overwrite the number of chars being used for extraction.').optional(),
+  max_field_bytes: ByteSize.describe('Maximum allowed size of the attachment `field` value in bytes: length of a string (if base64 in JSON, checked before base64 decoding) or byte array length for binary (for example, CBOR). If set to `-1`, there is no per-processor limit. The node setting `ingest.attachment.max_field_size` also applies.').optional(),
   properties: z.array(z.string()).describe('Array of properties to select to be stored. Can be `content`, `title`, `name`, `author`, `keywords`, `date`, `content_type`, `content_length`, `language`.').optional(),
   target_field: Field.describe('The field that will hold the attachment information.').optional(),
   remove_binary: z.boolean().describe('If true, the binary field will be removed from the document').optional(),
@@ -4160,7 +4198,7 @@ export interface IngestBytesProcessorShape {
 }
 export const IngestBytesProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4184,7 +4222,7 @@ export interface IngestCefProcessorShape {
 }
 export const IngestCefProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4210,7 +4248,7 @@ export interface IngestCircleProcessorShape {
 }
 export const IngestCircleProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4242,7 +4280,7 @@ export interface IngestCommunityIDProcessorShape {
 }
 export const IngestCommunityIDProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4273,7 +4311,7 @@ export interface IngestConvertProcessorShape {
 }
 export const IngestConvertProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4300,7 +4338,7 @@ export interface IngestCsvProcessorShape {
 }
 export const IngestCsvProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4330,7 +4368,7 @@ export interface IngestDateIndexNameProcessorShape {
 }
 export const IngestDateIndexNameProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4359,7 +4397,7 @@ export interface IngestDateProcessorShape {
 }
 export const IngestDateProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4385,7 +4423,7 @@ export interface IngestDissectProcessorShape {
 }
 export const IngestDissectProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4408,7 +4446,7 @@ export interface IngestDotExpanderProcessorShape {
 }
 export const IngestDotExpanderProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4427,7 +4465,7 @@ export interface IngestDropProcessorShape {
 }
 export const IngestDropProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional()
@@ -4450,7 +4488,7 @@ export interface IngestEnrichProcessorShape {
 }
 export const IngestEnrichProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4474,7 +4512,7 @@ export interface IngestFailProcessorShape {
 }
 export const IngestFailProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4499,7 +4537,7 @@ export interface IngestFingerprintProcessorShape {
 }
 export const IngestFingerprintProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4523,7 +4561,7 @@ export interface IngestForeachProcessorShape {
 }
 export const IngestForeachProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4551,7 +4589,7 @@ export interface IngestGeoGridProcessorShape {
 }
 export const IngestGeoGridProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4583,7 +4621,7 @@ export interface IngestGeoIpProcessorShape {
 }
 export const IngestGeoIpProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4613,7 +4651,7 @@ export interface IngestGrokProcessorShape {
 }
 export const IngestGrokProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4641,7 +4679,7 @@ export interface IngestGsubProcessorShape {
 }
 export const IngestGsubProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4665,7 +4703,7 @@ export interface IngestHtmlStripProcessorShape {
 }
 export const IngestHtmlStripProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4690,7 +4728,7 @@ export interface IngestInferenceProcessorShape {
 }
 export const IngestInferenceProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4719,7 +4757,7 @@ export interface IngestIpLocationProcessorShape {
 }
 export const IngestIpLocationProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4745,7 +4783,7 @@ export interface IngestJoinProcessorShape {
 }
 export const IngestJoinProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4769,7 +4807,7 @@ export interface IngestJsonProcessorShape {
 }
 export const IngestJsonProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4801,7 +4839,7 @@ export interface IngestKeyValueProcessorShape {
 }
 export const IngestKeyValueProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4831,7 +4869,7 @@ export interface IngestLowercaseProcessorShape {
 }
 export const IngestLowercaseProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4856,7 +4894,7 @@ export interface IngestNetworkDirectionProcessorShape {
 }
 export const IngestNetworkDirectionProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4880,7 +4918,7 @@ export interface IngestPipelineProcessorShape {
 }
 export const IngestPipelineProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4906,7 +4944,7 @@ export interface IngestRedactProcessorShape {
 }
 export const IngestRedactProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4933,7 +4971,7 @@ export interface IngestRegisteredDomainProcessorShape {
 }
 export const IngestRegisteredDomainProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4955,7 +4993,7 @@ export interface IngestRemoveProcessorShape {
 }
 export const IngestRemoveProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4977,7 +5015,7 @@ export interface IngestRenameProcessorShape {
 }
 export const IngestRenameProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4999,7 +5037,7 @@ export interface IngestRerouteProcessorShape {
 }
 export const IngestRerouteProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -5022,7 +5060,7 @@ export interface IngestScriptProcessorShape {
 }
 export const IngestScriptProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -5048,7 +5086,7 @@ export interface IngestSetProcessorShape {
 }
 export const IngestSetProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -5072,7 +5110,7 @@ export interface IngestSetSecurityUserProcessorShape {
 }
 export const IngestSetSecurityUserProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -5093,7 +5131,7 @@ export interface IngestSortProcessorShape {
 }
 export const IngestSortProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -5117,7 +5155,7 @@ export interface IngestSplitProcessorShape {
 }
 export const IngestSplitProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -5138,7 +5176,7 @@ export interface IngestTerminateProcessorShape {
 }
 export const IngestTerminateProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional()
@@ -5157,7 +5195,7 @@ export interface IngestTrimProcessorShape {
 }
 export const IngestTrimProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -5179,7 +5217,7 @@ export interface IngestUppercaseProcessorShape {
 }
 export const IngestUppercaseProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -5203,7 +5241,7 @@ export interface IngestUriPartsProcessorShape {
 }
 export const IngestUriPartsProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -5227,7 +5265,7 @@ export interface IngestUrlDecodeProcessorShape {
 }
 export const IngestUrlDecodeProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -5252,7 +5290,7 @@ export interface IngestUserAgentProcessorShape {
 }
 export const IngestUserAgentProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),

--- a/packages/es-schemas/src/ingest_simulate.ts
+++ b/packages/es-schemas/src/ingest_simulate.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -3966,6 +3999,9 @@ export type SearchFieldCollapse = z.infer<typeof SearchFieldCollapse>
  */
 export const SpecUtilsStringified = z.union([z.any(), z.string()]).meta({ id: 'SpecUtilsStringified' })
 export type SpecUtilsStringified = z.infer<typeof SpecUtilsStringified>
+
+export const ByteSize = z.union([long, z.string()]).meta({ id: 'ByteSize' })
+export type ByteSize = z.infer<typeof ByteSize>
 
 export interface ErrorCauseShape {
   type: string
@@ -4108,7 +4144,7 @@ export interface IngestProcessorBaseShape {
 }
 export const IngestProcessorBase = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional()
@@ -4130,7 +4166,7 @@ export interface IngestAppendProcessorShape {
 }
 export const IngestAppendProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4153,6 +4189,7 @@ export interface IngestAttachmentProcessorShape {
   ignore_missing?: boolean | undefined
   indexed_chars?: long | undefined
   indexed_chars_field?: Field | undefined
+  max_field_bytes?: ByteSize | undefined
   properties?: string[] | undefined
   target_field?: Field | undefined
   remove_binary?: boolean | undefined
@@ -4160,7 +4197,7 @@ export interface IngestAttachmentProcessorShape {
 }
 export const IngestAttachmentProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4168,6 +4205,7 @@ export const IngestAttachmentProcessor = z.object({
   ignore_missing: z.boolean().describe('If `true` and field does not exist, the processor quietly exits without modifying the document.').optional(),
   indexed_chars: long.describe('The number of chars being used for extraction to prevent huge fields. Use `-1` for no limit.').optional(),
   indexed_chars_field: Field.describe('Field name from which you can overwrite the number of chars being used for extraction.').optional(),
+  max_field_bytes: ByteSize.describe('Maximum allowed size of the attachment `field` value in bytes: length of a string (if base64 in JSON, checked before base64 decoding) or byte array length for binary (for example, CBOR). If set to `-1`, there is no per-processor limit. The node setting `ingest.attachment.max_field_size` also applies.').optional(),
   properties: z.array(z.string()).describe('Array of properties to select to be stored. Can be `content`, `title`, `name`, `author`, `keywords`, `date`, `content_type`, `content_length`, `language`.').optional(),
   target_field: Field.describe('The field that will hold the attachment information.').optional(),
   remove_binary: z.boolean().describe('If true, the binary field will be removed from the document').optional(),
@@ -4187,7 +4225,7 @@ export interface IngestBytesProcessorShape {
 }
 export const IngestBytesProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4211,7 +4249,7 @@ export interface IngestCefProcessorShape {
 }
 export const IngestCefProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4237,7 +4275,7 @@ export interface IngestCircleProcessorShape {
 }
 export const IngestCircleProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4269,7 +4307,7 @@ export interface IngestCommunityIDProcessorShape {
 }
 export const IngestCommunityIDProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4300,7 +4338,7 @@ export interface IngestConvertProcessorShape {
 }
 export const IngestConvertProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4327,7 +4365,7 @@ export interface IngestCsvProcessorShape {
 }
 export const IngestCsvProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4357,7 +4395,7 @@ export interface IngestDateIndexNameProcessorShape {
 }
 export const IngestDateIndexNameProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4386,7 +4424,7 @@ export interface IngestDateProcessorShape {
 }
 export const IngestDateProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4412,7 +4450,7 @@ export interface IngestDissectProcessorShape {
 }
 export const IngestDissectProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4466,7 +4504,7 @@ export interface IngestDotExpanderProcessorShape {
 }
 export const IngestDotExpanderProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4485,7 +4523,7 @@ export interface IngestDropProcessorShape {
 }
 export const IngestDropProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional()
@@ -4508,7 +4546,7 @@ export interface IngestEnrichProcessorShape {
 }
 export const IngestEnrichProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4532,7 +4570,7 @@ export interface IngestFailProcessorShape {
 }
 export const IngestFailProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4557,7 +4595,7 @@ export interface IngestFingerprintProcessorShape {
 }
 export const IngestFingerprintProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4581,7 +4619,7 @@ export interface IngestForeachProcessorShape {
 }
 export const IngestForeachProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4609,7 +4647,7 @@ export interface IngestGeoGridProcessorShape {
 }
 export const IngestGeoGridProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4641,7 +4679,7 @@ export interface IngestGeoIpProcessorShape {
 }
 export const IngestGeoIpProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4671,7 +4709,7 @@ export interface IngestGrokProcessorShape {
 }
 export const IngestGrokProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4699,7 +4737,7 @@ export interface IngestGsubProcessorShape {
 }
 export const IngestGsubProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4723,7 +4761,7 @@ export interface IngestHtmlStripProcessorShape {
 }
 export const IngestHtmlStripProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4748,7 +4786,7 @@ export interface IngestInferenceProcessorShape {
 }
 export const IngestInferenceProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4777,7 +4815,7 @@ export interface IngestIpLocationProcessorShape {
 }
 export const IngestIpLocationProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4803,7 +4841,7 @@ export interface IngestJoinProcessorShape {
 }
 export const IngestJoinProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4827,7 +4865,7 @@ export interface IngestJsonProcessorShape {
 }
 export const IngestJsonProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4859,7 +4897,7 @@ export interface IngestKeyValueProcessorShape {
 }
 export const IngestKeyValueProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4889,7 +4927,7 @@ export interface IngestLowercaseProcessorShape {
 }
 export const IngestLowercaseProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4914,7 +4952,7 @@ export interface IngestNetworkDirectionProcessorShape {
 }
 export const IngestNetworkDirectionProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4953,7 +4991,7 @@ export interface IngestPipelineProcessorShape {
 }
 export const IngestPipelineProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -4993,7 +5031,7 @@ export interface IngestRedactProcessorShape {
 }
 export const IngestRedactProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -5020,7 +5058,7 @@ export interface IngestRegisteredDomainProcessorShape {
 }
 export const IngestRegisteredDomainProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -5042,7 +5080,7 @@ export interface IngestRemoveProcessorShape {
 }
 export const IngestRemoveProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -5064,7 +5102,7 @@ export interface IngestRenameProcessorShape {
 }
 export const IngestRenameProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -5086,7 +5124,7 @@ export interface IngestRerouteProcessorShape {
 }
 export const IngestRerouteProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -5109,7 +5147,7 @@ export interface IngestScriptProcessorShape {
 }
 export const IngestScriptProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -5135,7 +5173,7 @@ export interface IngestSetProcessorShape {
 }
 export const IngestSetProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -5159,7 +5197,7 @@ export interface IngestSetSecurityUserProcessorShape {
 }
 export const IngestSetSecurityUserProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -5187,7 +5225,7 @@ export interface IngestSortProcessorShape {
 }
 export const IngestSortProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -5211,7 +5249,7 @@ export interface IngestSplitProcessorShape {
 }
 export const IngestSplitProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -5232,7 +5270,7 @@ export interface IngestTerminateProcessorShape {
 }
 export const IngestTerminateProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional()
@@ -5251,7 +5289,7 @@ export interface IngestTrimProcessorShape {
 }
 export const IngestTrimProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -5273,7 +5311,7 @@ export interface IngestUppercaseProcessorShape {
 }
 export const IngestUppercaseProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -5297,7 +5335,7 @@ export interface IngestUriPartsProcessorShape {
 }
 export const IngestUriPartsProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -5321,7 +5359,7 @@ export interface IngestUrlDecodeProcessorShape {
 }
 export const IngestUrlDecodeProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -5346,7 +5384,7 @@ export interface IngestUserAgentProcessorShape {
 }
 export const IngestUserAgentProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),

--- a/packages/es-schemas/src/knn_search.ts
+++ b/packages/es-schemas/src/knn_search.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -69,7 +70,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 /** A reference to a field with formatting instructions on how to return the value */
@@ -318,7 +319,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -329,11 +330,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -349,7 +350,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -362,7 +363,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -376,7 +377,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -422,7 +423,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -438,7 +439,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -452,7 +453,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -517,7 +518,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -617,7 +618,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -632,7 +633,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -644,7 +645,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -717,7 +718,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -735,7 +736,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -754,7 +755,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -792,7 +793,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -876,7 +877,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -959,7 +960,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -1011,7 +1012,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -1027,7 +1028,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1099,7 +1100,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1114,7 +1115,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1220,7 +1221,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1302,7 +1303,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1323,7 +1324,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1339,7 +1340,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1454,7 +1455,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1531,7 +1532,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1553,7 +1554,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1580,7 +1581,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1612,7 +1613,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1644,12 +1645,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1687,7 +1688,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1784,7 +1785,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1803,7 +1804,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1817,7 +1818,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1858,7 +1859,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -2049,7 +2050,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -2075,10 +2076,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -2099,7 +2100,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -2135,7 +2136,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -2151,7 +2152,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -2165,7 +2166,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -2178,7 +2179,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2208,7 +2209,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2318,7 +2319,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -2330,13 +2332,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -2371,6 +2374,36 @@ export type SearchTrackHits = z.infer<typeof SearchTrackHits>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2385,7 +2418,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2452,7 +2485,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2807,12 +2840,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2865,7 +2898,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2879,7 +2912,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2920,7 +2953,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -3098,7 +3131,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3618,7 +3651,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3634,7 +3667,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3797,7 +3830,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3873,7 +3906,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3914,7 +3947,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -4002,7 +4035,7 @@ export const KnnSearchRequest = z.object({
   index: Indices.describe('A comma-separated list of index names to search; use `_all` or to perform the operation on all indices.').meta({ found_in: 'path' }),
   routing: Routing.describe('A comma-separated list of specific routing values.').optional().meta({ found_in: 'query' }),
   _source: SearchSourceConfig.describe('Indicates which source fields are returned for matching documents. These fields are returned in the `hits._source` property of the search response.').optional().meta({ found_in: 'body' }),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('The request returns doc values for field names matching these patterns in the `hits.fields` property of the response. It accepts wildcard (`*`) patterns.').optional().meta({ found_in: 'body' }),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('The request returns doc values for field names matching these patterns in the `hits.fields` property of the response. It accepts wildcard (`*`) patterns.').optional().meta({ found_in: 'body' }),
   stored_fields: Fields.describe('A list of stored fields to return as part of a hit. If no fields are specified, no stored fields are included in the response. If this field is specified, the `_source` parameter defaults to `false`. You can pass `_source: true` to return both source fields and stored fields in the search response.').optional().meta({ found_in: 'body' }),
   fields: Fields.describe('The request returns values for field names matching these patterns in the `hits.fields` property of the response. It accepts wildcard (`*`) patterns.').optional().meta({ found_in: 'body' }),
   filter: z.union([z.lazy(() => QueryDslQueryContainer), z.array(z.lazy(() => QueryDslQueryContainer))]).describe('A query to filter the documents that can match. The kNN search will return the top `k` documents that also match this filter. The value can be a single query or a list of queries. If `filter` isn\'t provided, all documents are allowed to match.').optional().meta({ found_in: 'body' }),

--- a/packages/es-schemas/src/license_delete.ts
+++ b/packages/es-schemas/src/license_delete.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/license_get.ts
+++ b/packages/es-schemas/src/license_get.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/license_get_basic_status.ts
+++ b/packages/es-schemas/src/license_get_basic_status.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/license_get_trial_status.ts
+++ b/packages/es-schemas/src/license_get_trial_status.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/license_post.ts
+++ b/packages/es-schemas/src/license_post.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/license_post_start_basic.ts
+++ b/packages/es-schemas/src/license_post_start_basic.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/license_post_start_trial.ts
+++ b/packages/es-schemas/src/license_post_start_trial.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/list_reindex.ts
+++ b/packages/es-schemas/src/list_reindex.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/logstash_delete_pipeline.ts
+++ b/packages/es-schemas/src/logstash_delete_pipeline.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/logstash_get_pipeline.ts
+++ b/packages/es-schemas/src/logstash_get_pipeline.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/logstash_put_pipeline.ts
+++ b/packages/es-schemas/src/logstash_put_pipeline.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/mget.ts
+++ b/packages/es-schemas/src/mget.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -95,7 +96,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export const VersionType = z.enum(['internal', 'external', 'external_gte']).meta({ id: 'VersionType' })

--- a/packages/es-schemas/src/migration_deprecations.ts
+++ b/packages/es-schemas/src/migration_deprecations.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/migration_get_feature_upgrade_status.ts
+++ b/packages/es-schemas/src/migration_get_feature_upgrade_status.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/migration_post_feature_upgrade.ts
+++ b/packages/es-schemas/src/migration_post_feature_upgrade.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_clear_trained_model_deployment_cache.ts
+++ b/packages/es-schemas/src/ml_clear_trained_model_deployment_cache.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_close_job.ts
+++ b/packages/es-schemas/src/ml_close_job.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_delete_calendar.ts
+++ b/packages/es-schemas/src/ml_delete_calendar.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_delete_calendar_event.ts
+++ b/packages/es-schemas/src/ml_delete_calendar_event.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_delete_calendar_job.ts
+++ b/packages/es-schemas/src/ml_delete_calendar_job.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_delete_data_frame_analytics.ts
+++ b/packages/es-schemas/src/ml_delete_data_frame_analytics.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_delete_datafeed.ts
+++ b/packages/es-schemas/src/ml_delete_datafeed.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_delete_expired_data.ts
+++ b/packages/es-schemas/src/ml_delete_expired_data.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_delete_filter.ts
+++ b/packages/es-schemas/src/ml_delete_filter.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_delete_forecast.ts
+++ b/packages/es-schemas/src/ml_delete_forecast.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_delete_job.ts
+++ b/packages/es-schemas/src/ml_delete_job.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_delete_model_snapshot.ts
+++ b/packages/es-schemas/src/ml_delete_model_snapshot.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_delete_trained_model.ts
+++ b/packages/es-schemas/src/ml_delete_trained_model.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_delete_trained_model_alias.ts
+++ b/packages/es-schemas/src/ml_delete_trained_model_alias.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_estimate_model_memory.ts
+++ b/packages/es-schemas/src/ml_estimate_model_memory.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4142,7 +4175,7 @@ export const AnalysisConditionTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('condition'),
   filter: z.array(z.string()).describe('Array of token filters. If a token matches the predicate script in the `script` parameter, these filters are applied to the token in the order provided.'),
-  script: z.lazy(() => Script).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
 }).meta({ id: 'AnalysisConditionTokenFilter' })
 export type AnalysisConditionTokenFilter = z.infer<typeof AnalysisConditionTokenFilter>
 
@@ -4614,7 +4647,7 @@ export type AnalysisPorterStemTokenFilter = z.infer<typeof AnalysisPorterStemTok
 export const AnalysisPredicateTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('predicate_token_filter'),
-  script: z.lazy(() => Script).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
 }).meta({ id: 'AnalysisPredicateTokenFilter' })
 export type AnalysisPredicateTokenFilter = z.infer<typeof AnalysisPredicateTokenFilter>
 

--- a/packages/es-schemas/src/ml_evaluate_data_frame.ts
+++ b/packages/es-schemas/src/ml_evaluate_data_frame.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),

--- a/packages/es-schemas/src/ml_explain_data_frame_analytics.ts
+++ b/packages/es-schemas/src/ml_explain_data_frame_analytics.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4092,7 +4125,7 @@ export const MlDataframeAnalyticsSource = z.object({
   index: Indices.describe('Index or indices on which to perform the analysis. It can be a single index or index pattern as well as an array of indices or patterns. NOTE: If your source indices contain documents with the same IDs, only the document that is indexed last appears in the destination index.'),
   query: z.lazy(() => QueryDslQueryContainer).describe('The Elasticsearch query domain-specific language (DSL). This value corresponds to the query object in an Elasticsearch search POST body. All the options that are supported by Elasticsearch can be used, as this object is passed verbatim to Elasticsearch. By default, this property has the following value: {"match_all": {}}.').optional(),
   runtime_mappings: z.lazy(() => MappingRuntimeFields).describe('Definitions of runtime fields that will become part of the mapping of the destination index.').optional(),
-  _source: MlDataframeAnalysisAnalyzedFields.describe('Specify `includes` and/or `excludes patterns to select which fields will be present in the destination. Fields that are excluded cannot be included in the analysis.').optional()
+  _source: z.union([MlDataframeAnalysisAnalyzedFields, z.array(z.string())]).describe('Specify `includes` and/or `excludes patterns to select which fields will be present in the destination. Fields that are excluded cannot be included in the analysis.').optional()
 }).meta({ id: 'MlDataframeAnalyticsSource' })
 export type MlDataframeAnalyticsSource = z.infer<typeof MlDataframeAnalyticsSource>
 
@@ -4115,7 +4148,7 @@ export const MlExplainDataFrameAnalyticsRequest = z.object({
   description: z.string().describe('A description of the job.').optional().meta({ found_in: 'body' }),
   model_memory_limit: z.string().describe('The approximate maximum amount of memory resources that are permitted for analytical processing. If your `elasticsearch.yml` file contains an `xpack.ml.max_model_memory_limit` setting, an error occurs when you try to create data frame analytics jobs that have `model_memory_limit` values greater than that setting.').optional().meta({ found_in: 'body' }),
   max_num_threads: integer.describe('The maximum number of threads to be used by the analysis. Using more threads may decrease the time necessary to complete the analysis at the cost of using more CPU. Note that the process may use additional threads for operational functionality other than the analysis itself.').optional().meta({ found_in: 'body' }),
-  analyzed_fields: MlDataframeAnalysisAnalyzedFields.describe('Specify includes and/or excludes patterns to select which fields will be included in the analysis. The patterns specified in excludes are applied last, therefore excludes takes precedence. In other words, if the same field is specified in both includes and excludes, then the field will not be included in the analysis.').optional().meta({ found_in: 'body' }),
+  analyzed_fields: z.union([MlDataframeAnalysisAnalyzedFields, z.array(z.string())]).describe('Specify includes and/or excludes patterns to select which fields will be included in the analysis. The patterns specified in excludes are applied last, therefore excludes takes precedence. In other words, if the same field is specified in both includes and excludes, then the field will not be included in the analysis.').optional().meta({ found_in: 'body' }),
   allow_lazy_start: z.boolean().describe('Specifies whether this job can start when there is insufficient machine learning node capacity for it to be immediately assigned to a node.').optional().meta({ found_in: 'body' })
 }).meta({ id: 'MlExplainDataFrameAnalyticsRequest' })
 export type MlExplainDataFrameAnalyticsRequest = z.infer<typeof MlExplainDataFrameAnalyticsRequest>

--- a/packages/es-schemas/src/ml_flush_job.ts
+++ b/packages/es-schemas/src/ml_flush_job.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_forecast.ts
+++ b/packages/es-schemas/src/ml_forecast.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_get_buckets.ts
+++ b/packages/es-schemas/src/ml_get_buckets.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_get_calendar_events.ts
+++ b/packages/es-schemas/src/ml_get_calendar_events.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_get_calendars.ts
+++ b/packages/es-schemas/src/ml_get_calendars.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_get_categories.ts
+++ b/packages/es-schemas/src/ml_get_categories.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_get_data_frame_analytics.ts
+++ b/packages/es-schemas/src/ml_get_data_frame_analytics.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4092,14 +4125,14 @@ export const MlDataframeAnalyticsSource = z.object({
   index: Indices.describe('Index or indices on which to perform the analysis. It can be a single index or index pattern as well as an array of indices or patterns. NOTE: If your source indices contain documents with the same IDs, only the document that is indexed last appears in the destination index.'),
   query: z.lazy(() => QueryDslQueryContainer).describe('The Elasticsearch query domain-specific language (DSL). This value corresponds to the query object in an Elasticsearch search POST body. All the options that are supported by Elasticsearch can be used, as this object is passed verbatim to Elasticsearch. By default, this property has the following value: {"match_all": {}}.').optional(),
   runtime_mappings: z.lazy(() => MappingRuntimeFields).describe('Definitions of runtime fields that will become part of the mapping of the destination index.').optional(),
-  _source: MlDataframeAnalysisAnalyzedFields.describe('Specify `includes` and/or `excludes patterns to select which fields will be present in the destination. Fields that are excluded cannot be included in the analysis.').optional()
+  _source: z.union([MlDataframeAnalysisAnalyzedFields, z.array(z.string())]).describe('Specify `includes` and/or `excludes patterns to select which fields will be present in the destination. Fields that are excluded cannot be included in the analysis.').optional()
 }).meta({ id: 'MlDataframeAnalyticsSource' })
 export type MlDataframeAnalyticsSource = z.infer<typeof MlDataframeAnalyticsSource>
 
 export const MlDataframeAnalyticsSummary = z.object({
   allow_lazy_start: z.boolean().optional(),
   analysis: MlDataframeAnalysisContainer,
-  analyzed_fields: MlDataframeAnalysisAnalyzedFields.optional(),
+  analyzed_fields: z.union([MlDataframeAnalysisAnalyzedFields, z.array(z.string())]).optional(),
   authorization: MlDataframeAnalyticsAuthorization.describe('The security privileges that the job uses to run its queries. If Elastic Stack security features were disabled at the time of the most recent update to the job, this property is omitted.').optional(),
   create_time: EpochTime.optional(),
   description: z.string().optional(),

--- a/packages/es-schemas/src/ml_get_data_frame_analytics_stats.ts
+++ b/packages/es-schemas/src/ml_get_data_frame_analytics_stats.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_get_datafeed_stats.ts
+++ b/packages/es-schemas/src/ml_get_datafeed_stats.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_get_datafeeds.ts
+++ b/packages/es-schemas/src/ml_get_datafeeds.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),

--- a/packages/es-schemas/src/ml_get_filters.ts
+++ b/packages/es-schemas/src/ml_get_filters.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_get_influencers.ts
+++ b/packages/es-schemas/src/ml_get_influencers.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_get_job_stats.ts
+++ b/packages/es-schemas/src/ml_get_job_stats.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_get_jobs.ts
+++ b/packages/es-schemas/src/ml_get_jobs.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4166,7 +4199,7 @@ export const AnalysisConditionTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('condition'),
   filter: z.array(z.string()).describe('Array of token filters. If a token matches the predicate script in the `script` parameter, these filters are applied to the token in the order provided.'),
-  script: z.lazy(() => Script).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
 }).meta({ id: 'AnalysisConditionTokenFilter' })
 export type AnalysisConditionTokenFilter = z.infer<typeof AnalysisConditionTokenFilter>
 
@@ -4638,7 +4671,7 @@ export type AnalysisPorterStemTokenFilter = z.infer<typeof AnalysisPorterStemTok
 export const AnalysisPredicateTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('predicate_token_filter'),
-  script: z.lazy(() => Script).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
 }).meta({ id: 'AnalysisPredicateTokenFilter' })
 export type AnalysisPredicateTokenFilter = z.infer<typeof AnalysisPredicateTokenFilter>
 

--- a/packages/es-schemas/src/ml_get_memory_stats.ts
+++ b/packages/es-schemas/src/ml_get_memory_stats.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_get_model_snapshot_upgrade_stats.ts
+++ b/packages/es-schemas/src/ml_get_model_snapshot_upgrade_stats.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_get_model_snapshots.ts
+++ b/packages/es-schemas/src/ml_get_model_snapshots.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_get_overall_buckets.ts
+++ b/packages/es-schemas/src/ml_get_overall_buckets.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_get_records.ts
+++ b/packages/es-schemas/src/ml_get_records.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_get_trained_models.ts
+++ b/packages/es-schemas/src/ml_get_trained_models.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),

--- a/packages/es-schemas/src/ml_get_trained_models_stats.ts
+++ b/packages/es-schemas/src/ml_get_trained_models_stats.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -74,6 +75,7 @@ export const MlTrainedModelDeploymentNodesStats = z.object({
   average_inference_time_ms: DurationValue.describe('The average time for each inference call to complete on this node.').optional(),
   average_inference_time_ms_last_minute: DurationValue.optional(),
   average_inference_time_ms_excluding_cache_hits: DurationValue.describe('The average time for each inference call to complete on this node, excluding cache').optional(),
+  average_inference_process_memory_rss_bytes: ByteSize.optional(),
   error_count: integer.describe('The number of errors when evaluating the trained model.').optional(),
   inference_count: long.describe('The total number of inference calls made against this node for this model.').optional(),
   inference_cache_hit_count: long.optional(),

--- a/packages/es-schemas/src/ml_infer_trained_model.ts
+++ b/packages/es-schemas/src/ml_infer_trained_model.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_info.ts
+++ b/packages/es-schemas/src/ml_info.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4145,7 +4178,7 @@ export const AnalysisConditionTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('condition'),
   filter: z.array(z.string()).describe('Array of token filters. If a token matches the predicate script in the `script` parameter, these filters are applied to the token in the order provided.'),
-  script: z.lazy(() => Script).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
 }).meta({ id: 'AnalysisConditionTokenFilter' })
 export type AnalysisConditionTokenFilter = z.infer<typeof AnalysisConditionTokenFilter>
 
@@ -4617,7 +4650,7 @@ export type AnalysisPorterStemTokenFilter = z.infer<typeof AnalysisPorterStemTok
 export const AnalysisPredicateTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('predicate_token_filter'),
-  script: z.lazy(() => Script).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
 }).meta({ id: 'AnalysisPredicateTokenFilter' })
 export type AnalysisPredicateTokenFilter = z.infer<typeof AnalysisPredicateTokenFilter>
 

--- a/packages/es-schemas/src/ml_open_job.ts
+++ b/packages/es-schemas/src/ml_open_job.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_post_calendar_events.ts
+++ b/packages/es-schemas/src/ml_post_calendar_events.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_post_data.ts
+++ b/packages/es-schemas/src/ml_post_data.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_preview_data_frame_analytics.ts
+++ b/packages/es-schemas/src/ml_preview_data_frame_analytics.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4070,7 +4103,7 @@ export const MlDataframeAnalyticsSource = z.object({
   index: Indices.describe('Index or indices on which to perform the analysis. It can be a single index or index pattern as well as an array of indices or patterns. NOTE: If your source indices contain documents with the same IDs, only the document that is indexed last appears in the destination index.'),
   query: z.lazy(() => QueryDslQueryContainer).describe('The Elasticsearch query domain-specific language (DSL). This value corresponds to the query object in an Elasticsearch search POST body. All the options that are supported by Elasticsearch can be used, as this object is passed verbatim to Elasticsearch. By default, this property has the following value: {"match_all": {}}.').optional(),
   runtime_mappings: z.lazy(() => MappingRuntimeFields).describe('Definitions of runtime fields that will become part of the mapping of the destination index.').optional(),
-  _source: MlDataframeAnalysisAnalyzedFields.describe('Specify `includes` and/or `excludes patterns to select which fields will be present in the destination. Fields that are excluded cannot be included in the analysis.').optional()
+  _source: z.union([MlDataframeAnalysisAnalyzedFields, z.array(z.string())]).describe('Specify `includes` and/or `excludes patterns to select which fields will be present in the destination. Fields that are excluded cannot be included in the analysis.').optional()
 }).meta({ id: 'MlDataframeAnalyticsSource' })
 export type MlDataframeAnalyticsSource = z.infer<typeof MlDataframeAnalyticsSource>
 
@@ -4079,7 +4112,7 @@ export const MlPreviewDataFrameAnalyticsDataframePreviewConfig = z.object({
   analysis: MlDataframeAnalysisContainer,
   model_memory_limit: z.string().optional(),
   max_num_threads: integer.optional(),
-  analyzed_fields: MlDataframeAnalysisAnalyzedFields.optional()
+  analyzed_fields: z.union([MlDataframeAnalysisAnalyzedFields, z.array(z.string())]).optional()
 }).meta({ id: 'MlPreviewDataFrameAnalyticsDataframePreviewConfig' })
 export type MlPreviewDataFrameAnalyticsDataframePreviewConfig = z.infer<typeof MlPreviewDataFrameAnalyticsDataframePreviewConfig>
 

--- a/packages/es-schemas/src/ml_preview_datafeed.ts
+++ b/packages/es-schemas/src/ml_preview_datafeed.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4166,7 +4199,7 @@ export const AnalysisConditionTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('condition'),
   filter: z.array(z.string()).describe('Array of token filters. If a token matches the predicate script in the `script` parameter, these filters are applied to the token in the order provided.'),
-  script: z.lazy(() => Script).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
 }).meta({ id: 'AnalysisConditionTokenFilter' })
 export type AnalysisConditionTokenFilter = z.infer<typeof AnalysisConditionTokenFilter>
 
@@ -4638,7 +4671,7 @@ export type AnalysisPorterStemTokenFilter = z.infer<typeof AnalysisPorterStemTok
 export const AnalysisPredicateTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('predicate_token_filter'),
-  script: z.lazy(() => Script).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
 }).meta({ id: 'AnalysisPredicateTokenFilter' })
 export type AnalysisPredicateTokenFilter = z.infer<typeof AnalysisPredicateTokenFilter>
 

--- a/packages/es-schemas/src/ml_put_calendar.ts
+++ b/packages/es-schemas/src/ml_put_calendar.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_put_calendar_job.ts
+++ b/packages/es-schemas/src/ml_put_calendar_job.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_put_data_frame_analytics.ts
+++ b/packages/es-schemas/src/ml_put_data_frame_analytics.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4095,7 +4128,7 @@ export const MlDataframeAnalyticsSource = z.object({
   index: Indices.describe('Index or indices on which to perform the analysis. It can be a single index or index pattern as well as an array of indices or patterns. NOTE: If your source indices contain documents with the same IDs, only the document that is indexed last appears in the destination index.'),
   query: z.lazy(() => QueryDslQueryContainer).describe('The Elasticsearch query domain-specific language (DSL). This value corresponds to the query object in an Elasticsearch search POST body. All the options that are supported by Elasticsearch can be used, as this object is passed verbatim to Elasticsearch. By default, this property has the following value: {"match_all": {}}.').optional(),
   runtime_mappings: z.lazy(() => MappingRuntimeFields).describe('Definitions of runtime fields that will become part of the mapping of the destination index.').optional(),
-  _source: MlDataframeAnalysisAnalyzedFields.describe('Specify `includes` and/or `excludes patterns to select which fields will be present in the destination. Fields that are excluded cannot be included in the analysis.').optional()
+  _source: z.union([MlDataframeAnalysisAnalyzedFields, z.array(z.string())]).describe('Specify `includes` and/or `excludes patterns to select which fields will be present in the destination. Fields that are excluded cannot be included in the analysis.').optional()
 }).meta({ id: 'MlDataframeAnalyticsSource' })
 export type MlDataframeAnalyticsSource = z.infer<typeof MlDataframeAnalyticsSource>
 
@@ -4115,7 +4148,7 @@ export const MlPutDataFrameAnalyticsRequest = z.object({
   id: Id.describe('Identifier for the data frame analytics job. This identifier can contain lowercase alphanumeric characters (a-z and 0-9), hyphens, and underscores. It must start and end with alphanumeric characters.').meta({ found_in: 'path' }),
   allow_lazy_start: z.boolean().describe('Specifies whether this job can start when there is insufficient machine learning node capacity for it to be immediately assigned to a node. If set to `false` and a machine learning node with capacity to run the job cannot be immediately found, the API returns an error. If set to `true`, the API does not return an error; the job waits in the `starting` state until sufficient machine learning node capacity is available. This behavior is also affected by the cluster-wide `xpack.ml.max_lazy_ml_nodes` setting.').optional().meta({ found_in: 'body' }),
   analysis: MlDataframeAnalysisContainer.describe('The analysis configuration, which contains the information necessary to perform one of the following types of analysis: classification, outlier detection, or regression.').meta({ found_in: 'body' }),
-  analyzed_fields: MlDataframeAnalysisAnalyzedFields.describe('Specifies `includes` and/or `excludes` patterns to select which fields will be included in the analysis. The patterns specified in `excludes` are applied last, therefore `excludes` takes precedence. In other words, if the same field is specified in both `includes` and `excludes`, then the field will not be included in the analysis. If `analyzed_fields` is not set, only the relevant fields will be included. For example, all the numeric fields for outlier detection. The supported fields vary for each type of analysis. Outlier detection requires numeric or `boolean` data to analyze. The algorithms don’t support missing values therefore fields that have data types other than numeric or boolean are ignored. Documents where included fields contain missing values, null values, or an array are also ignored. Therefore the `dest` index may contain documents that don’t have an outlier score. Regression supports fields that are numeric, `boolean`, `text`, `keyword`, and `ip` data types. It is also tolerant of missing values. Fields that are supported are included in the analysis, other fields are ignored. Documents where included fields contain an array with two or more values are also ignored. Documents in the `dest` index that don’t contain a results field are not included in the regression analysis. Classification supports fields that are numeric, `boolean`, `text`, `keyword`, and `ip` data types. It is also tolerant of missing values. Fields that are supported are included in the analysis, other fields are ignored. Documents where included fields contain an array with two or more values are also ignored. Documents in the `dest` index that don’t contain a results field are not included in the classification analysis. Classification analysis can be improved by mapping ordinal variable values to a single number. For example, in case of age ranges, you can model the values as `0-14 = 0`, `15-24 = 1`, `25-34 = 2`, and so on.').optional().meta({ found_in: 'body' }),
+  analyzed_fields: z.union([MlDataframeAnalysisAnalyzedFields, z.array(z.string())]).describe('Specifies `includes` and/or `excludes` patterns to select which fields will be included in the analysis. The patterns specified in `excludes` are applied last, therefore `excludes` takes precedence. In other words, if the same field is specified in both `includes` and `excludes`, then the field will not be included in the analysis. If `analyzed_fields` is not set, only the relevant fields will be included. For example, all the numeric fields for outlier detection. The supported fields vary for each type of analysis. Outlier detection requires numeric or `boolean` data to analyze. The algorithms don’t support missing values therefore fields that have data types other than numeric or boolean are ignored. Documents where included fields contain missing values, null values, or an array are also ignored. Therefore the `dest` index may contain documents that don’t have an outlier score. Regression supports fields that are numeric, `boolean`, `text`, `keyword`, and `ip` data types. It is also tolerant of missing values. Fields that are supported are included in the analysis, other fields are ignored. Documents where included fields contain an array with two or more values are also ignored. Documents in the `dest` index that don’t contain a results field are not included in the regression analysis. Classification supports fields that are numeric, `boolean`, `text`, `keyword`, and `ip` data types. It is also tolerant of missing values. Fields that are supported are included in the analysis, other fields are ignored. Documents where included fields contain an array with two or more values are also ignored. Documents in the `dest` index that don’t contain a results field are not included in the classification analysis. Classification analysis can be improved by mapping ordinal variable values to a single number. For example, in case of age ranges, you can model the values as `0-14 = 0`, `15-24 = 1`, `25-34 = 2`, and so on.').optional().meta({ found_in: 'body' }),
   description: z.string().describe('A description of the job.').optional().meta({ found_in: 'body' }),
   dest: MlDataframeAnalyticsDestination.describe('The destination configuration.').meta({ found_in: 'body' }),
   max_num_threads: integer.describe('The maximum number of threads to be used by the analysis. Using more threads may decrease the time necessary to complete the analysis at the cost of using more CPU. Note that the process may use additional threads for operational functionality other than the analysis itself.').optional().meta({ found_in: 'body' }),
@@ -4131,7 +4164,7 @@ export const MlPutDataFrameAnalyticsResponse = z.object({
   authorization: MlDataframeAnalyticsAuthorization.optional(),
   allow_lazy_start: z.boolean(),
   analysis: MlDataframeAnalysisContainer,
-  analyzed_fields: MlDataframeAnalysisAnalyzedFields.optional(),
+  analyzed_fields: z.union([MlDataframeAnalysisAnalyzedFields, z.array(z.string())]).optional(),
   create_time: EpochTime,
   description: z.string().optional(),
   dest: MlDataframeAnalyticsDestination,

--- a/packages/es-schemas/src/ml_put_datafeed.ts
+++ b/packages/es-schemas/src/ml_put_datafeed.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),

--- a/packages/es-schemas/src/ml_put_filter.ts
+++ b/packages/es-schemas/src/ml_put_filter.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_put_job.ts
+++ b/packages/es-schemas/src/ml_put_job.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4166,7 +4199,7 @@ export const AnalysisConditionTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('condition'),
   filter: z.array(z.string()).describe('Array of token filters. If a token matches the predicate script in the `script` parameter, these filters are applied to the token in the order provided.'),
-  script: z.lazy(() => Script).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
 }).meta({ id: 'AnalysisConditionTokenFilter' })
 export type AnalysisConditionTokenFilter = z.infer<typeof AnalysisConditionTokenFilter>
 
@@ -4638,7 +4671,7 @@ export type AnalysisPorterStemTokenFilter = z.infer<typeof AnalysisPorterStemTok
 export const AnalysisPredicateTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('predicate_token_filter'),
-  script: z.lazy(() => Script).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
 }).meta({ id: 'AnalysisPredicateTokenFilter' })
 export type AnalysisPredicateTokenFilter = z.infer<typeof AnalysisPredicateTokenFilter>
 

--- a/packages/es-schemas/src/ml_put_trained_model.ts
+++ b/packages/es-schemas/src/ml_put_trained_model.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),

--- a/packages/es-schemas/src/ml_put_trained_model_alias.ts
+++ b/packages/es-schemas/src/ml_put_trained_model_alias.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_put_trained_model_definition_part.ts
+++ b/packages/es-schemas/src/ml_put_trained_model_definition_part.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_put_trained_model_vocabulary.ts
+++ b/packages/es-schemas/src/ml_put_trained_model_vocabulary.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_reset_job.ts
+++ b/packages/es-schemas/src/ml_reset_job.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_revert_model_snapshot.ts
+++ b/packages/es-schemas/src/ml_revert_model_snapshot.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_set_upgrade_mode.ts
+++ b/packages/es-schemas/src/ml_set_upgrade_mode.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_start_data_frame_analytics.ts
+++ b/packages/es-schemas/src/ml_start_data_frame_analytics.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_start_datafeed.ts
+++ b/packages/es-schemas/src/ml_start_datafeed.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_start_trained_model_deployment.ts
+++ b/packages/es-schemas/src/ml_start_trained_model_deployment.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_stop_data_frame_analytics.ts
+++ b/packages/es-schemas/src/ml_stop_data_frame_analytics.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_stop_datafeed.ts
+++ b/packages/es-schemas/src/ml_stop_datafeed.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_stop_trained_model_deployment.ts
+++ b/packages/es-schemas/src/ml_stop_trained_model_deployment.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_update_data_frame_analytics.ts
+++ b/packages/es-schemas/src/ml_update_data_frame_analytics.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4092,7 +4125,7 @@ export const MlDataframeAnalyticsSource = z.object({
   index: Indices.describe('Index or indices on which to perform the analysis. It can be a single index or index pattern as well as an array of indices or patterns. NOTE: If your source indices contain documents with the same IDs, only the document that is indexed last appears in the destination index.'),
   query: z.lazy(() => QueryDslQueryContainer).describe('The Elasticsearch query domain-specific language (DSL). This value corresponds to the query object in an Elasticsearch search POST body. All the options that are supported by Elasticsearch can be used, as this object is passed verbatim to Elasticsearch. By default, this property has the following value: {"match_all": {}}.').optional(),
   runtime_mappings: z.lazy(() => MappingRuntimeFields).describe('Definitions of runtime fields that will become part of the mapping of the destination index.').optional(),
-  _source: MlDataframeAnalysisAnalyzedFields.describe('Specify `includes` and/or `excludes patterns to select which fields will be present in the destination. Fields that are excluded cannot be included in the analysis.').optional()
+  _source: z.union([MlDataframeAnalysisAnalyzedFields, z.array(z.string())]).describe('Specify `includes` and/or `excludes patterns to select which fields will be present in the destination. Fields that are excluded cannot be included in the analysis.').optional()
 }).meta({ id: 'MlDataframeAnalyticsSource' })
 export type MlDataframeAnalyticsSource = z.infer<typeof MlDataframeAnalyticsSource>
 
@@ -4111,7 +4144,7 @@ export const MlUpdateDataFrameAnalyticsResponse = z.object({
   authorization: MlDataframeAnalyticsAuthorization.optional(),
   allow_lazy_start: z.boolean(),
   analysis: MlDataframeAnalysisContainer,
-  analyzed_fields: MlDataframeAnalysisAnalyzedFields.optional(),
+  analyzed_fields: z.union([MlDataframeAnalysisAnalyzedFields, z.array(z.string())]).optional(),
   create_time: long,
   description: z.string().optional(),
   dest: MlDataframeAnalyticsDestination,

--- a/packages/es-schemas/src/ml_update_datafeed.ts
+++ b/packages/es-schemas/src/ml_update_datafeed.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),

--- a/packages/es-schemas/src/ml_update_filter.ts
+++ b/packages/es-schemas/src/ml_update_filter.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_update_job.ts
+++ b/packages/es-schemas/src/ml_update_job.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4163,7 +4196,7 @@ export const AnalysisConditionTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('condition'),
   filter: z.array(z.string()).describe('Array of token filters. If a token matches the predicate script in the `script` parameter, these filters are applied to the token in the order provided.'),
-  script: z.lazy(() => Script).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
 }).meta({ id: 'AnalysisConditionTokenFilter' })
 export type AnalysisConditionTokenFilter = z.infer<typeof AnalysisConditionTokenFilter>
 
@@ -4635,7 +4668,7 @@ export type AnalysisPorterStemTokenFilter = z.infer<typeof AnalysisPorterStemTok
 export const AnalysisPredicateTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('predicate_token_filter'),
-  script: z.lazy(() => Script).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
 }).meta({ id: 'AnalysisPredicateTokenFilter' })
 export type AnalysisPredicateTokenFilter = z.infer<typeof AnalysisPredicateTokenFilter>
 

--- a/packages/es-schemas/src/ml_update_model_snapshot.ts
+++ b/packages/es-schemas/src/ml_update_model_snapshot.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_update_trained_model_deployment.ts
+++ b/packages/es-schemas/src/ml_update_trained_model_deployment.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_upgrade_job_snapshot.ts
+++ b/packages/es-schemas/src/ml_upgrade_job_snapshot.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/ml_validate.ts
+++ b/packages/es-schemas/src/ml_validate.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4150,7 +4183,7 @@ export const AnalysisConditionTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('condition'),
   filter: z.array(z.string()).describe('Array of token filters. If a token matches the predicate script in the `script` parameter, these filters are applied to the token in the order provided.'),
-  script: z.lazy(() => Script).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
 }).meta({ id: 'AnalysisConditionTokenFilter' })
 export type AnalysisConditionTokenFilter = z.infer<typeof AnalysisConditionTokenFilter>
 
@@ -4622,7 +4655,7 @@ export type AnalysisPorterStemTokenFilter = z.infer<typeof AnalysisPorterStemTok
 export const AnalysisPredicateTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('predicate_token_filter'),
-  script: z.lazy(() => Script).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
 }).meta({ id: 'AnalysisPredicateTokenFilter' })
 export type AnalysisPredicateTokenFilter = z.infer<typeof AnalysisPredicateTokenFilter>
 

--- a/packages/es-schemas/src/ml_validate_detector.ts
+++ b/packages/es-schemas/src/ml_validate_detector.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/monitoring_bulk.ts
+++ b/packages/es-schemas/src/monitoring_bulk.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -295,7 +296,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -626,7 +627,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -689,7 +690,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -728,7 +729,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface SearchInnerHitsShape {
@@ -742,7 +743,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -754,13 +756,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -828,7 +831,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -960,6 +963,43 @@ export type QueryDslIntervalsQuery = z.infer<typeof QueryDslIntervalsQuery>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+/**
+ * A duration. Units can be `nanos`, `micros`, `ms` (milliseconds), `s` (seconds), `m` (minutes), `h` (hours) and
+ * `d` (days). Also accepts "0" without a unit and "-1" to indicate an unspecified value.
+ */
+export const Duration = z.union([z.string(), z.literal(-1), z.literal(0)]).meta({ id: 'Duration' })
+export type Duration = z.infer<typeof Duration>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -974,7 +1014,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -1376,7 +1416,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -1392,7 +1432,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -1559,7 +1599,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -1635,7 +1675,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -1676,7 +1716,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -1773,7 +1813,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -1784,11 +1824,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -1804,7 +1844,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -1817,7 +1857,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -1831,7 +1871,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -1877,7 +1917,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -1893,7 +1933,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -1907,7 +1947,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -1982,7 +2022,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -1997,7 +2037,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -2009,7 +2049,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -2075,7 +2115,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -2093,7 +2133,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -2112,7 +2152,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -2125,13 +2165,6 @@ export type AggregationsCompositeHistogramAggregation = z.infer<typeof Aggregati
  */
 export const DurationLarge = z.string().meta({ id: 'DurationLarge' })
 export type DurationLarge = z.infer<typeof DurationLarge>
-
-/**
- * A duration. Units can be `nanos`, `micros`, `ms` (milliseconds), `s` (seconds), `m` (minutes), `h` (hours) and
- * `d` (days). Also accepts "0" without a unit and "-1" to indicate an unspecified value.
- */
-export const Duration = z.union([z.string(), z.literal(-1), z.literal(0)]).meta({ id: 'Duration' })
-export type Duration = z.infer<typeof Duration>
 
 export interface AggregationsCompositeDateHistogramAggregationShape {
   field?: Field | undefined
@@ -2150,7 +2183,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -2231,7 +2264,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -2314,7 +2347,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -2366,7 +2399,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -2382,7 +2415,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -2454,7 +2487,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -2469,7 +2502,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -2575,7 +2608,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -2654,7 +2687,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -2675,7 +2708,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -2691,7 +2724,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -2806,7 +2839,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -2883,7 +2916,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -2905,7 +2938,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -2932,7 +2965,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -2964,7 +2997,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -2996,12 +3029,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -3039,7 +3072,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -3136,7 +3169,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -3155,7 +3188,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -3169,7 +3202,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -3210,7 +3243,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -3247,10 +3280,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -3271,7 +3304,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -3307,7 +3340,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -3323,7 +3356,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -3337,7 +3370,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -3350,7 +3383,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -3380,7 +3413,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -3545,7 +3578,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -3897,12 +3930,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -3955,7 +3988,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -3969,7 +4002,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -4010,7 +4043,7 @@ export const BulkUpdateAction = z.object({
   detect_noop: z.boolean().describe('If true, the `result` in the response is set to \'noop\' when no changes to the document occur.').optional(),
   doc: z.any().describe('A partial update to an existing document.').optional(),
   doc_as_upsert: z.boolean().describe('Set to `true` to use the contents of `doc` as the value of `upsert`.').optional(),
-  script: z.lazy(() => Script).describe('The script to run to update the document.').optional(),
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('The script to run to update the document.').optional(),
   scripted_upsert: z.boolean().describe('Set to `true` to run the script whether or not the document exists.').optional(),
   _source: SearchSourceConfig.describe('If `false`, source retrieval is turned off. You can also specify a comma-separated list of the fields you want to retrieve.').optional(),
   upsert: z.any().describe('If the document does not already exist, the contents of `upsert` are inserted as a new document. If the document exists, the `script` is run.').optional()

--- a/packages/es-schemas/src/msearch.ts
+++ b/packages/es-schemas/src/msearch.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -572,188 +573,6 @@ export const SearchShardProfile = z.object({
 }).meta({ id: 'SearchShardProfile' })
 export type SearchShardProfile = z.infer<typeof SearchShardProfile>
 
-export const SearchProfile = z.object({
-  shards: z.array(SearchShardProfile)
-}).meta({ id: 'SearchProfile' })
-export type SearchProfile = z.infer<typeof SearchProfile>
-
-export const ScrollId = z.string().meta({ id: 'ScrollId' })
-export type ScrollId = z.infer<typeof ScrollId>
-
-/**
- * The suggestion name as returned from the server. Depending whether typed_keys is specified this could come back
- * in the form of `name#type` instead of simply `name`
- */
-export const SuggestionName = z.string().meta({ id: 'SuggestionName' })
-export type SuggestionName = z.infer<typeof SuggestionName>
-
-export const SearchSuggestBase = z.object({
-  length: integer,
-  offset: integer,
-  text: z.string()
-}).meta({ id: 'SearchSuggestBase' })
-export type SearchSuggestBase = z.infer<typeof SearchSuggestBase>
-
-export const LatLonGeoLocation = z.object({
-  lat: double.describe('Latitude'),
-  lon: double.describe('Longitude')
-}).meta({ id: 'LatLonGeoLocation' })
-export type LatLonGeoLocation = z.infer<typeof LatLonGeoLocation>
-
-export const GeoHash = z.string().meta({ id: 'GeoHash' })
-export type GeoHash = z.infer<typeof GeoHash>
-
-export const GeoHashLocation = z.object({
-  geohash: GeoHash
-}).meta({ id: 'GeoHashLocation' })
-export type GeoHashLocation = z.infer<typeof GeoHashLocation>
-
-/**
- * A latitude/longitude as a 2 dimensional point. It can be represented in various ways:
- * - as a `{lat, long}` object
- * - as a geo hash value
- * - as a `[lon, lat]` array
- * - as a string in `"<lat>, <lon>"` or WKT point formats
- */
-export const GeoLocation = z.union([LatLonGeoLocation, GeoHashLocation, z.array(double), z.string()]).meta({ id: 'GeoLocation' })
-export type GeoLocation = z.infer<typeof GeoLocation>
-
-/** Text or location that we want similar documents for or a lookup to a document's field for the text. */
-export const SearchContext = z.union([z.string(), GeoLocation]).meta({ id: 'SearchContext' })
-export type SearchContext = z.infer<typeof SearchContext>
-
-export const SearchCompletionSuggestOption = z.object({
-  collate_match: z.boolean().optional(),
-  contexts: z.record(z.string(), z.array(SearchContext)).optional(),
-  fields: z.record(z.string(), z.any()).optional(),
-  _id: z.string().optional(),
-  _index: IndexName.optional(),
-  _routing: z.string().optional(),
-  _score: double.optional(),
-  _source: z.any().optional(),
-  text: z.string(),
-  score: double.optional()
-}).meta({ id: 'SearchCompletionSuggestOption' })
-export type SearchCompletionSuggestOption = z.infer<typeof SearchCompletionSuggestOption>
-
-export const SearchCompletionSuggest = z.object({
-  ...SearchSuggestBase.shape,
-  options: z.union([SearchCompletionSuggestOption, z.array(SearchCompletionSuggestOption)])
-}).meta({ id: 'SearchCompletionSuggest' })
-export type SearchCompletionSuggest = z.infer<typeof SearchCompletionSuggest>
-
-export const SearchPhraseSuggestOption = z.object({
-  text: z.string(),
-  score: double,
-  highlighted: z.string().optional(),
-  collate_match: z.boolean().optional()
-}).meta({ id: 'SearchPhraseSuggestOption' })
-export type SearchPhraseSuggestOption = z.infer<typeof SearchPhraseSuggestOption>
-
-export const SearchPhraseSuggest = z.object({
-  ...SearchSuggestBase.shape,
-  options: z.union([SearchPhraseSuggestOption, z.array(SearchPhraseSuggestOption)])
-}).meta({ id: 'SearchPhraseSuggest' })
-export type SearchPhraseSuggest = z.infer<typeof SearchPhraseSuggest>
-
-export const SearchTermSuggestOption = z.object({
-  text: z.string(),
-  score: double,
-  freq: long,
-  highlighted: z.string().optional(),
-  collate_match: z.boolean().optional()
-}).meta({ id: 'SearchTermSuggestOption' })
-export type SearchTermSuggestOption = z.infer<typeof SearchTermSuggestOption>
-
-export const SearchTermSuggest = z.object({
-  ...SearchSuggestBase.shape,
-  options: z.union([SearchTermSuggestOption, z.array(SearchTermSuggestOption)])
-}).meta({ id: 'SearchTermSuggest' })
-export type SearchTermSuggest = z.infer<typeof SearchTermSuggest>
-
-export const SearchSuggest = z.union([SearchCompletionSuggest, SearchPhraseSuggest, SearchTermSuggest]).meta({ id: 'SearchSuggest' })
-export type SearchSuggest = z.infer<typeof SearchSuggest>
-
-export const SearchResponseBody = z.object({
-  took: long.describe('The number of milliseconds it took Elasticsearch to run the request. This value is calculated by measuring the time elapsed between receipt of a request on the coordinating node and the time at which the coordinating node is ready to send the response. It includes: * Communication time between the coordinating node and data nodes * Time the request spends in the search thread pool, queued for execution * Actual run time It does not include: * Time needed to send the request to Elasticsearch * Time needed to serialize the JSON response * Time needed to send the response to a client'),
-  timed_out: z.boolean().describe('If `true`, the request timed out before completion; returned results may be partial or empty.'),
-  _shards: ShardStatistics.describe('A count of shards used for the request.'),
-  hits: z.lazy(() => SearchHitsMetadata).describe('The returned documents and metadata.'),
-  aggregations: z.any().optional(),
-  _clusters: ClusterStatistics.optional(),
-  fields: z.record(z.string(), z.any()).optional(),
-  max_score: double.optional(),
-  num_reduce_phases: long.optional(),
-  profile: SearchProfile.optional(),
-  pit_id: Id.optional(),
-  _scroll_id: ScrollId.describe('The identifier for the search and its search context. You can use this scroll ID with the scroll API to retrieve the next batch of search results for the request. This property is returned only if the `scroll` query parameter is specified in the request.').optional(),
-  suggest: z.record(SuggestionName, z.array(SearchSuggest)).optional(),
-  terminated_early: z.boolean().optional()
-}).meta({ id: 'SearchResponseBody' })
-export type SearchResponseBody = z.infer<typeof SearchResponseBody>
-
-export const MsearchMultiSearchItem = z.object({
-  ...SearchResponseBody.shape,
-  status: integer.optional()
-}).meta({ id: 'MsearchMultiSearchItem' })
-export type MsearchMultiSearchItem = z.infer<typeof MsearchMultiSearchItem>
-
-/** The response returned by Elasticsearch when request execution did not succeed. */
-export const ErrorResponseBase = z.object({
-  error: z.lazy(() => ErrorCause),
-  status: integer
-}).meta({ id: 'ErrorResponseBase' })
-export type ErrorResponseBase = z.infer<typeof ErrorResponseBase>
-
-export const MsearchResponseItem = z.union([MsearchMultiSearchItem, ErrorResponseBase]).meta({ id: 'MsearchResponseItem' })
-export type MsearchResponseItem = z.infer<typeof MsearchResponseItem>
-
-export const MsearchMultiSearchResult = z.object({
-  took: long,
-  responses: z.array(MsearchResponseItem)
-}).meta({ id: 'MsearchMultiSearchResult' })
-export type MsearchMultiSearchResult = z.infer<typeof MsearchMultiSearchResult>
-
-export const ExpandWildcard = z.enum(['all', 'open', 'closed', 'hidden', 'none']).meta({ id: 'ExpandWildcard' })
-export type ExpandWildcard = z.infer<typeof ExpandWildcard>
-
-export const ExpandWildcards = z.union([ExpandWildcard, z.array(ExpandWildcard)]).meta({ id: 'ExpandWildcards' })
-export type ExpandWildcards = z.infer<typeof ExpandWildcards>
-
-export const Indices = z.union([IndexName, z.array(IndexName)]).meta({ id: 'Indices' })
-export type Indices = z.infer<typeof Indices>
-
-export const ProjectRouting = z.string().meta({ id: 'ProjectRouting' })
-export type ProjectRouting = z.infer<typeof ProjectRouting>
-
-/** Only to be used in query and path parameters, as the array form is actually a csv */
-export const Routing = z.union([z.string(), z.array(z.string())]).meta({ id: 'Routing' })
-export type Routing = z.infer<typeof Routing>
-
-export const SearchType = z.enum(['query_then_fetch', 'dfs_query_then_fetch']).meta({ id: 'SearchType' })
-export type SearchType = z.infer<typeof SearchType>
-
-/** Contains parameters used to limit or change the subsequent search body request. */
-export const MsearchMultisearchHeader = z.object({
-  allow_no_indices: z.boolean().describe('A setting that does two separate checks on the index expression. If `false`, the request returns an error (1) if any wildcard expression (including `_all` and `*`) resolves to zero matching indices or (2) if the complete set of resolved indices, aliases or data streams is empty after all expressions are evaluated. If `true`, index expressions that resolve to no indices are allowed and the request returns an empty result.').optional(),
-  expand_wildcards: ExpandWildcards.optional(),
-  ignore_unavailable: z.boolean().describe('If `false`, the request returns an error if it targets a concrete (non-wildcarded) index, alias, or data stream that is missing, closed, or otherwise unavailable. If `true`, unavailable concrete targets are silently ignored.').optional(),
-  index: Indices.optional(),
-  preference: z.string().optional(),
-  project_routing: ProjectRouting.optional(),
-  request_cache: z.boolean().optional(),
-  routing: Routing.optional(),
-  search_type: SearchType.optional(),
-  ccs_minimize_roundtrips: z.boolean().optional(),
-  allow_partial_search_results: z.boolean().optional(),
-  ignore_throttled: z.boolean().optional()
-}).meta({ id: 'MsearchMultisearchHeader' })
-export type MsearchMultisearchHeader = z.infer<typeof MsearchMultisearchHeader>
-
-export const RequestBase = z.object({
-}).meta({ id: 'RequestBase' })
-export type RequestBase = z.infer<typeof RequestBase>
-
 export const Metadata = z.record(z.string(), z.any()).meta({ id: 'Metadata' })
 export type Metadata = z.infer<typeof Metadata>
 
@@ -979,7 +798,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -1079,6 +898,9 @@ export type QueryDslGeoDistanceQuery = z.infer<typeof QueryDslGeoDistanceQuery>
 /** A map tile reference, represented as `{zoom}/{x}/{y}` */
 export const GeoTile = z.string().meta({ id: 'GeoTile' })
 export type GeoTile = z.infer<typeof GeoTile>
+
+export const GeoHash = z.string().meta({ id: 'GeoHash' })
+export type GeoHash = z.infer<typeof GeoHash>
 
 /** A map hex cell (H3) reference */
 export const GeoHexCell = z.string().meta({ id: 'GeoHexCell' })
@@ -1307,7 +1129,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1370,7 +1192,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -1409,7 +1231,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface SearchInnerHitsShape {
@@ -1423,7 +1245,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -1435,13 +1258,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -1509,7 +1333,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -1641,6 +1465,36 @@ export type QueryDslIntervalsQuery = z.infer<typeof QueryDslIntervalsQuery>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -1655,7 +1509,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -1756,6 +1610,10 @@ export const QueryDslMatchPhrasePrefixQuery = z.object({
   zero_terms_query: QueryDslZeroTermsQuery.describe('Indicates whether no documents are returned if the analyzer removes all tokens, such as when using a `stop` filter.').optional()
 }).meta({ id: 'QueryDslMatchPhrasePrefixQuery' })
 export type QueryDslMatchPhrasePrefixQuery = z.infer<typeof QueryDslMatchPhrasePrefixQuery>
+
+/** Only to be used in query and path parameters, as the array form is actually a csv */
+export const Routing = z.union([z.string(), z.array(z.string())]).meta({ id: 'Routing' })
+export type Routing = z.infer<typeof Routing>
 
 export const VersionType = z.enum(['internal', 'external', 'external_gte']).meta({ id: 'VersionType' })
 export type VersionType = z.infer<typeof VersionType>
@@ -2056,7 +1914,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -2072,7 +1930,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -2235,7 +2093,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -2311,7 +2169,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -2352,7 +2210,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -2449,7 +2307,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -2460,11 +2318,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -2480,7 +2338,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -2493,7 +2351,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -2507,7 +2365,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -2553,7 +2411,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -2569,7 +2427,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -2583,7 +2441,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -2658,7 +2516,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -2673,7 +2531,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -2685,7 +2543,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -2751,7 +2609,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -2769,7 +2627,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -2788,7 +2646,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -2819,7 +2677,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -2837,6 +2695,27 @@ export const CoordsGeoBounds = z.object({
   right: double
 }).meta({ id: 'CoordsGeoBounds' })
 export type CoordsGeoBounds = z.infer<typeof CoordsGeoBounds>
+
+export const LatLonGeoLocation = z.object({
+  lat: double.describe('Latitude'),
+  lon: double.describe('Longitude')
+}).meta({ id: 'LatLonGeoLocation' })
+export type LatLonGeoLocation = z.infer<typeof LatLonGeoLocation>
+
+export const GeoHashLocation = z.object({
+  geohash: GeoHash
+}).meta({ id: 'GeoHashLocation' })
+export type GeoHashLocation = z.infer<typeof GeoHashLocation>
+
+/**
+ * A latitude/longitude as a 2 dimensional point. It can be represented in various ways:
+ * - as a `{lat, long}` object
+ * - as a geo hash value
+ * - as a `[lon, lat]` array
+ * - as a string in `"<lat>, <lon>"` or WKT point formats
+ */
+export const GeoLocation = z.union([LatLonGeoLocation, GeoHashLocation, z.array(double), z.string()]).meta({ id: 'GeoLocation' })
+export type GeoLocation = z.infer<typeof GeoLocation>
 
 export const TopLeftBottomRightGeoBounds = z.object({
   top_left: GeoLocation,
@@ -2879,7 +2758,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -2962,7 +2841,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -3014,7 +2893,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -3030,7 +2909,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -3102,7 +2981,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -3117,7 +2996,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -3223,7 +3102,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -3302,7 +3181,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -3323,7 +3202,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -3339,7 +3218,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -3454,7 +3333,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -3531,7 +3410,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -3553,7 +3432,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -3580,7 +3459,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -3612,7 +3491,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -3644,12 +3523,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -3687,7 +3566,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -3784,7 +3663,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -3803,7 +3682,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -3817,7 +3696,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -3858,7 +3737,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -3895,10 +3774,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -3919,7 +3798,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -3955,7 +3834,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -3971,7 +3850,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -3985,7 +3864,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -3998,7 +3877,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -4028,7 +3907,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -4193,7 +4072,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -4542,12 +4421,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -4600,7 +4479,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -4614,7 +4493,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -4627,6 +4506,171 @@ export const SearchSearchRequestBody = z.object({
   stats: z.array(z.string()).describe('The stats groups to associate with the search. Each group maintains a statistics aggregation for its associated searches. You can retrieve these stats using the indices stats API.').optional()
 }).meta({ id: 'SearchSearchRequestBody' })
 export type SearchSearchRequestBody = z.infer<typeof SearchSearchRequestBody>
+
+/**
+ * Coordinator snapshot of the original search request, serialized under `profile.request` when profiling is enabled.
+ * Introduced in Elasticsearch 9.5; omitted when the cluster contains mixed-version nodes that do not serialize this metadata.
+ */
+export const SearchSearchRequestCoordinatorMetadata = z.object({
+  source: z.lazy(() => SearchSearchRequestBody).describe('Original query source from the search request (`SearchSourceBuilder` as JSON).').optional(),
+  indices: z.array(IndexName).describe('Target index expressions from the request (before index resolution).').optional()
+}).meta({ id: 'SearchSearchRequestCoordinatorMetadata' })
+export type SearchSearchRequestCoordinatorMetadata = z.infer<typeof SearchSearchRequestCoordinatorMetadata>
+
+export const SearchProfile = z.object({
+  shards: z.array(SearchShardProfile),
+  request: SearchSearchRequestCoordinatorMetadata.describe('When profiling is enabled, the original query source and target indices from the coordinating request.').optional()
+}).meta({ id: 'SearchProfile' })
+export type SearchProfile = z.infer<typeof SearchProfile>
+
+export const ScrollId = z.string().meta({ id: 'ScrollId' })
+export type ScrollId = z.infer<typeof ScrollId>
+
+/**
+ * The suggestion name as returned from the server. Depending whether typed_keys is specified this could come back
+ * in the form of `name#type` instead of simply `name`
+ */
+export const SuggestionName = z.string().meta({ id: 'SuggestionName' })
+export type SuggestionName = z.infer<typeof SuggestionName>
+
+export const SearchSuggestBase = z.object({
+  length: integer,
+  offset: integer,
+  text: z.string()
+}).meta({ id: 'SearchSuggestBase' })
+export type SearchSuggestBase = z.infer<typeof SearchSuggestBase>
+
+/** Text or location that we want similar documents for or a lookup to a document's field for the text. */
+export const SearchContext = z.union([z.string(), GeoLocation]).meta({ id: 'SearchContext' })
+export type SearchContext = z.infer<typeof SearchContext>
+
+export const SearchCompletionSuggestOption = z.object({
+  collate_match: z.boolean().optional(),
+  contexts: z.record(z.string(), z.array(SearchContext)).optional(),
+  fields: z.record(z.string(), z.any()).optional(),
+  _id: z.string().optional(),
+  _index: IndexName.optional(),
+  _routing: z.string().optional(),
+  _score: double.optional(),
+  _source: z.any().optional(),
+  text: z.string(),
+  score: double.optional()
+}).meta({ id: 'SearchCompletionSuggestOption' })
+export type SearchCompletionSuggestOption = z.infer<typeof SearchCompletionSuggestOption>
+
+export const SearchCompletionSuggest = z.object({
+  ...SearchSuggestBase.shape,
+  options: z.union([SearchCompletionSuggestOption, z.array(SearchCompletionSuggestOption)])
+}).meta({ id: 'SearchCompletionSuggest' })
+export type SearchCompletionSuggest = z.infer<typeof SearchCompletionSuggest>
+
+export const SearchPhraseSuggestOption = z.object({
+  text: z.string(),
+  score: double,
+  highlighted: z.string().optional(),
+  collate_match: z.boolean().optional()
+}).meta({ id: 'SearchPhraseSuggestOption' })
+export type SearchPhraseSuggestOption = z.infer<typeof SearchPhraseSuggestOption>
+
+export const SearchPhraseSuggest = z.object({
+  ...SearchSuggestBase.shape,
+  options: z.union([SearchPhraseSuggestOption, z.array(SearchPhraseSuggestOption)])
+}).meta({ id: 'SearchPhraseSuggest' })
+export type SearchPhraseSuggest = z.infer<typeof SearchPhraseSuggest>
+
+export const SearchTermSuggestOption = z.object({
+  text: z.string(),
+  score: double,
+  freq: long,
+  highlighted: z.string().optional(),
+  collate_match: z.boolean().optional()
+}).meta({ id: 'SearchTermSuggestOption' })
+export type SearchTermSuggestOption = z.infer<typeof SearchTermSuggestOption>
+
+export const SearchTermSuggest = z.object({
+  ...SearchSuggestBase.shape,
+  options: z.union([SearchTermSuggestOption, z.array(SearchTermSuggestOption)])
+}).meta({ id: 'SearchTermSuggest' })
+export type SearchTermSuggest = z.infer<typeof SearchTermSuggest>
+
+export const SearchSuggest = z.union([SearchCompletionSuggest, SearchPhraseSuggest, SearchTermSuggest]).meta({ id: 'SearchSuggest' })
+export type SearchSuggest = z.infer<typeof SearchSuggest>
+
+export const SearchResponseBody = z.object({
+  took: long.describe('The number of milliseconds it took Elasticsearch to run the request. This value is calculated by measuring the time elapsed between receipt of a request on the coordinating node and the time at which the coordinating node is ready to send the response. It includes: * Communication time between the coordinating node and data nodes * Time the request spends in the search thread pool, queued for execution * Actual run time It does not include: * Time needed to send the request to Elasticsearch * Time needed to serialize the JSON response * Time needed to send the response to a client'),
+  timed_out: z.boolean().describe('If `true`, the request timed out before completion; returned results may be partial or empty.'),
+  _shards: ShardStatistics.describe('A count of shards used for the request.'),
+  hits: z.lazy(() => SearchHitsMetadata).describe('The returned documents and metadata.'),
+  aggregations: z.any().optional(),
+  _clusters: ClusterStatistics.optional(),
+  fields: z.record(z.string(), z.any()).optional(),
+  max_score: double.optional(),
+  num_reduce_phases: long.optional(),
+  profile: SearchProfile.optional(),
+  pit_id: Id.optional(),
+  _scroll_id: ScrollId.describe('The identifier for the search and its search context. You can use this scroll ID with the scroll API to retrieve the next batch of search results for the request. This property is returned only if the `scroll` query parameter is specified in the request.').optional(),
+  suggest: z.record(SuggestionName, z.array(SearchSuggest)).optional(),
+  terminated_early: z.boolean().optional()
+}).meta({ id: 'SearchResponseBody' })
+export type SearchResponseBody = z.infer<typeof SearchResponseBody>
+
+export const MsearchMultiSearchItem = z.object({
+  ...SearchResponseBody.shape,
+  status: integer.optional()
+}).meta({ id: 'MsearchMultiSearchItem' })
+export type MsearchMultiSearchItem = z.infer<typeof MsearchMultiSearchItem>
+
+/** The response returned by Elasticsearch when request execution did not succeed. */
+export const ErrorResponseBase = z.object({
+  error: z.lazy(() => ErrorCause),
+  status: integer
+}).meta({ id: 'ErrorResponseBase' })
+export type ErrorResponseBase = z.infer<typeof ErrorResponseBase>
+
+export const MsearchResponseItem = z.union([MsearchMultiSearchItem, ErrorResponseBase]).meta({ id: 'MsearchResponseItem' })
+export type MsearchResponseItem = z.infer<typeof MsearchResponseItem>
+
+export const MsearchMultiSearchResult = z.object({
+  took: long,
+  responses: z.array(MsearchResponseItem)
+}).meta({ id: 'MsearchMultiSearchResult' })
+export type MsearchMultiSearchResult = z.infer<typeof MsearchMultiSearchResult>
+
+export const ExpandWildcard = z.enum(['all', 'open', 'closed', 'hidden', 'none']).meta({ id: 'ExpandWildcard' })
+export type ExpandWildcard = z.infer<typeof ExpandWildcard>
+
+export const ExpandWildcards = z.union([ExpandWildcard, z.array(ExpandWildcard)]).meta({ id: 'ExpandWildcards' })
+export type ExpandWildcards = z.infer<typeof ExpandWildcards>
+
+export const Indices = z.union([IndexName, z.array(IndexName)]).meta({ id: 'Indices' })
+export type Indices = z.infer<typeof Indices>
+
+export const ProjectRouting = z.string().meta({ id: 'ProjectRouting' })
+export type ProjectRouting = z.infer<typeof ProjectRouting>
+
+export const SearchType = z.enum(['query_then_fetch', 'dfs_query_then_fetch']).meta({ id: 'SearchType' })
+export type SearchType = z.infer<typeof SearchType>
+
+/** Contains parameters used to limit or change the subsequent search body request. */
+export const MsearchMultisearchHeader = z.object({
+  allow_no_indices: z.boolean().describe('A setting that does two separate checks on the index expression. If `false`, the request returns an error (1) if any wildcard expression (including `_all` and `*`) resolves to zero matching indices or (2) if the complete set of resolved indices, aliases or data streams is empty after all expressions are evaluated. If `true`, index expressions that resolve to no indices are allowed and the request returns an empty result.').optional(),
+  expand_wildcards: ExpandWildcards.optional(),
+  ignore_unavailable: z.boolean().describe('If `false`, the request returns an error if it targets a concrete (non-wildcarded) index, alias, or data stream that is missing, closed, or otherwise unavailable. If `true`, unavailable concrete targets are silently ignored.').optional(),
+  index: Indices.optional(),
+  preference: z.string().optional(),
+  project_routing: ProjectRouting.optional(),
+  request_cache: z.boolean().optional(),
+  routing: Routing.optional(),
+  search_type: SearchType.optional(),
+  ccs_minimize_roundtrips: z.boolean().optional(),
+  allow_partial_search_results: z.boolean().optional(),
+  ignore_throttled: z.boolean().optional()
+}).meta({ id: 'MsearchMultisearchHeader' })
+export type MsearchMultisearchHeader = z.infer<typeof MsearchMultisearchHeader>
+
+export const RequestBase = z.object({
+}).meta({ id: 'RequestBase' })
+export type RequestBase = z.infer<typeof RequestBase>
 
 export const MsearchRequestItem = z.union([MsearchMultisearchHeader, z.lazy(() => SearchSearchRequestBody)]).meta({ id: 'MsearchRequestItem' })
 export type MsearchRequestItem = z.infer<typeof MsearchRequestItem>

--- a/packages/es-schemas/src/msearch_template.ts
+++ b/packages/es-schemas/src/msearch_template.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -572,188 +573,6 @@ export const SearchShardProfile = z.object({
 }).meta({ id: 'SearchShardProfile' })
 export type SearchShardProfile = z.infer<typeof SearchShardProfile>
 
-export const SearchProfile = z.object({
-  shards: z.array(SearchShardProfile)
-}).meta({ id: 'SearchProfile' })
-export type SearchProfile = z.infer<typeof SearchProfile>
-
-export const ScrollId = z.string().meta({ id: 'ScrollId' })
-export type ScrollId = z.infer<typeof ScrollId>
-
-/**
- * The suggestion name as returned from the server. Depending whether typed_keys is specified this could come back
- * in the form of `name#type` instead of simply `name`
- */
-export const SuggestionName = z.string().meta({ id: 'SuggestionName' })
-export type SuggestionName = z.infer<typeof SuggestionName>
-
-export const SearchSuggestBase = z.object({
-  length: integer,
-  offset: integer,
-  text: z.string()
-}).meta({ id: 'SearchSuggestBase' })
-export type SearchSuggestBase = z.infer<typeof SearchSuggestBase>
-
-export const LatLonGeoLocation = z.object({
-  lat: double.describe('Latitude'),
-  lon: double.describe('Longitude')
-}).meta({ id: 'LatLonGeoLocation' })
-export type LatLonGeoLocation = z.infer<typeof LatLonGeoLocation>
-
-export const GeoHash = z.string().meta({ id: 'GeoHash' })
-export type GeoHash = z.infer<typeof GeoHash>
-
-export const GeoHashLocation = z.object({
-  geohash: GeoHash
-}).meta({ id: 'GeoHashLocation' })
-export type GeoHashLocation = z.infer<typeof GeoHashLocation>
-
-/**
- * A latitude/longitude as a 2 dimensional point. It can be represented in various ways:
- * - as a `{lat, long}` object
- * - as a geo hash value
- * - as a `[lon, lat]` array
- * - as a string in `"<lat>, <lon>"` or WKT point formats
- */
-export const GeoLocation = z.union([LatLonGeoLocation, GeoHashLocation, z.array(double), z.string()]).meta({ id: 'GeoLocation' })
-export type GeoLocation = z.infer<typeof GeoLocation>
-
-/** Text or location that we want similar documents for or a lookup to a document's field for the text. */
-export const SearchContext = z.union([z.string(), GeoLocation]).meta({ id: 'SearchContext' })
-export type SearchContext = z.infer<typeof SearchContext>
-
-export const SearchCompletionSuggestOption = z.object({
-  collate_match: z.boolean().optional(),
-  contexts: z.record(z.string(), z.array(SearchContext)).optional(),
-  fields: z.record(z.string(), z.any()).optional(),
-  _id: z.string().optional(),
-  _index: IndexName.optional(),
-  _routing: z.string().optional(),
-  _score: double.optional(),
-  _source: z.any().optional(),
-  text: z.string(),
-  score: double.optional()
-}).meta({ id: 'SearchCompletionSuggestOption' })
-export type SearchCompletionSuggestOption = z.infer<typeof SearchCompletionSuggestOption>
-
-export const SearchCompletionSuggest = z.object({
-  ...SearchSuggestBase.shape,
-  options: z.union([SearchCompletionSuggestOption, z.array(SearchCompletionSuggestOption)])
-}).meta({ id: 'SearchCompletionSuggest' })
-export type SearchCompletionSuggest = z.infer<typeof SearchCompletionSuggest>
-
-export const SearchPhraseSuggestOption = z.object({
-  text: z.string(),
-  score: double,
-  highlighted: z.string().optional(),
-  collate_match: z.boolean().optional()
-}).meta({ id: 'SearchPhraseSuggestOption' })
-export type SearchPhraseSuggestOption = z.infer<typeof SearchPhraseSuggestOption>
-
-export const SearchPhraseSuggest = z.object({
-  ...SearchSuggestBase.shape,
-  options: z.union([SearchPhraseSuggestOption, z.array(SearchPhraseSuggestOption)])
-}).meta({ id: 'SearchPhraseSuggest' })
-export type SearchPhraseSuggest = z.infer<typeof SearchPhraseSuggest>
-
-export const SearchTermSuggestOption = z.object({
-  text: z.string(),
-  score: double,
-  freq: long,
-  highlighted: z.string().optional(),
-  collate_match: z.boolean().optional()
-}).meta({ id: 'SearchTermSuggestOption' })
-export type SearchTermSuggestOption = z.infer<typeof SearchTermSuggestOption>
-
-export const SearchTermSuggest = z.object({
-  ...SearchSuggestBase.shape,
-  options: z.union([SearchTermSuggestOption, z.array(SearchTermSuggestOption)])
-}).meta({ id: 'SearchTermSuggest' })
-export type SearchTermSuggest = z.infer<typeof SearchTermSuggest>
-
-export const SearchSuggest = z.union([SearchCompletionSuggest, SearchPhraseSuggest, SearchTermSuggest]).meta({ id: 'SearchSuggest' })
-export type SearchSuggest = z.infer<typeof SearchSuggest>
-
-export const SearchResponseBody = z.object({
-  took: long.describe('The number of milliseconds it took Elasticsearch to run the request. This value is calculated by measuring the time elapsed between receipt of a request on the coordinating node and the time at which the coordinating node is ready to send the response. It includes: * Communication time between the coordinating node and data nodes * Time the request spends in the search thread pool, queued for execution * Actual run time It does not include: * Time needed to send the request to Elasticsearch * Time needed to serialize the JSON response * Time needed to send the response to a client'),
-  timed_out: z.boolean().describe('If `true`, the request timed out before completion; returned results may be partial or empty.'),
-  _shards: ShardStatistics.describe('A count of shards used for the request.'),
-  hits: z.lazy(() => SearchHitsMetadata).describe('The returned documents and metadata.'),
-  aggregations: z.any().optional(),
-  _clusters: ClusterStatistics.optional(),
-  fields: z.record(z.string(), z.any()).optional(),
-  max_score: double.optional(),
-  num_reduce_phases: long.optional(),
-  profile: SearchProfile.optional(),
-  pit_id: Id.optional(),
-  _scroll_id: ScrollId.describe('The identifier for the search and its search context. You can use this scroll ID with the scroll API to retrieve the next batch of search results for the request. This property is returned only if the `scroll` query parameter is specified in the request.').optional(),
-  suggest: z.record(SuggestionName, z.array(SearchSuggest)).optional(),
-  terminated_early: z.boolean().optional()
-}).meta({ id: 'SearchResponseBody' })
-export type SearchResponseBody = z.infer<typeof SearchResponseBody>
-
-export const MsearchMultiSearchItem = z.object({
-  ...SearchResponseBody.shape,
-  status: integer.optional()
-}).meta({ id: 'MsearchMultiSearchItem' })
-export type MsearchMultiSearchItem = z.infer<typeof MsearchMultiSearchItem>
-
-/** The response returned by Elasticsearch when request execution did not succeed. */
-export const ErrorResponseBase = z.object({
-  error: z.lazy(() => ErrorCause),
-  status: integer
-}).meta({ id: 'ErrorResponseBase' })
-export type ErrorResponseBase = z.infer<typeof ErrorResponseBase>
-
-export const MsearchResponseItem = z.union([MsearchMultiSearchItem, ErrorResponseBase]).meta({ id: 'MsearchResponseItem' })
-export type MsearchResponseItem = z.infer<typeof MsearchResponseItem>
-
-export const MsearchMultiSearchResult = z.object({
-  took: long,
-  responses: z.array(MsearchResponseItem)
-}).meta({ id: 'MsearchMultiSearchResult' })
-export type MsearchMultiSearchResult = z.infer<typeof MsearchMultiSearchResult>
-
-export const ExpandWildcard = z.enum(['all', 'open', 'closed', 'hidden', 'none']).meta({ id: 'ExpandWildcard' })
-export type ExpandWildcard = z.infer<typeof ExpandWildcard>
-
-export const ExpandWildcards = z.union([ExpandWildcard, z.array(ExpandWildcard)]).meta({ id: 'ExpandWildcards' })
-export type ExpandWildcards = z.infer<typeof ExpandWildcards>
-
-export const Indices = z.union([IndexName, z.array(IndexName)]).meta({ id: 'Indices' })
-export type Indices = z.infer<typeof Indices>
-
-export const ProjectRouting = z.string().meta({ id: 'ProjectRouting' })
-export type ProjectRouting = z.infer<typeof ProjectRouting>
-
-/** Only to be used in query and path parameters, as the array form is actually a csv */
-export const Routing = z.union([z.string(), z.array(z.string())]).meta({ id: 'Routing' })
-export type Routing = z.infer<typeof Routing>
-
-export const SearchType = z.enum(['query_then_fetch', 'dfs_query_then_fetch']).meta({ id: 'SearchType' })
-export type SearchType = z.infer<typeof SearchType>
-
-/** Contains parameters used to limit or change the subsequent search body request. */
-export const MsearchMultisearchHeader = z.object({
-  allow_no_indices: z.boolean().describe('A setting that does two separate checks on the index expression. If `false`, the request returns an error (1) if any wildcard expression (including `_all` and `*`) resolves to zero matching indices or (2) if the complete set of resolved indices, aliases or data streams is empty after all expressions are evaluated. If `true`, index expressions that resolve to no indices are allowed and the request returns an empty result.').optional(),
-  expand_wildcards: ExpandWildcards.optional(),
-  ignore_unavailable: z.boolean().describe('If `false`, the request returns an error if it targets a concrete (non-wildcarded) index, alias, or data stream that is missing, closed, or otherwise unavailable. If `true`, unavailable concrete targets are silently ignored.').optional(),
-  index: Indices.optional(),
-  preference: z.string().optional(),
-  project_routing: ProjectRouting.optional(),
-  request_cache: z.boolean().optional(),
-  routing: Routing.optional(),
-  search_type: SearchType.optional(),
-  ccs_minimize_roundtrips: z.boolean().optional(),
-  allow_partial_search_results: z.boolean().optional(),
-  ignore_throttled: z.boolean().optional()
-}).meta({ id: 'MsearchMultisearchHeader' })
-export type MsearchMultisearchHeader = z.infer<typeof MsearchMultisearchHeader>
-
-export const RequestBase = z.object({
-}).meta({ id: 'RequestBase' })
-export type RequestBase = z.infer<typeof RequestBase>
-
 export const Metadata = z.record(z.string(), z.any()).meta({ id: 'Metadata' })
 export type Metadata = z.infer<typeof Metadata>
 
@@ -952,6 +771,10 @@ export const QueryDslRandomScoreFunction = z.object({
 }).meta({ id: 'QueryDslRandomScoreFunction' })
 export type QueryDslRandomScoreFunction = z.infer<typeof QueryDslRandomScoreFunction>
 
+export type ScriptSourceShape = string | SearchSearchRequestBodyShape
+export const ScriptSource: z.ZodType<ScriptSourceShape> = z.union([z.string(), z.lazy(() => SearchSearchRequestBody)]).meta({ id: 'ScriptSource' })
+export type ScriptSource = z.infer<typeof ScriptSource>
+
 export const ScriptLanguage = z.union([z.enum(['painless', 'expression', 'mustache', 'java']), z.string()]).meta({ id: 'ScriptLanguage' })
 export type ScriptLanguage = z.infer<typeof ScriptLanguage>
 
@@ -975,7 +798,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -1075,6 +898,9 @@ export type QueryDslGeoDistanceQuery = z.infer<typeof QueryDslGeoDistanceQuery>
 /** A map tile reference, represented as `{zoom}/{x}/{y}` */
 export const GeoTile = z.string().meta({ id: 'GeoTile' })
 export type GeoTile = z.infer<typeof GeoTile>
+
+export const GeoHash = z.string().meta({ id: 'GeoHash' })
+export type GeoHash = z.infer<typeof GeoHash>
 
 /** A map hex cell (H3) reference */
 export const GeoHexCell = z.string().meta({ id: 'GeoHexCell' })
@@ -1303,7 +1129,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1366,7 +1192,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -1405,7 +1231,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface SearchInnerHitsShape {
@@ -1419,7 +1245,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -1431,13 +1258,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -1505,7 +1333,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -1637,6 +1465,36 @@ export type QueryDslIntervalsQuery = z.infer<typeof QueryDslIntervalsQuery>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -1651,7 +1509,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -1752,6 +1610,10 @@ export const QueryDslMatchPhrasePrefixQuery = z.object({
   zero_terms_query: QueryDslZeroTermsQuery.describe('Indicates whether no documents are returned if the analyzer removes all tokens, such as when using a `stop` filter.').optional()
 }).meta({ id: 'QueryDslMatchPhrasePrefixQuery' })
 export type QueryDslMatchPhrasePrefixQuery = z.infer<typeof QueryDslMatchPhrasePrefixQuery>
+
+/** Only to be used in query and path parameters, as the array form is actually a csv */
+export const Routing = z.union([z.string(), z.array(z.string())]).meta({ id: 'Routing' })
+export type Routing = z.infer<typeof Routing>
 
 export const VersionType = z.enum(['internal', 'external', 'external_gte']).meta({ id: 'VersionType' })
 export type VersionType = z.infer<typeof VersionType>
@@ -2052,7 +1914,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -2068,7 +1930,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -2231,7 +2093,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -2307,7 +2169,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -2348,7 +2210,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -2445,7 +2307,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -2456,11 +2318,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -2476,7 +2338,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -2489,7 +2351,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -2503,7 +2365,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -2549,7 +2411,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -2565,7 +2427,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -2579,7 +2441,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -2654,7 +2516,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -2669,7 +2531,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -2681,7 +2543,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -2747,7 +2609,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -2765,7 +2627,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -2784,7 +2646,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -2815,7 +2677,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -2833,6 +2695,27 @@ export const CoordsGeoBounds = z.object({
   right: double
 }).meta({ id: 'CoordsGeoBounds' })
 export type CoordsGeoBounds = z.infer<typeof CoordsGeoBounds>
+
+export const LatLonGeoLocation = z.object({
+  lat: double.describe('Latitude'),
+  lon: double.describe('Longitude')
+}).meta({ id: 'LatLonGeoLocation' })
+export type LatLonGeoLocation = z.infer<typeof LatLonGeoLocation>
+
+export const GeoHashLocation = z.object({
+  geohash: GeoHash
+}).meta({ id: 'GeoHashLocation' })
+export type GeoHashLocation = z.infer<typeof GeoHashLocation>
+
+/**
+ * A latitude/longitude as a 2 dimensional point. It can be represented in various ways:
+ * - as a `{lat, long}` object
+ * - as a geo hash value
+ * - as a `[lon, lat]` array
+ * - as a string in `"<lat>, <lon>"` or WKT point formats
+ */
+export const GeoLocation = z.union([LatLonGeoLocation, GeoHashLocation, z.array(double), z.string()]).meta({ id: 'GeoLocation' })
+export type GeoLocation = z.infer<typeof GeoLocation>
 
 export const TopLeftBottomRightGeoBounds = z.object({
   top_left: GeoLocation,
@@ -2875,7 +2758,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -2958,7 +2841,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -3010,7 +2893,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -3026,7 +2909,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -3098,7 +2981,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -3113,7 +2996,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -3219,7 +3102,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -3298,7 +3181,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -3319,7 +3202,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -3335,7 +3218,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -3450,7 +3333,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -3527,7 +3410,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -3549,7 +3432,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -3576,7 +3459,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -3608,7 +3491,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -3640,12 +3523,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -3683,7 +3566,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -3780,7 +3663,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -3799,7 +3682,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -3813,7 +3696,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -3854,7 +3737,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -3891,10 +3774,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -3915,7 +3798,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -3951,7 +3834,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -3967,7 +3850,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -3981,7 +3864,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -3994,7 +3877,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -4024,7 +3907,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -4189,7 +4072,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -4538,12 +4421,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -4596,7 +4479,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -4610,7 +4493,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -4624,9 +4507,170 @@ export const SearchSearchRequestBody = z.object({
 }).meta({ id: 'SearchSearchRequestBody' })
 export type SearchSearchRequestBody = z.infer<typeof SearchSearchRequestBody>
 
-export type ScriptSourceShape = string | SearchSearchRequestBodyShape
-export const ScriptSource: z.ZodType<ScriptSourceShape> = z.union([z.string(), z.lazy(() => SearchSearchRequestBody)]).meta({ id: 'ScriptSource' })
-export type ScriptSource = z.infer<typeof ScriptSource>
+/**
+ * Coordinator snapshot of the original search request, serialized under `profile.request` when profiling is enabled.
+ * Introduced in Elasticsearch 9.5; omitted when the cluster contains mixed-version nodes that do not serialize this metadata.
+ */
+export const SearchSearchRequestCoordinatorMetadata = z.object({
+  source: z.lazy(() => SearchSearchRequestBody).describe('Original query source from the search request (`SearchSourceBuilder` as JSON).').optional(),
+  indices: z.array(IndexName).describe('Target index expressions from the request (before index resolution).').optional()
+}).meta({ id: 'SearchSearchRequestCoordinatorMetadata' })
+export type SearchSearchRequestCoordinatorMetadata = z.infer<typeof SearchSearchRequestCoordinatorMetadata>
+
+export const SearchProfile = z.object({
+  shards: z.array(SearchShardProfile),
+  request: SearchSearchRequestCoordinatorMetadata.describe('When profiling is enabled, the original query source and target indices from the coordinating request.').optional()
+}).meta({ id: 'SearchProfile' })
+export type SearchProfile = z.infer<typeof SearchProfile>
+
+export const ScrollId = z.string().meta({ id: 'ScrollId' })
+export type ScrollId = z.infer<typeof ScrollId>
+
+/**
+ * The suggestion name as returned from the server. Depending whether typed_keys is specified this could come back
+ * in the form of `name#type` instead of simply `name`
+ */
+export const SuggestionName = z.string().meta({ id: 'SuggestionName' })
+export type SuggestionName = z.infer<typeof SuggestionName>
+
+export const SearchSuggestBase = z.object({
+  length: integer,
+  offset: integer,
+  text: z.string()
+}).meta({ id: 'SearchSuggestBase' })
+export type SearchSuggestBase = z.infer<typeof SearchSuggestBase>
+
+/** Text or location that we want similar documents for or a lookup to a document's field for the text. */
+export const SearchContext = z.union([z.string(), GeoLocation]).meta({ id: 'SearchContext' })
+export type SearchContext = z.infer<typeof SearchContext>
+
+export const SearchCompletionSuggestOption = z.object({
+  collate_match: z.boolean().optional(),
+  contexts: z.record(z.string(), z.array(SearchContext)).optional(),
+  fields: z.record(z.string(), z.any()).optional(),
+  _id: z.string().optional(),
+  _index: IndexName.optional(),
+  _routing: z.string().optional(),
+  _score: double.optional(),
+  _source: z.any().optional(),
+  text: z.string(),
+  score: double.optional()
+}).meta({ id: 'SearchCompletionSuggestOption' })
+export type SearchCompletionSuggestOption = z.infer<typeof SearchCompletionSuggestOption>
+
+export const SearchCompletionSuggest = z.object({
+  ...SearchSuggestBase.shape,
+  options: z.union([SearchCompletionSuggestOption, z.array(SearchCompletionSuggestOption)])
+}).meta({ id: 'SearchCompletionSuggest' })
+export type SearchCompletionSuggest = z.infer<typeof SearchCompletionSuggest>
+
+export const SearchPhraseSuggestOption = z.object({
+  text: z.string(),
+  score: double,
+  highlighted: z.string().optional(),
+  collate_match: z.boolean().optional()
+}).meta({ id: 'SearchPhraseSuggestOption' })
+export type SearchPhraseSuggestOption = z.infer<typeof SearchPhraseSuggestOption>
+
+export const SearchPhraseSuggest = z.object({
+  ...SearchSuggestBase.shape,
+  options: z.union([SearchPhraseSuggestOption, z.array(SearchPhraseSuggestOption)])
+}).meta({ id: 'SearchPhraseSuggest' })
+export type SearchPhraseSuggest = z.infer<typeof SearchPhraseSuggest>
+
+export const SearchTermSuggestOption = z.object({
+  text: z.string(),
+  score: double,
+  freq: long,
+  highlighted: z.string().optional(),
+  collate_match: z.boolean().optional()
+}).meta({ id: 'SearchTermSuggestOption' })
+export type SearchTermSuggestOption = z.infer<typeof SearchTermSuggestOption>
+
+export const SearchTermSuggest = z.object({
+  ...SearchSuggestBase.shape,
+  options: z.union([SearchTermSuggestOption, z.array(SearchTermSuggestOption)])
+}).meta({ id: 'SearchTermSuggest' })
+export type SearchTermSuggest = z.infer<typeof SearchTermSuggest>
+
+export const SearchSuggest = z.union([SearchCompletionSuggest, SearchPhraseSuggest, SearchTermSuggest]).meta({ id: 'SearchSuggest' })
+export type SearchSuggest = z.infer<typeof SearchSuggest>
+
+export const SearchResponseBody = z.object({
+  took: long.describe('The number of milliseconds it took Elasticsearch to run the request. This value is calculated by measuring the time elapsed between receipt of a request on the coordinating node and the time at which the coordinating node is ready to send the response. It includes: * Communication time between the coordinating node and data nodes * Time the request spends in the search thread pool, queued for execution * Actual run time It does not include: * Time needed to send the request to Elasticsearch * Time needed to serialize the JSON response * Time needed to send the response to a client'),
+  timed_out: z.boolean().describe('If `true`, the request timed out before completion; returned results may be partial or empty.'),
+  _shards: ShardStatistics.describe('A count of shards used for the request.'),
+  hits: z.lazy(() => SearchHitsMetadata).describe('The returned documents and metadata.'),
+  aggregations: z.any().optional(),
+  _clusters: ClusterStatistics.optional(),
+  fields: z.record(z.string(), z.any()).optional(),
+  max_score: double.optional(),
+  num_reduce_phases: long.optional(),
+  profile: SearchProfile.optional(),
+  pit_id: Id.optional(),
+  _scroll_id: ScrollId.describe('The identifier for the search and its search context. You can use this scroll ID with the scroll API to retrieve the next batch of search results for the request. This property is returned only if the `scroll` query parameter is specified in the request.').optional(),
+  suggest: z.record(SuggestionName, z.array(SearchSuggest)).optional(),
+  terminated_early: z.boolean().optional()
+}).meta({ id: 'SearchResponseBody' })
+export type SearchResponseBody = z.infer<typeof SearchResponseBody>
+
+export const MsearchMultiSearchItem = z.object({
+  ...SearchResponseBody.shape,
+  status: integer.optional()
+}).meta({ id: 'MsearchMultiSearchItem' })
+export type MsearchMultiSearchItem = z.infer<typeof MsearchMultiSearchItem>
+
+/** The response returned by Elasticsearch when request execution did not succeed. */
+export const ErrorResponseBase = z.object({
+  error: z.lazy(() => ErrorCause),
+  status: integer
+}).meta({ id: 'ErrorResponseBase' })
+export type ErrorResponseBase = z.infer<typeof ErrorResponseBase>
+
+export const MsearchResponseItem = z.union([MsearchMultiSearchItem, ErrorResponseBase]).meta({ id: 'MsearchResponseItem' })
+export type MsearchResponseItem = z.infer<typeof MsearchResponseItem>
+
+export const MsearchMultiSearchResult = z.object({
+  took: long,
+  responses: z.array(MsearchResponseItem)
+}).meta({ id: 'MsearchMultiSearchResult' })
+export type MsearchMultiSearchResult = z.infer<typeof MsearchMultiSearchResult>
+
+export const ExpandWildcard = z.enum(['all', 'open', 'closed', 'hidden', 'none']).meta({ id: 'ExpandWildcard' })
+export type ExpandWildcard = z.infer<typeof ExpandWildcard>
+
+export const ExpandWildcards = z.union([ExpandWildcard, z.array(ExpandWildcard)]).meta({ id: 'ExpandWildcards' })
+export type ExpandWildcards = z.infer<typeof ExpandWildcards>
+
+export const Indices = z.union([IndexName, z.array(IndexName)]).meta({ id: 'Indices' })
+export type Indices = z.infer<typeof Indices>
+
+export const ProjectRouting = z.string().meta({ id: 'ProjectRouting' })
+export type ProjectRouting = z.infer<typeof ProjectRouting>
+
+export const SearchType = z.enum(['query_then_fetch', 'dfs_query_then_fetch']).meta({ id: 'SearchType' })
+export type SearchType = z.infer<typeof SearchType>
+
+/** Contains parameters used to limit or change the subsequent search body request. */
+export const MsearchMultisearchHeader = z.object({
+  allow_no_indices: z.boolean().describe('A setting that does two separate checks on the index expression. If `false`, the request returns an error (1) if any wildcard expression (including `_all` and `*`) resolves to zero matching indices or (2) if the complete set of resolved indices, aliases or data streams is empty after all expressions are evaluated. If `true`, index expressions that resolve to no indices are allowed and the request returns an empty result.').optional(),
+  expand_wildcards: ExpandWildcards.optional(),
+  ignore_unavailable: z.boolean().describe('If `false`, the request returns an error if it targets a concrete (non-wildcarded) index, alias, or data stream that is missing, closed, or otherwise unavailable. If `true`, unavailable concrete targets are silently ignored.').optional(),
+  index: Indices.optional(),
+  preference: z.string().optional(),
+  project_routing: ProjectRouting.optional(),
+  request_cache: z.boolean().optional(),
+  routing: Routing.optional(),
+  search_type: SearchType.optional(),
+  ccs_minimize_roundtrips: z.boolean().optional(),
+  allow_partial_search_results: z.boolean().optional(),
+  ignore_throttled: z.boolean().optional()
+}).meta({ id: 'MsearchMultisearchHeader' })
+export type MsearchMultisearchHeader = z.infer<typeof MsearchMultisearchHeader>
+
+export const RequestBase = z.object({
+}).meta({ id: 'RequestBase' })
+export type RequestBase = z.infer<typeof RequestBase>
 
 export const MsearchTemplateTemplateConfig = z.object({
   explain: z.boolean().describe('If `true`, returns detailed information about score calculation as part of each hit.').optional(),

--- a/packages/es-schemas/src/mtermvectors.ts
+++ b/packages/es-schemas/src/mtermvectors.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/nodes_clear_repositories_metering_archive.ts
+++ b/packages/es-schemas/src/nodes_clear_repositories_metering_archive.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/nodes_get_repositories_metering_info.ts
+++ b/packages/es-schemas/src/nodes_get_repositories_metering_info.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/nodes_hot_threads.ts
+++ b/packages/es-schemas/src/nodes_hot_threads.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/nodes_info.ts
+++ b/packages/es-schemas/src/nodes_info.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -309,7 +310,7 @@ export const NodesInfoNodeInfoSettingsHttpType = z.object({
 export type NodesInfoNodeInfoSettingsHttpType = z.infer<typeof NodesInfoNodeInfoSettingsHttpType>
 
 export const NodesInfoNodeInfoSettingsHttp = z.object({
-  type: NodesInfoNodeInfoSettingsHttpType,
+  type: z.union([NodesInfoNodeInfoSettingsHttpType, z.string()]),
   'type.default': z.string().optional(),
   compression: z.union([z.boolean(), z.string()]).optional(),
   port: z.union([integer, z.string()]).optional()
@@ -332,7 +333,7 @@ export const NodesInfoNodeInfoSettingsTransportFeatures = z.object({
 export type NodesInfoNodeInfoSettingsTransportFeatures = z.infer<typeof NodesInfoNodeInfoSettingsTransportFeatures>
 
 export const NodesInfoNodeInfoSettingsTransport = z.object({
-  type: NodesInfoNodeInfoSettingsTransportType,
+  type: z.union([NodesInfoNodeInfoSettingsTransportType, z.string()]),
   'type.default': z.string().optional(),
   features: NodesInfoNodeInfoSettingsTransportFeatures.optional()
 }).meta({ id: 'NodesInfoNodeInfoSettingsTransport' })

--- a/packages/es-schemas/src/nodes_reload_secure_settings.ts
+++ b/packages/es-schemas/src/nodes_reload_secure_settings.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/nodes_stats.ts
+++ b/packages/es-schemas/src/nodes_stats.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/nodes_usage.ts
+++ b/packages/es-schemas/src/nodes_usage.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/open_point_in_time.ts
+++ b/packages/es-schemas/src/open_point_in_time.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -288,7 +289,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -299,11 +300,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -319,7 +320,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -332,7 +333,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -346,7 +347,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -392,7 +393,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -408,7 +409,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -422,7 +423,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -487,7 +488,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -587,7 +588,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -602,7 +603,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -614,7 +615,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -687,7 +688,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -705,7 +706,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -724,7 +725,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1268,7 +1269,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1289,7 +1290,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1305,7 +1306,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1420,7 +1421,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1497,7 +1498,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1519,7 +1520,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1546,7 +1547,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1578,7 +1579,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1610,12 +1611,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1653,7 +1654,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1750,7 +1751,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1769,7 +1770,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1783,7 +1784,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1824,7 +1825,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -2023,7 +2024,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -2038,7 +2039,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -2062,10 +2063,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -2086,7 +2087,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -2122,7 +2123,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -2138,7 +2139,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -2152,7 +2153,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -2165,7 +2166,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2195,7 +2196,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2305,7 +2306,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -2317,13 +2319,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -2358,6 +2361,36 @@ export type SearchTrackHits = z.infer<typeof SearchTrackHits>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2372,7 +2405,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2439,7 +2472,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2794,12 +2827,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2852,7 +2885,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2866,7 +2899,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2907,7 +2940,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -3085,7 +3118,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3605,7 +3638,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3621,7 +3654,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3784,7 +3817,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3860,7 +3893,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3901,7 +3934,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined

--- a/packages/es-schemas/src/ping.ts
+++ b/packages/es-schemas/src/ping.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/profiling_flamegraph.ts
+++ b/packages/es-schemas/src/profiling_flamegraph.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/profiling_stacktraces.ts
+++ b/packages/es-schemas/src/profiling_stacktraces.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/profiling_status.ts
+++ b/packages/es-schemas/src/profiling_status.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/profiling_topn_functions.ts
+++ b/packages/es-schemas/src/profiling_topn_functions.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/project_create_many_routing.ts
+++ b/packages/es-schemas/src/project_create_many_routing.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/project_create_routing.ts
+++ b/packages/es-schemas/src/project_create_routing.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/project_delete_routing.ts
+++ b/packages/es-schemas/src/project_delete_routing.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/project_get_many_routing.ts
+++ b/packages/es-schemas/src/project_get_many_routing.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/project_get_routing.ts
+++ b/packages/es-schemas/src/project_get_routing.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/project_tags.ts
+++ b/packages/es-schemas/src/project_tags.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/put_script.ts
+++ b/packages/es-schemas/src/put_script.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -270,7 +271,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -598,7 +599,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -661,7 +662,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -700,7 +701,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface SearchInnerHitsShape {
@@ -714,7 +715,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -726,13 +728,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -800,7 +803,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -932,6 +935,36 @@ export type QueryDslIntervalsQuery = z.infer<typeof QueryDslIntervalsQuery>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -946,7 +979,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -1357,7 +1390,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -1373,7 +1406,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -1540,7 +1573,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -1616,7 +1649,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -1657,7 +1690,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -1754,7 +1787,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -1765,11 +1798,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -1785,7 +1818,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -1798,7 +1831,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -1812,7 +1845,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -1858,7 +1891,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -1874,7 +1907,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -1888,7 +1921,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -1963,7 +1996,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -1978,7 +2011,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -1990,7 +2023,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -2056,7 +2089,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -2074,7 +2107,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -2093,7 +2126,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -2124,7 +2157,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -2205,7 +2238,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -2288,7 +2321,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -2340,7 +2373,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -2356,7 +2389,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -2428,7 +2461,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -2443,7 +2476,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -2549,7 +2582,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -2628,7 +2661,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -2649,7 +2682,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -2665,7 +2698,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -2780,7 +2813,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -2857,7 +2890,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -2879,7 +2912,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -2906,7 +2939,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -2938,7 +2971,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -2970,12 +3003,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -3013,7 +3046,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -3110,7 +3143,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -3129,7 +3162,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -3143,7 +3176,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -3184,7 +3217,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -3221,10 +3254,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -3245,7 +3278,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -3281,7 +3314,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -3297,7 +3330,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -3311,7 +3344,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -3324,7 +3357,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -3354,7 +3387,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -3519,7 +3552,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -3871,12 +3904,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -3929,7 +3962,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -3943,7 +3976,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),

--- a/packages/es-schemas/src/query_rules_delete_rule.ts
+++ b/packages/es-schemas/src/query_rules_delete_rule.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/query_rules_delete_ruleset.ts
+++ b/packages/es-schemas/src/query_rules_delete_ruleset.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/query_rules_get_rule.ts
+++ b/packages/es-schemas/src/query_rules_get_rule.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/query_rules_get_ruleset.ts
+++ b/packages/es-schemas/src/query_rules_get_ruleset.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/query_rules_list_rulesets.ts
+++ b/packages/es-schemas/src/query_rules_list_rulesets.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/query_rules_put_rule.ts
+++ b/packages/es-schemas/src/query_rules_put_rule.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/query_rules_put_ruleset.ts
+++ b/packages/es-schemas/src/query_rules_put_ruleset.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/query_rules_test.ts
+++ b/packages/es-schemas/src/query_rules_test.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/rank_eval.ts
+++ b/packages/es-schemas/src/rank_eval.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -354,7 +355,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -365,11 +366,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -398,7 +399,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -412,7 +413,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -458,7 +459,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -474,7 +475,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -488,7 +489,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -553,7 +554,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -653,7 +654,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -668,7 +669,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -680,7 +681,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -753,7 +754,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -771,7 +772,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -790,7 +791,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -828,7 +829,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -912,7 +913,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -995,7 +996,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -1047,7 +1048,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -1063,7 +1064,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1135,7 +1136,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1150,7 +1151,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1256,7 +1257,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1341,7 +1342,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1362,7 +1363,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1378,7 +1379,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1493,7 +1494,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1570,7 +1571,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1592,7 +1593,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1619,7 +1620,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1651,7 +1652,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1683,12 +1684,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1726,7 +1727,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1823,7 +1824,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1842,7 +1843,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1856,7 +1857,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1897,7 +1898,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -2096,7 +2097,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -2111,7 +2112,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -2135,10 +2136,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -2159,7 +2160,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -2195,7 +2196,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -2211,7 +2212,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -2225,7 +2226,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -2238,7 +2239,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2268,7 +2269,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2378,7 +2379,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -2390,13 +2392,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -2431,6 +2434,36 @@ export type SearchTrackHits = z.infer<typeof SearchTrackHits>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2445,7 +2478,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2512,7 +2545,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2864,12 +2897,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2922,7 +2955,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2936,7 +2969,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2977,7 +3010,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -3155,7 +3188,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3679,7 +3712,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3695,7 +3728,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3858,7 +3891,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3934,7 +3967,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3975,7 +4008,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -4052,7 +4085,7 @@ export type RankEvalRankEvalQuery = z.infer<typeof RankEvalRankEvalQuery>
 
 export const RankEvalRankEvalRequestItem = z.object({
   id: Id.describe('The search request’s ID, used to group result details later.'),
-  request: RankEvalRankEvalQuery.describe('The query being evaluated.').optional(),
+  request: z.union([RankEvalRankEvalQuery, z.lazy(() => QueryDslQueryContainer)]).describe('The query being evaluated.').optional(),
   ratings: z.array(RankEvalDocumentRating).describe('List of document ratings'),
   template_id: Id.describe('The search template Id').optional(),
   params: z.record(z.string(), z.any()).describe('The search template parameters.').optional()

--- a/packages/es-schemas/src/reindex.ts
+++ b/packages/es-schemas/src/reindex.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -299,7 +300,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -630,7 +631,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -693,7 +694,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -732,7 +733,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface SearchInnerHitsShape {
@@ -746,7 +747,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -758,13 +760,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -835,7 +838,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -967,6 +970,36 @@ export type QueryDslIntervalsQuery = z.infer<typeof QueryDslIntervalsQuery>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -981,7 +1014,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -1386,7 +1419,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -1402,7 +1435,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -1569,7 +1602,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -1645,7 +1678,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -1686,7 +1719,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -1783,7 +1816,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -1794,11 +1827,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -1814,7 +1847,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -1827,7 +1860,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -1841,7 +1874,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -1887,7 +1920,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -1903,7 +1936,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -1917,7 +1950,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -1992,7 +2025,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -2007,7 +2040,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -2019,7 +2052,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -2085,7 +2118,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -2103,7 +2136,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -2122,7 +2155,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -2153,7 +2186,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -2234,7 +2267,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -2317,7 +2350,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -2369,7 +2402,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -2385,7 +2418,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -2457,7 +2490,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -2472,7 +2505,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -2578,7 +2611,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -2657,7 +2690,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -2678,7 +2711,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -2694,7 +2727,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -2809,7 +2842,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -2886,7 +2919,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -2908,7 +2941,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -2935,7 +2968,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -2967,7 +3000,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -2999,12 +3032,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -3042,7 +3075,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -3139,7 +3172,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -3158,7 +3191,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -3172,7 +3205,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -3213,7 +3246,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -3250,10 +3283,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -3274,7 +3307,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -3310,7 +3343,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -3326,7 +3359,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -3340,7 +3373,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -3353,7 +3386,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -3383,7 +3416,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -3548,7 +3581,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -3900,12 +3933,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -3958,7 +3991,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -3972,7 +4005,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -4088,7 +4121,7 @@ export const ReindexRequest = z.object({
   conflicts: Conflicts.describe('Indicates whether to continue reindexing even when there are conflicts.').optional().meta({ found_in: 'body' }),
   dest: ReindexDestination.describe('The destination you are copying to.').meta({ found_in: 'body' }),
   max_docs: long.describe('The maximum number of documents to reindex. By default, all documents are reindexed. If it is a value less then or equal to `scroll_size`, a scroll will not be used to retrieve the results for the operation. If `conflicts` is set to `proceed`, the reindex operation could attempt to reindex more documents from the source than `max_docs` until it has successfully indexed `max_docs` documents into the target or it has gone through every document in the source query.').optional().meta({ found_in: 'body' }),
-  script: z.lazy(() => Script).describe('The script to run to update the document source or metadata when reindexing.').optional().meta({ found_in: 'body' }),
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('The script to run to update the document source or metadata when reindexing.').optional().meta({ found_in: 'body' }),
   source: ReindexSource.describe('The source you are copying from.').meta({ found_in: 'body' })
 }).meta({ id: 'ReindexRequest' })
 export type ReindexRequest = z.infer<typeof ReindexRequest>

--- a/packages/es-schemas/src/reindex_rethrottle.ts
+++ b/packages/es-schemas/src/reindex_rethrottle.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -16,20 +17,11 @@ import { z } from 'zod'
 export const TODO = z.record(z.string(), z.any())
 export type TODO = z.infer<typeof TODO>
 
-export const long = z.number().meta({ id: 'long' })
-export type long = z.infer<typeof long>
-
-export const Name = z.string().meta({ id: 'Name' })
-export type Name = z.infer<typeof Name>
-
-export const DurationValue = z.any().meta({ id: 'DurationValue' })
-export type DurationValue = z.infer<typeof DurationValue>
-
-export const EpochTime = z.any().meta({ id: 'EpochTime' })
-export type EpochTime = z.infer<typeof EpochTime>
-
 export const integer = z.number().meta({ id: 'integer' })
 export type integer = z.infer<typeof integer>
+
+export const long = z.number().meta({ id: 'long' })
+export type long = z.infer<typeof long>
 
 export const float = z.number().meta({ id: 'float' })
 export type float = z.infer<typeof float>
@@ -46,6 +38,9 @@ export type Retries = z.infer<typeof Retries>
  */
 export const Duration = z.union([z.string(), z.literal(-1), z.literal(0)]).meta({ id: 'Duration' })
 export type Duration = z.infer<typeof Duration>
+
+export const DurationValue = z.any().meta({ id: 'DurationValue' })
+export type DurationValue = z.infer<typeof DurationValue>
 
 export const ReindexStatus = z.object({
   slice_id: integer.describe('The slice ID').optional(),
@@ -66,6 +61,32 @@ export const ReindexStatus = z.object({
 }).meta({ id: 'ReindexStatus' })
 export type ReindexStatus = z.infer<typeof ReindexStatus>
 
+export const ReindexRethrottleParentReindexStatus = z.object({
+  slices: z.array(ReindexStatus).optional(),
+  slice_id: integer.describe('The slice ID').optional(),
+  batches: long.describe('The number of scroll responses pulled back by the reindex.'),
+  created: long.describe('The number of documents that were successfully created.').optional(),
+  deleted: long.describe('The number of documents that were successfully deleted.'),
+  noops: long.describe('The number of documents that were ignored because the script used for the reindex returned a `noop` value for `ctx.op`.'),
+  requests_per_second: float.describe('The number of requests per second effectively executed during the reindex.'),
+  retries: Retries.describe('The number of retries attempted by reindex. `bulk` is the number of bulk actions retried and `search` is the number of search actions retried.'),
+  throttled: Duration.optional(),
+  throttled_millis: DurationValue.describe('Number of milliseconds the request slept to conform to `requests_per_second`.'),
+  throttled_until: Duration.optional(),
+  throttled_until_millis: DurationValue.describe('This field should always be equal to zero in a `_reindex` response. It only has meaning when using the Task API, where it indicates the next time (in milliseconds since epoch) a throttled request will be executed again in order to conform to `requests_per_second`.'),
+  total: long.describe('The number of documents that were successfully processed.'),
+  updated: long.describe('The number of documents that were successfully updated, for example, a document with same ID already existed prior to reindex updating it.').optional(),
+  version_conflicts: long.describe('The number of version conflicts that reindex hits.'),
+  cancelled: z.string().describe('The reason for cancellation if the slice was canceled').optional()
+}).meta({ id: 'ReindexRethrottleParentReindexStatus' })
+export type ReindexRethrottleParentReindexStatus = z.infer<typeof ReindexRethrottleParentReindexStatus>
+
+export const Name = z.string().meta({ id: 'Name' })
+export type Name = z.infer<typeof Name>
+
+export const EpochTime = z.any().meta({ id: 'EpochTime' })
+export type EpochTime = z.infer<typeof EpochTime>
+
 export const HttpHeaders = z.record(z.string(), z.union([z.string(), z.array(z.string())])).meta({ id: 'HttpHeaders' })
 export type HttpHeaders = z.infer<typeof HttpHeaders>
 
@@ -78,7 +99,7 @@ export const ReindexRethrottleReindexTask = z.object({
   node: Name,
   running_time_in_nanos: DurationValue,
   start_time_in_millis: EpochTime,
-  status: ReindexStatus,
+  status: ReindexRethrottleParentReindexStatus,
   type: z.string(),
   headers: HttpHeaders
 }).meta({ id: 'ReindexRethrottleReindexTask' })

--- a/packages/es-schemas/src/render_search_template.ts
+++ b/packages/es-schemas/src/render_search_template.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -260,7 +261,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -591,7 +592,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -654,7 +655,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -693,7 +694,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface SearchInnerHitsShape {
@@ -707,7 +708,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -719,13 +721,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -793,7 +796,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -925,6 +928,43 @@ export type QueryDslIntervalsQuery = z.infer<typeof QueryDslIntervalsQuery>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+/**
+ * A duration. Units can be `nanos`, `micros`, `ms` (milliseconds), `s` (seconds), `m` (minutes), `h` (hours) and
+ * `d` (days). Also accepts "0" without a unit and "-1" to indicate an unspecified value.
+ */
+export const Duration = z.union([z.string(), z.literal(-1), z.literal(0)]).meta({ id: 'Duration' })
+export type Duration = z.infer<typeof Duration>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -939,7 +979,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -1350,7 +1390,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -1366,7 +1406,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -1533,7 +1573,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -1609,7 +1649,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -1650,7 +1690,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -1747,7 +1787,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -1758,11 +1798,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -1778,7 +1818,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -1791,7 +1831,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -1805,7 +1845,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -1851,7 +1891,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -1867,7 +1907,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -1881,7 +1921,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -1956,7 +1996,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -1971,7 +2011,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -1983,7 +2023,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -2049,7 +2089,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -2067,7 +2107,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -2086,7 +2126,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -2099,13 +2139,6 @@ export type AggregationsCompositeHistogramAggregation = z.infer<typeof Aggregati
  */
 export const DurationLarge = z.string().meta({ id: 'DurationLarge' })
 export type DurationLarge = z.infer<typeof DurationLarge>
-
-/**
- * A duration. Units can be `nanos`, `micros`, `ms` (milliseconds), `s` (seconds), `m` (minutes), `h` (hours) and
- * `d` (days). Also accepts "0" without a unit and "-1" to indicate an unspecified value.
- */
-export const Duration = z.union([z.string(), z.literal(-1), z.literal(0)]).meta({ id: 'Duration' })
-export type Duration = z.infer<typeof Duration>
 
 export interface AggregationsCompositeDateHistogramAggregationShape {
   field?: Field | undefined
@@ -2124,7 +2157,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -2205,7 +2238,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -2288,7 +2321,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -2340,7 +2373,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -2356,7 +2389,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -2428,7 +2461,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -2443,7 +2476,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -2549,7 +2582,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -2628,7 +2661,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -2649,7 +2682,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -2665,7 +2698,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -2780,7 +2813,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -2857,7 +2890,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -2879,7 +2912,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -2906,7 +2939,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -2938,7 +2971,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -2970,12 +3003,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -3013,7 +3046,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -3110,7 +3143,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -3129,7 +3162,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -3143,7 +3176,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -3184,7 +3217,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -3221,10 +3254,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -3245,7 +3278,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -3281,7 +3314,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -3297,7 +3330,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -3311,7 +3344,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -3324,7 +3357,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -3354,7 +3387,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -3519,7 +3552,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -3871,12 +3904,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -3929,7 +3962,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -3943,7 +3976,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),

--- a/packages/es-schemas/src/rollup_delete_job.ts
+++ b/packages/es-schemas/src/rollup_delete_job.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/rollup_get_jobs.ts
+++ b/packages/es-schemas/src/rollup_get_jobs.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/rollup_get_rollup_caps.ts
+++ b/packages/es-schemas/src/rollup_get_rollup_caps.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/rollup_get_rollup_index_caps.ts
+++ b/packages/es-schemas/src/rollup_get_rollup_index_caps.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/rollup_put_job.ts
+++ b/packages/es-schemas/src/rollup_put_job.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/rollup_rollup_search.ts
+++ b/packages/es-schemas/src/rollup_rollup_search.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -300,7 +301,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -311,11 +312,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -331,7 +332,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -344,7 +345,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -358,7 +359,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -404,7 +405,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -420,7 +421,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -434,7 +435,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -499,7 +500,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -599,7 +600,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -614,7 +615,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -626,7 +627,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -699,7 +700,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -736,7 +737,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -774,7 +775,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -858,7 +859,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -941,7 +942,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -993,7 +994,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -1009,7 +1010,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1081,7 +1082,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1096,7 +1097,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1202,7 +1203,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1284,7 +1285,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1305,7 +1306,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1321,7 +1322,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1436,7 +1437,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1513,7 +1514,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1535,7 +1536,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1562,7 +1563,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1594,7 +1595,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1626,12 +1627,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1669,7 +1670,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1766,7 +1767,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1785,7 +1786,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1799,7 +1800,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1840,7 +1841,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1861,7 +1862,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1876,7 +1877,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1900,10 +1901,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1924,7 +1925,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1960,7 +1961,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1976,7 +1977,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1990,7 +1991,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -2003,7 +2004,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2033,7 +2034,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2147,6 +2148,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2161,7 +2192,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2228,7 +2259,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2583,12 +2614,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2641,7 +2672,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2655,7 +2686,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2696,7 +2727,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2874,7 +2905,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3398,7 +3429,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3414,7 +3445,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3577,7 +3608,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3653,7 +3684,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3694,7 +3725,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3935,7 +3966,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3947,13 +3979,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),

--- a/packages/es-schemas/src/rollup_start_job.ts
+++ b/packages/es-schemas/src/rollup_start_job.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/rollup_stop_job.ts
+++ b/packages/es-schemas/src/rollup_stop_job.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/scripts_painless_execute.ts
+++ b/packages/es-schemas/src/scripts_painless_execute.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -267,7 +268,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -278,11 +279,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -298,7 +299,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -311,7 +312,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -325,7 +326,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -371,7 +372,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -387,7 +388,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -401,7 +402,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -466,7 +467,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -566,7 +567,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -581,7 +582,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -593,7 +594,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -666,7 +667,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -684,7 +685,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -703,7 +704,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -741,7 +742,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -825,7 +826,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -908,7 +909,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -960,7 +961,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -976,7 +977,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1048,7 +1049,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1063,7 +1064,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1169,7 +1170,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1254,7 +1255,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1275,7 +1276,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1291,7 +1292,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1406,7 +1407,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1483,7 +1484,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1505,7 +1506,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1532,7 +1533,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1564,7 +1565,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1596,12 +1597,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1639,7 +1640,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1736,7 +1737,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1755,7 +1756,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1769,7 +1770,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1810,7 +1811,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -2009,7 +2010,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -2024,7 +2025,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -2048,10 +2049,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -2072,7 +2073,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -2108,7 +2109,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -2124,7 +2125,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -2138,7 +2139,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -2151,7 +2152,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2181,7 +2182,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2291,7 +2292,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -2303,13 +2305,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -2344,6 +2347,36 @@ export type SearchTrackHits = z.infer<typeof SearchTrackHits>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2358,7 +2391,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2425,7 +2458,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2780,12 +2813,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2838,7 +2871,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2852,7 +2885,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2893,7 +2926,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -3071,7 +3104,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3595,7 +3628,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3611,7 +3644,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3774,7 +3807,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3850,7 +3883,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3891,7 +3924,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3986,7 +4019,7 @@ export const ScriptsPainlessExecuteRequest = z.object({
   ...RequestBase.shape,
   context: ScriptsPainlessExecutePainlessContext.describe('The context that the script should run in. NOTE: Result ordering in the field contexts is not guaranteed.').optional().meta({ found_in: 'body' }),
   context_setup: ScriptsPainlessExecutePainlessContextSetup.describe('Additional parameters for the `context`. NOTE: This parameter is required for all contexts except `painless_test`, which is the default if no value is provided for `context`.').optional().meta({ found_in: 'body' }),
-  script: z.lazy(() => Script).describe('The Painless script to run.').optional().meta({ found_in: 'body' })
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('The Painless script to run.').optional().meta({ found_in: 'body' })
 }).meta({ id: 'ScriptsPainlessExecuteRequest' })
 export type ScriptsPainlessExecuteRequest = z.infer<typeof ScriptsPainlessExecuteRequest>
 

--- a/packages/es-schemas/src/scroll.ts
+++ b/packages/es-schemas/src/scroll.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -603,8 +604,3953 @@ export const SearchShardProfile = z.object({
 }).meta({ id: 'SearchShardProfile' })
 export type SearchShardProfile = z.infer<typeof SearchShardProfile>
 
+export const Metadata = z.record(z.string(), z.any()).meta({ id: 'Metadata' })
+export type Metadata = z.infer<typeof Metadata>
+
+export const AggregationsAggregation = z.object({
+}).meta({ id: 'AggregationsAggregation' })
+export type AggregationsAggregation = z.infer<typeof AggregationsAggregation>
+
+/** Base type for bucket aggregations. These aggregations also accept sub-aggregations. */
+export const AggregationsBucketAggregationBase = z.object({
+}).meta({ id: 'AggregationsBucketAggregationBase' })
+export type AggregationsBucketAggregationBase = z.infer<typeof AggregationsBucketAggregationBase>
+
+export const QueryDslQueryBase = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional()
+}).meta({ id: 'QueryDslQueryBase' })
+export type QueryDslQueryBase = z.infer<typeof QueryDslQueryBase>
+
+/** The minimum number of terms that should match as integer, percentage or range */
+export const MinimumShouldMatch = z.union([integer, z.string()]).meta({ id: 'MinimumShouldMatch' })
+export type MinimumShouldMatch = z.infer<typeof MinimumShouldMatch>
+
+export interface QueryDslBoolQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  filter?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+  minimum_should_match?: MinimumShouldMatch | undefined
+  must?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+  must_not?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+  should?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+}
+export const QueryDslBoolQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  get filter (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('The clause (query) must appear in matching documents. However, unlike `must`, the score of the query will be ignored.').optional() },
+  minimum_should_match: MinimumShouldMatch.describe('Specifies the number or percentage of `should` clauses returned documents must match.').optional(),
+  get must (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('The clause (query) must appear in matching documents and will contribute to the score.').optional() },
+  get must_not (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('The clause (query) must not appear in the matching documents. Because scoring is ignored, a score of `0` is returned for all documents.').optional() },
+  get should (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('The clause (query) should appear in the matching document.').optional() }
+}).meta({ id: 'QueryDslBoolQuery' })
+export type QueryDslBoolQuery = z.infer<typeof QueryDslBoolQuery>
+
+export interface QueryDslBoostingQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  negative_boost: double
+  negative: QueryDslQueryContainerShape
+  positive: QueryDslQueryContainerShape
+}
+export const QueryDslBoostingQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  negative_boost: double.describe('Floating point number between 0 and 1.0 used to decrease the relevance scores of documents matching the `negative` query.'),
+  get negative () { return QueryDslQueryContainer.describe('Query used to decrease the relevance score of matching documents.') },
+  get positive () { return QueryDslQueryContainer.describe('Any returned documents must match this query.') }
+}).meta({ id: 'QueryDslBoostingQuery' })
+export type QueryDslBoostingQuery = z.infer<typeof QueryDslBoostingQuery>
+
+export const QueryDslOperator = z.enum(['and', 'AND', 'or', 'OR']).meta({ id: 'QueryDslOperator' })
+export type QueryDslOperator = z.infer<typeof QueryDslOperator>
+
+export const QueryDslCommonTermsQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  analyzer: z.string().optional(),
+  cutoff_frequency: double.optional(),
+  high_freq_operator: QueryDslOperator.optional(),
+  low_freq_operator: QueryDslOperator.optional(),
+  minimum_should_match: MinimumShouldMatch.optional(),
+  query: z.string()
+}).meta({ id: 'QueryDslCommonTermsQuery' })
+export type QueryDslCommonTermsQuery = z.infer<typeof QueryDslCommonTermsQuery>
+
+export const QueryDslCombinedFieldsOperator = z.enum(['or', 'and']).meta({ id: 'QueryDslCombinedFieldsOperator' })
+export type QueryDslCombinedFieldsOperator = z.infer<typeof QueryDslCombinedFieldsOperator>
+
+export const QueryDslCombinedFieldsZeroTerms = z.enum(['none', 'all']).meta({ id: 'QueryDslCombinedFieldsZeroTerms' })
+export type QueryDslCombinedFieldsZeroTerms = z.infer<typeof QueryDslCombinedFieldsZeroTerms>
+
+export const QueryDslCombinedFieldsQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  fields: z.array(Field).describe('List of fields to search. Field wildcard patterns are allowed. Only `text` fields are supported, and they must all have the same search `analyzer`.'),
+  query: z.string().describe('Text to search for in the provided `fields`. The `combined_fields` query analyzes the provided text before performing a search.'),
+  auto_generate_synonyms_phrase_query: z.boolean().describe('If true, match phrase queries are automatically created for multi-term synonyms.').optional(),
+  operator: QueryDslCombinedFieldsOperator.describe('Boolean logic used to interpret text in the query value.').optional(),
+  minimum_should_match: MinimumShouldMatch.describe('Minimum number of clauses that must match for a document to be returned.').optional(),
+  zero_terms_query: QueryDslCombinedFieldsZeroTerms.describe('Indicates whether no documents are returned if the analyzer removes all tokens, such as when using a `stop` filter.').optional()
+}).meta({ id: 'QueryDslCombinedFieldsQuery' })
+export type QueryDslCombinedFieldsQuery = z.infer<typeof QueryDslCombinedFieldsQuery>
+
+export interface QueryDslConstantScoreQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  filter: QueryDslQueryContainerShape
+}
+export const QueryDslConstantScoreQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  get filter () { return QueryDslQueryContainer.describe('Filter query you wish to run. Any returned documents must match this query. Filter queries do not calculate relevance scores. To speed up performance, Elasticsearch automatically caches frequently used filter queries.') }
+}).meta({ id: 'QueryDslConstantScoreQuery' })
+export type QueryDslConstantScoreQuery = z.infer<typeof QueryDslConstantScoreQuery>
+
+export interface QueryDslDisMaxQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  queries: QueryDslQueryContainerShape[]
+  tie_breaker?: double | undefined
+}
+export const QueryDslDisMaxQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  get queries () { return QueryDslQueryContainer.array().describe('One or more query clauses. Returned documents must match one or more of these queries. If a document matches multiple queries, Elasticsearch uses the highest relevance score.') },
+  tie_breaker: double.describe('Floating point number between 0 and 1.0 used to increase the relevance scores of documents matching multiple query clauses.').optional()
+}).meta({ id: 'QueryDslDisMaxQuery' })
+export type QueryDslDisMaxQuery = z.infer<typeof QueryDslDisMaxQuery>
+
+export const QueryDslDistanceFeatureQueryBase = z.object({
+  ...QueryDslQueryBase.shape,
+  origin: z.any().describe('Date or point of origin used to calculate distances. If the `field` value is a `date` or `date_nanos` field, the `origin` value must be a date. Date Math, such as `now-1h`, is supported. If the field value is a `geo_point` field, the `origin` value must be a geopoint.'),
+  pivot: z.any().describe('Distance from the `origin` at which relevance scores receive half of the `boost` value. If the `field` value is a `date` or `date_nanos` field, the `pivot` value must be a time unit, such as `1h` or `10d`. If the `field` value is a `geo_point` field, the `pivot` value must be a distance unit, such as `1km` or `12m`.'),
+  field: Field.describe('Name of the field used to calculate distances. This field must meet the following criteria: be a `date`, `date_nanos` or `geo_point` field; have an `index` mapping parameter value of `true`, which is the default; have an `doc_values` mapping parameter value of `true`, which is the default.')
+}).meta({ id: 'QueryDslDistanceFeatureQueryBase' })
+export type QueryDslDistanceFeatureQueryBase = z.infer<typeof QueryDslDistanceFeatureQueryBase>
+
+export const QueryDslUntypedDistanceFeatureQuery = z.object({
+  ...QueryDslDistanceFeatureQueryBase.shape
+}).meta({ id: 'QueryDslUntypedDistanceFeatureQuery' })
+export type QueryDslUntypedDistanceFeatureQuery = z.infer<typeof QueryDslUntypedDistanceFeatureQuery>
+
+export const QueryDslGeoDistanceFeatureQuery = z.object({
+  ...QueryDslDistanceFeatureQueryBase.shape
+}).meta({ id: 'QueryDslGeoDistanceFeatureQuery' })
+export type QueryDslGeoDistanceFeatureQuery = z.infer<typeof QueryDslGeoDistanceFeatureQuery>
+
+export const QueryDslDateDistanceFeatureQuery = z.object({
+  ...QueryDslDistanceFeatureQueryBase.shape
+}).meta({ id: 'QueryDslDateDistanceFeatureQuery' })
+export type QueryDslDateDistanceFeatureQuery = z.infer<typeof QueryDslDateDistanceFeatureQuery>
+
+export const QueryDslDistanceFeatureQuery = z.union([QueryDslUntypedDistanceFeatureQuery, QueryDslGeoDistanceFeatureQuery, QueryDslDateDistanceFeatureQuery]).meta({ id: 'QueryDslDistanceFeatureQuery' })
+export type QueryDslDistanceFeatureQuery = z.infer<typeof QueryDslDistanceFeatureQuery>
+
+export const QueryDslExistsQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  field: Field.describe('Name of the field you wish to search.')
+}).meta({ id: 'QueryDslExistsQuery' })
+export type QueryDslExistsQuery = z.infer<typeof QueryDslExistsQuery>
+
+export const QueryDslFunctionBoostMode = z.enum(['multiply', 'replace', 'sum', 'avg', 'max', 'min']).meta({ id: 'QueryDslFunctionBoostMode' })
+export type QueryDslFunctionBoostMode = z.infer<typeof QueryDslFunctionBoostMode>
+
+export const QueryDslMultiValueMode = z.enum(['min', 'max', 'avg', 'sum']).meta({ id: 'QueryDslMultiValueMode' })
+export type QueryDslMultiValueMode = z.infer<typeof QueryDslMultiValueMode>
+
+export const QueryDslDecayFunctionBase = z.object({
+  multi_value_mode: QueryDslMultiValueMode.describe('Determines how the distance is calculated when a field used for computing the decay contains multiple values.').optional()
+}).meta({ id: 'QueryDslDecayFunctionBase' })
+export type QueryDslDecayFunctionBase = z.infer<typeof QueryDslDecayFunctionBase>
+
+export const QueryDslUntypedDecayFunction = z.object({
+  multi_value_mode: QueryDslMultiValueMode.describe('Determines how the distance is calculated when a field used for computing the decay contains multiple values.').optional()
+}).catchall(z.any()).meta({ id: 'QueryDslUntypedDecayFunction' })
+export type QueryDslUntypedDecayFunction = z.infer<typeof QueryDslUntypedDecayFunction>
+
+export const QueryDslDateDecayFunction = z.object({
+  multi_value_mode: QueryDslMultiValueMode.describe('Determines how the distance is calculated when a field used for computing the decay contains multiple values.').optional()
+}).catchall(z.any()).meta({ id: 'QueryDslDateDecayFunction' })
+export type QueryDslDateDecayFunction = z.infer<typeof QueryDslDateDecayFunction>
+
+export const QueryDslNumericDecayFunction = z.object({
+  multi_value_mode: QueryDslMultiValueMode.describe('Determines how the distance is calculated when a field used for computing the decay contains multiple values.').optional()
+}).catchall(z.any()).meta({ id: 'QueryDslNumericDecayFunction' })
+export type QueryDslNumericDecayFunction = z.infer<typeof QueryDslNumericDecayFunction>
+
+export const QueryDslGeoDecayFunction = z.object({
+  multi_value_mode: QueryDslMultiValueMode.describe('Determines how the distance is calculated when a field used for computing the decay contains multiple values.').optional()
+}).catchall(z.any()).meta({ id: 'QueryDslGeoDecayFunction' })
+export type QueryDslGeoDecayFunction = z.infer<typeof QueryDslGeoDecayFunction>
+
+export const QueryDslDecayFunction = z.union([QueryDslUntypedDecayFunction, QueryDslDateDecayFunction, QueryDslNumericDecayFunction, QueryDslGeoDecayFunction]).meta({ id: 'QueryDslDecayFunction' })
+export type QueryDslDecayFunction = z.infer<typeof QueryDslDecayFunction>
+
+export const QueryDslFieldValueFactorModifier = z.enum(['none', 'log', 'log1p', 'log2p', 'ln', 'ln1p', 'ln2p', 'square', 'sqrt', 'reciprocal']).meta({ id: 'QueryDslFieldValueFactorModifier' })
+export type QueryDslFieldValueFactorModifier = z.infer<typeof QueryDslFieldValueFactorModifier>
+
+export const QueryDslFieldValueFactorScoreFunction = z.object({
+  field: Field.describe('Field to be extracted from the document.'),
+  factor: double.describe('Optional factor to multiply the field value with.').optional(),
+  missing: double.describe('Value used if the document doesn’t have that field. The modifier and factor are still applied to it as though it were read from the document.').optional(),
+  modifier: QueryDslFieldValueFactorModifier.describe('Modifier to apply to the field value.').optional()
+}).meta({ id: 'QueryDslFieldValueFactorScoreFunction' })
+export type QueryDslFieldValueFactorScoreFunction = z.infer<typeof QueryDslFieldValueFactorScoreFunction>
+
+export const QueryDslRandomScoreFunction = z.object({
+  field: Field.optional(),
+  seed: z.union([long, z.string()]).optional()
+}).meta({ id: 'QueryDslRandomScoreFunction' })
+export type QueryDslRandomScoreFunction = z.infer<typeof QueryDslRandomScoreFunction>
+
+export type ScriptSourceShape = string | SearchSearchRequestBodyShape
+export const ScriptSource: z.ZodType<ScriptSourceShape> = z.union([z.string(), z.lazy(() => SearchSearchRequestBody)]).meta({ id: 'ScriptSource' })
+export type ScriptSource = z.infer<typeof ScriptSource>
+
+export const ScriptLanguage = z.union([z.enum(['painless', 'expression', 'mustache', 'java']), z.string()]).meta({ id: 'ScriptLanguage' })
+export type ScriptLanguage = z.infer<typeof ScriptLanguage>
+
+export interface ScriptShape {
+  source?: ScriptSourceShape | undefined
+  id?: Id | undefined
+  params?: Record<string, unknown> | undefined
+  lang?: ScriptLanguage | undefined
+  options?: Record<string, string> | undefined
+}
+export const Script = z.object({
+  get source () { return ScriptSource.describe('The script source.').optional() },
+  id: Id.describe('The `id` for a stored script.').optional(),
+  params: z.record(z.string(), z.any()).describe('Specifies any named parameters that are passed into the script as variables. Use parameters instead of hard-coded values to decrease compile time.').optional(),
+  lang: ScriptLanguage.describe('Specifies the language the script is written in.').optional(),
+  options: z.record(z.string(), z.string()).optional()
+}).meta({ id: 'Script' })
+export type Script = z.infer<typeof Script>
+
+export interface QueryDslScriptScoreFunctionShape {
+  script: ScriptShape
+}
+export const QueryDslScriptScoreFunction = z.object({
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
+}).meta({ id: 'QueryDslScriptScoreFunction' })
+export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
+
+const QueryDslFunctionScoreContainerCommonProps = z.object({
+  filter: z.lazy(() => QueryDslQueryContainer).optional(),
+  weight: double.optional()
+})
+
+const QueryDslFunctionScoreContainerExclusiveProps = z.union([z.object({ exp: QueryDslDecayFunction }), z.object({ gauss: QueryDslDecayFunction }), z.object({ linear: QueryDslDecayFunction }), z.object({ field_value_factor: QueryDslFieldValueFactorScoreFunction }), z.object({ random_score: QueryDslRandomScoreFunction }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreFunction) })])
+
+export interface QueryDslFunctionScoreContainerShape {
+  filter?: QueryDslQueryContainerShape | undefined
+  weight?: double | undefined
+  exp?: QueryDslDecayFunction | undefined
+  gauss?: QueryDslDecayFunction | undefined
+  linear?: QueryDslDecayFunction | undefined
+  field_value_factor?: QueryDslFieldValueFactorScoreFunction | undefined
+  random_score?: QueryDslRandomScoreFunction | undefined
+  script_score?: QueryDslScriptScoreFunction | undefined
+}
+export const QueryDslFunctionScoreContainer: z.ZodType<QueryDslFunctionScoreContainerShape> = QueryDslFunctionScoreContainerCommonProps.and(QueryDslFunctionScoreContainerExclusiveProps).meta({ id: 'QueryDslFunctionScoreContainer' })
+export type QueryDslFunctionScoreContainer = z.infer<typeof QueryDslFunctionScoreContainer>
+
+export const QueryDslFunctionScoreMode = z.enum(['multiply', 'sum', 'avg', 'first', 'max', 'min']).meta({ id: 'QueryDslFunctionScoreMode' })
+export type QueryDslFunctionScoreMode = z.infer<typeof QueryDslFunctionScoreMode>
+
+export interface QueryDslFunctionScoreQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  boost_mode?: QueryDslFunctionBoostMode | undefined
+  functions?: QueryDslFunctionScoreContainerShape[] | undefined
+  max_boost?: double | undefined
+  min_score?: double | undefined
+  query?: QueryDslQueryContainerShape | undefined
+  score_mode?: QueryDslFunctionScoreMode | undefined
+}
+export const QueryDslFunctionScoreQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  boost_mode: QueryDslFunctionBoostMode.describe('Defines how he newly computed score is combined with the score of the query').optional(),
+  get functions () { return QueryDslFunctionScoreContainer.array().describe('One or more functions that compute a new score for each document returned by the query.').optional() },
+  max_boost: double.describe('Restricts the new score to not exceed the provided limit.').optional(),
+  min_score: double.describe('Excludes documents that do not meet the provided score threshold.').optional(),
+  get query () { return QueryDslQueryContainer.describe('A query that determines the documents for which a new score is computed.').optional() },
+  score_mode: QueryDslFunctionScoreMode.describe('Specifies how the computed scores are combined').optional()
+}).meta({ id: 'QueryDslFunctionScoreQuery' })
+export type QueryDslFunctionScoreQuery = z.infer<typeof QueryDslFunctionScoreQuery>
+
+export const MultiTermQueryRewrite = z.string().meta({ id: 'MultiTermQueryRewrite' })
+export type MultiTermQueryRewrite = z.infer<typeof MultiTermQueryRewrite>
+
+export const Fuzziness = z.union([z.string(), integer]).meta({ id: 'Fuzziness' })
+export type Fuzziness = z.infer<typeof Fuzziness>
+
+export const QueryDslFuzzyQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  max_expansions: integer.describe('Maximum number of variations created.').optional(),
+  prefix_length: integer.describe('Number of beginning characters left unchanged when creating expansions.').optional(),
+  rewrite: MultiTermQueryRewrite.describe('Number of beginning characters left unchanged when creating expansions.').optional(),
+  transpositions: z.boolean().describe('Indicates whether edits include transpositions of two adjacent characters (for example `ab` to `ba`).').optional(),
+  fuzziness: Fuzziness.describe('Maximum edit distance allowed for matching.').optional(),
+  value: z.union([z.string(), double, z.boolean()]).describe('Term you wish to find in the provided field.')
+}).meta({ id: 'QueryDslFuzzyQuery' })
+export type QueryDslFuzzyQuery = z.infer<typeof QueryDslFuzzyQuery>
+
+export const QueryDslGeoExecution = z.enum(['memory', 'indexed']).meta({ id: 'QueryDslGeoExecution' })
+export type QueryDslGeoExecution = z.infer<typeof QueryDslGeoExecution>
+
+export const QueryDslGeoValidationMethod = z.enum(['coerce', 'ignore_malformed', 'strict']).meta({ id: 'QueryDslGeoValidationMethod' })
+export type QueryDslGeoValidationMethod = z.infer<typeof QueryDslGeoValidationMethod>
+
+export const QueryDslGeoBoundingBoxQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  type: QueryDslGeoExecution.optional(),
+  validation_method: QueryDslGeoValidationMethod.describe('Set to `IGNORE_MALFORMED` to accept geo points with invalid latitude or longitude. Set to `COERCE` to also try to infer correct latitude or longitude.').optional(),
+  ignore_unmapped: z.boolean().describe('Set to `true` to ignore an unmapped field and not match any documents for this query. Set to `false` to throw an exception if the field is not mapped.').optional()
+}).catchall(z.any()).meta({ id: 'QueryDslGeoBoundingBoxQuery' })
+export type QueryDslGeoBoundingBoxQuery = z.infer<typeof QueryDslGeoBoundingBoxQuery>
+
+export const Distance = z.string().meta({ id: 'Distance' })
+export type Distance = z.infer<typeof Distance>
+
+export const GeoDistanceType = z.enum(['arc', 'plane']).meta({ id: 'GeoDistanceType' })
+export type GeoDistanceType = z.infer<typeof GeoDistanceType>
+
+export const QueryDslGeoDistanceQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  distance: Distance.describe('The radius of the circle centred on the specified location. Points which fall into this circle are considered to be matches.'),
+  distance_type: GeoDistanceType.describe('How to compute the distance. Set to `plane` for a faster calculation that\'s inaccurate on long distances and close to the poles.').optional(),
+  validation_method: QueryDslGeoValidationMethod.describe('Set to `IGNORE_MALFORMED` to accept geo points with invalid latitude or longitude. Set to `COERCE` to also try to infer correct latitude or longitude.').optional(),
+  ignore_unmapped: z.boolean().describe('Set to `true` to ignore an unmapped field and not match any documents for this query. Set to `false` to throw an exception if the field is not mapped.').optional()
+}).catchall(z.any()).meta({ id: 'QueryDslGeoDistanceQuery' })
+export type QueryDslGeoDistanceQuery = z.infer<typeof QueryDslGeoDistanceQuery>
+
+/** A map tile reference, represented as `{zoom}/{x}/{y}` */
+export const GeoTile = z.string().meta({ id: 'GeoTile' })
+export type GeoTile = z.infer<typeof GeoTile>
+
+export const GeoHash = z.string().meta({ id: 'GeoHash' })
+export type GeoHash = z.infer<typeof GeoHash>
+
+/** A map hex cell (H3) reference */
+export const GeoHexCell = z.string().meta({ id: 'GeoHexCell' })
+export type GeoHexCell = z.infer<typeof GeoHexCell>
+
+const QueryDslGeoGridQueryExclusiveProps = z.union([z.object({ geotile: GeoTile }), z.object({ geohash: GeoHash }), z.object({ geohex: GeoHexCell })])
+
+export const QueryDslGeoGridQuery = QueryDslGeoGridQueryExclusiveProps.meta({ id: 'QueryDslGeoGridQuery' })
+export type QueryDslGeoGridQuery = z.infer<typeof QueryDslGeoGridQuery>
+
+export const QueryDslGeoPolygonQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  validation_method: QueryDslGeoValidationMethod.optional(),
+  ignore_unmapped: z.boolean().optional()
+}).catchall(z.any()).meta({ id: 'QueryDslGeoPolygonQuery' })
+export type QueryDslGeoPolygonQuery = z.infer<typeof QueryDslGeoPolygonQuery>
+
+export const QueryDslGeoShapeQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  ignore_unmapped: z.boolean().describe('Set to `true` to ignore an unmapped field and not match any documents for this query. Set to `false` to throw an exception if the field is not mapped.').optional()
+}).catchall(z.any()).meta({ id: 'QueryDslGeoShapeQuery' })
+export type QueryDslGeoShapeQuery = z.infer<typeof QueryDslGeoShapeQuery>
+
+export const Name = z.string().meta({ id: 'Name' })
+export type Name = z.infer<typeof Name>
+
+export interface SearchFieldCollapseShape {
+  field: Field
+  inner_hits?: SearchInnerHitsShape | SearchInnerHitsShape[] | undefined
+  max_concurrent_group_searches?: integer | undefined
+  collapse?: SearchFieldCollapseShape | undefined
+}
+export const SearchFieldCollapse = z.object({
+  field: Field.describe('The field to collapse the result set on'),
+  get inner_hits (): z.ZodOptional<z.ZodUnion<readonly [typeof SearchInnerHits, z.ZodArray<typeof SearchInnerHits>]>> { return z.union([SearchInnerHits, SearchInnerHits.array()]).describe('The number of inner hits and their sort order').optional() },
+  max_concurrent_group_searches: integer.describe('The number of concurrent requests allowed to retrieve the inner_hits per group').optional(),
+  get collapse () { return SearchFieldCollapse.optional() }
+}).meta({ id: 'SearchFieldCollapse' })
+export type SearchFieldCollapse = z.infer<typeof SearchFieldCollapse>
+
+/** A reference to a field with formatting instructions on how to return the value */
+export const QueryDslFieldAndFormat = z.object({
+  field: Field.describe('A wildcard pattern. The request returns values for field names matching this pattern.'),
+  format: z.string().describe('The format in which the values are returned.').optional(),
+  include_unmapped: z.boolean().optional()
+}).meta({ id: 'QueryDslFieldAndFormat' })
+export type QueryDslFieldAndFormat = z.infer<typeof QueryDslFieldAndFormat>
+
+export const SearchHighlighterType = z.union([z.enum(['plain', 'fvh', 'unified']), z.string()]).meta({ id: 'SearchHighlighterType' })
+export type SearchHighlighterType = z.infer<typeof SearchHighlighterType>
+
+export const SearchBoundaryScanner = z.enum(['chars', 'sentence', 'word']).meta({ id: 'SearchBoundaryScanner' })
+export type SearchBoundaryScanner = z.infer<typeof SearchBoundaryScanner>
+
+export const SearchHighlighterFragmenter = z.enum(['simple', 'span']).meta({ id: 'SearchHighlighterFragmenter' })
+export type SearchHighlighterFragmenter = z.infer<typeof SearchHighlighterFragmenter>
+
+export const SearchHighlighterOrder = z.enum(['score']).meta({ id: 'SearchHighlighterOrder' })
+export type SearchHighlighterOrder = z.infer<typeof SearchHighlighterOrder>
+
+export const SearchHighlighterTagsSchema = z.enum(['styled']).meta({ id: 'SearchHighlighterTagsSchema' })
+export type SearchHighlighterTagsSchema = z.infer<typeof SearchHighlighterTagsSchema>
+
+export interface SearchHighlightBaseShape {
+  type?: SearchHighlighterType | undefined
+  boundary_chars?: string | undefined
+  boundary_max_scan?: integer | undefined
+  boundary_scanner?: SearchBoundaryScanner | undefined
+  boundary_scanner_locale?: string | undefined
+  force_source?: boolean | undefined
+  fragmenter?: SearchHighlighterFragmenter | undefined
+  fragment_size?: integer | undefined
+  highlight_filter?: boolean | undefined
+  highlight_query?: QueryDslQueryContainerShape | undefined
+  max_fragment_length?: integer | undefined
+  max_analyzed_offset?: integer | undefined
+  no_match_size?: integer | undefined
+  number_of_fragments?: integer | undefined
+  options?: Record<string, unknown> | undefined
+  order?: SearchHighlighterOrder | undefined
+  phrase_limit?: integer | undefined
+  post_tags?: string[] | undefined
+  pre_tags?: string[] | undefined
+  require_field_match?: boolean | undefined
+  tags_schema?: SearchHighlighterTagsSchema | undefined
+}
+export const SearchHighlightBase = z.object({
+  type: SearchHighlighterType.optional(),
+  boundary_chars: z.string().describe('A string that contains each boundary character.').optional(),
+  boundary_max_scan: integer.describe('How far to scan for boundary characters.').optional(),
+  boundary_scanner: SearchBoundaryScanner.describe('Specifies how to break the highlighted fragments: chars, sentence, or word. Only valid for the unified and fvh highlighters. Defaults to `sentence` for the `unified` highlighter. Defaults to `chars` for the `fvh` highlighter.').optional(),
+  boundary_scanner_locale: z.string().describe('Controls which locale is used to search for sentence and word boundaries. This parameter takes a form of a language tag, for example: `"en-US"`, `"fr-FR"`, `"ja-JP"`.').optional(),
+  force_source: z.boolean().optional(),
+  fragmenter: SearchHighlighterFragmenter.describe('Specifies how text should be broken up in highlight snippets: `simple` or `span`. Only valid for the `plain` highlighter.').optional(),
+  fragment_size: integer.describe('The size of the highlighted fragment in characters.').optional(),
+  highlight_filter: z.boolean().optional(),
+  get highlight_query () { return QueryDslQueryContainer.describe('Highlight matches for a query other than the search query. This is especially useful if you use a rescore query because those are not taken into account by highlighting by default.').optional() },
+  max_fragment_length: integer.optional(),
+  max_analyzed_offset: integer.describe('If set to a non-negative value, highlighting stops at this defined maximum limit. The rest of the text is not processed, thus not highlighted and no error is returned The `max_analyzed_offset` query setting does not override the `index.highlight.max_analyzed_offset` setting, which prevails when it’s set to lower value than the query setting.').optional(),
+  no_match_size: integer.describe('The amount of text you want to return from the beginning of the field if there are no matching fragments to highlight.').optional(),
+  number_of_fragments: integer.describe('The maximum number of fragments to return. If the number of fragments is set to `0`, no fragments are returned. Instead, the entire field contents are highlighted and returned. This can be handy when you need to highlight short texts such as a title or address, but fragmentation is not required. If `number_of_fragments` is `0`, `fragment_size` is ignored.').optional(),
+  options: z.record(z.string(), z.any()).optional(),
+  order: SearchHighlighterOrder.describe('Sorts highlighted fragments by score when set to `score`. By default, fragments will be output in the order they appear in the field (order: `none`). Setting this option to `score` will output the most relevant fragments first. Each highlighter applies its own logic to compute relevancy scores.').optional(),
+  phrase_limit: integer.describe('Controls the number of matching phrases in a document that are considered. Prevents the `fvh` highlighter from analyzing too many phrases and consuming too much memory. When using `matched_fields`, `phrase_limit` phrases per matched field are considered. Raising the limit increases query time and consumes more memory. Only supported by the `fvh` highlighter.').optional(),
+  post_tags: z.array(z.string()).describe('Use in conjunction with `pre_tags` to define the HTML tags to use for the highlighted text. By default, highlighted text is wrapped in `<em>` and `</em>` tags.').optional(),
+  pre_tags: z.array(z.string()).describe('Use in conjunction with `post_tags` to define the HTML tags to use for the highlighted text. By default, highlighted text is wrapped in `<em>` and `</em>` tags.').optional(),
+  require_field_match: z.boolean().describe('By default, only fields that contains a query match are highlighted. Set to `false` to highlight all fields.').optional(),
+  tags_schema: SearchHighlighterTagsSchema.describe('Set to `styled` to use the built-in tag schema.').optional()
+}).meta({ id: 'SearchHighlightBase' })
+export type SearchHighlightBase = z.infer<typeof SearchHighlightBase>
+
+export const SearchHighlighterEncoder = z.enum(['default', 'html']).meta({ id: 'SearchHighlighterEncoder' })
+export type SearchHighlighterEncoder = z.infer<typeof SearchHighlighterEncoder>
+
+export const Fields = z.union([Field, z.array(Field)]).meta({ id: 'Fields' })
+export type Fields = z.infer<typeof Fields>
+
+export interface SearchHighlightFieldShape {
+  type?: SearchHighlighterType | undefined
+  boundary_chars?: string | undefined
+  boundary_max_scan?: integer | undefined
+  boundary_scanner?: SearchBoundaryScanner | undefined
+  boundary_scanner_locale?: string | undefined
+  force_source?: boolean | undefined
+  fragmenter?: SearchHighlighterFragmenter | undefined
+  fragment_size?: integer | undefined
+  highlight_filter?: boolean | undefined
+  highlight_query?: QueryDslQueryContainerShape | undefined
+  max_fragment_length?: integer | undefined
+  max_analyzed_offset?: integer | undefined
+  no_match_size?: integer | undefined
+  number_of_fragments?: integer | undefined
+  options?: Record<string, unknown> | undefined
+  order?: SearchHighlighterOrder | undefined
+  phrase_limit?: integer | undefined
+  post_tags?: string[] | undefined
+  pre_tags?: string[] | undefined
+  require_field_match?: boolean | undefined
+  tags_schema?: SearchHighlighterTagsSchema | undefined
+  fragment_offset?: integer | undefined
+  matched_fields?: Fields | undefined
+}
+export const SearchHighlightField = z.object({
+  type: SearchHighlighterType.optional(),
+  boundary_chars: z.string().describe('A string that contains each boundary character.').optional(),
+  boundary_max_scan: integer.describe('How far to scan for boundary characters.').optional(),
+  boundary_scanner: SearchBoundaryScanner.describe('Specifies how to break the highlighted fragments: chars, sentence, or word. Only valid for the unified and fvh highlighters. Defaults to `sentence` for the `unified` highlighter. Defaults to `chars` for the `fvh` highlighter.').optional(),
+  boundary_scanner_locale: z.string().describe('Controls which locale is used to search for sentence and word boundaries. This parameter takes a form of a language tag, for example: `"en-US"`, `"fr-FR"`, `"ja-JP"`.').optional(),
+  force_source: z.boolean().optional(),
+  fragmenter: SearchHighlighterFragmenter.describe('Specifies how text should be broken up in highlight snippets: `simple` or `span`. Only valid for the `plain` highlighter.').optional(),
+  fragment_size: integer.describe('The size of the highlighted fragment in characters.').optional(),
+  highlight_filter: z.boolean().optional(),
+  get highlight_query () { return QueryDslQueryContainer.describe('Highlight matches for a query other than the search query. This is especially useful if you use a rescore query because those are not taken into account by highlighting by default.').optional() },
+  max_fragment_length: integer.optional(),
+  max_analyzed_offset: integer.describe('If set to a non-negative value, highlighting stops at this defined maximum limit. The rest of the text is not processed, thus not highlighted and no error is returned The `max_analyzed_offset` query setting does not override the `index.highlight.max_analyzed_offset` setting, which prevails when it’s set to lower value than the query setting.').optional(),
+  no_match_size: integer.describe('The amount of text you want to return from the beginning of the field if there are no matching fragments to highlight.').optional(),
+  number_of_fragments: integer.describe('The maximum number of fragments to return. If the number of fragments is set to `0`, no fragments are returned. Instead, the entire field contents are highlighted and returned. This can be handy when you need to highlight short texts such as a title or address, but fragmentation is not required. If `number_of_fragments` is `0`, `fragment_size` is ignored.').optional(),
+  options: z.record(z.string(), z.any()).optional(),
+  order: SearchHighlighterOrder.describe('Sorts highlighted fragments by score when set to `score`. By default, fragments will be output in the order they appear in the field (order: `none`). Setting this option to `score` will output the most relevant fragments first. Each highlighter applies its own logic to compute relevancy scores.').optional(),
+  phrase_limit: integer.describe('Controls the number of matching phrases in a document that are considered. Prevents the `fvh` highlighter from analyzing too many phrases and consuming too much memory. When using `matched_fields`, `phrase_limit` phrases per matched field are considered. Raising the limit increases query time and consumes more memory. Only supported by the `fvh` highlighter.').optional(),
+  post_tags: z.array(z.string()).describe('Use in conjunction with `pre_tags` to define the HTML tags to use for the highlighted text. By default, highlighted text is wrapped in `<em>` and `</em>` tags.').optional(),
+  pre_tags: z.array(z.string()).describe('Use in conjunction with `post_tags` to define the HTML tags to use for the highlighted text. By default, highlighted text is wrapped in `<em>` and `</em>` tags.').optional(),
+  require_field_match: z.boolean().describe('By default, only fields that contains a query match are highlighted. Set to `false` to highlight all fields.').optional(),
+  tags_schema: SearchHighlighterTagsSchema.describe('Set to `styled` to use the built-in tag schema.').optional(),
+  fragment_offset: integer.optional(),
+  matched_fields: Fields.optional()
+}).meta({ id: 'SearchHighlightField' })
+export type SearchHighlightField = z.infer<typeof SearchHighlightField>
+
+export interface SearchHighlightShape {
+  type?: SearchHighlighterType | undefined
+  boundary_chars?: string | undefined
+  boundary_max_scan?: integer | undefined
+  boundary_scanner?: SearchBoundaryScanner | undefined
+  boundary_scanner_locale?: string | undefined
+  force_source?: boolean | undefined
+  fragmenter?: SearchHighlighterFragmenter | undefined
+  fragment_size?: integer | undefined
+  highlight_filter?: boolean | undefined
+  highlight_query?: QueryDslQueryContainerShape | undefined
+  max_fragment_length?: integer | undefined
+  max_analyzed_offset?: integer | undefined
+  no_match_size?: integer | undefined
+  number_of_fragments?: integer | undefined
+  options?: Record<string, unknown> | undefined
+  order?: SearchHighlighterOrder | undefined
+  phrase_limit?: integer | undefined
+  post_tags?: string[] | undefined
+  pre_tags?: string[] | undefined
+  require_field_match?: boolean | undefined
+  tags_schema?: SearchHighlighterTagsSchema | undefined
+  encoder?: SearchHighlighterEncoder | undefined
+  fields: Record<Field, SearchHighlightFieldShape> | Array<Record<Field, SearchHighlightFieldShape>>
+}
+export const SearchHighlight = z.object({
+  type: SearchHighlighterType.optional(),
+  boundary_chars: z.string().describe('A string that contains each boundary character.').optional(),
+  boundary_max_scan: integer.describe('How far to scan for boundary characters.').optional(),
+  boundary_scanner: SearchBoundaryScanner.describe('Specifies how to break the highlighted fragments: chars, sentence, or word. Only valid for the unified and fvh highlighters. Defaults to `sentence` for the `unified` highlighter. Defaults to `chars` for the `fvh` highlighter.').optional(),
+  boundary_scanner_locale: z.string().describe('Controls which locale is used to search for sentence and word boundaries. This parameter takes a form of a language tag, for example: `"en-US"`, `"fr-FR"`, `"ja-JP"`.').optional(),
+  force_source: z.boolean().optional(),
+  fragmenter: SearchHighlighterFragmenter.describe('Specifies how text should be broken up in highlight snippets: `simple` or `span`. Only valid for the `plain` highlighter.').optional(),
+  fragment_size: integer.describe('The size of the highlighted fragment in characters.').optional(),
+  highlight_filter: z.boolean().optional(),
+  get highlight_query () { return QueryDslQueryContainer.describe('Highlight matches for a query other than the search query. This is especially useful if you use a rescore query because those are not taken into account by highlighting by default.').optional() },
+  max_fragment_length: integer.optional(),
+  max_analyzed_offset: integer.describe('If set to a non-negative value, highlighting stops at this defined maximum limit. The rest of the text is not processed, thus not highlighted and no error is returned The `max_analyzed_offset` query setting does not override the `index.highlight.max_analyzed_offset` setting, which prevails when it’s set to lower value than the query setting.').optional(),
+  no_match_size: integer.describe('The amount of text you want to return from the beginning of the field if there are no matching fragments to highlight.').optional(),
+  number_of_fragments: integer.describe('The maximum number of fragments to return. If the number of fragments is set to `0`, no fragments are returned. Instead, the entire field contents are highlighted and returned. This can be handy when you need to highlight short texts such as a title or address, but fragmentation is not required. If `number_of_fragments` is `0`, `fragment_size` is ignored.').optional(),
+  options: z.record(z.string(), z.any()).optional(),
+  order: SearchHighlighterOrder.describe('Sorts highlighted fragments by score when set to `score`. By default, fragments will be output in the order they appear in the field (order: `none`). Setting this option to `score` will output the most relevant fragments first. Each highlighter applies its own logic to compute relevancy scores.').optional(),
+  phrase_limit: integer.describe('Controls the number of matching phrases in a document that are considered. Prevents the `fvh` highlighter from analyzing too many phrases and consuming too much memory. When using `matched_fields`, `phrase_limit` phrases per matched field are considered. Raising the limit increases query time and consumes more memory. Only supported by the `fvh` highlighter.').optional(),
+  post_tags: z.array(z.string()).describe('Use in conjunction with `pre_tags` to define the HTML tags to use for the highlighted text. By default, highlighted text is wrapped in `<em>` and `</em>` tags.').optional(),
+  pre_tags: z.array(z.string()).describe('Use in conjunction with `post_tags` to define the HTML tags to use for the highlighted text. By default, highlighted text is wrapped in `<em>` and `</em>` tags.').optional(),
+  require_field_match: z.boolean().describe('By default, only fields that contains a query match are highlighted. Set to `false` to highlight all fields.').optional(),
+  tags_schema: SearchHighlighterTagsSchema.describe('Set to `styled` to use the built-in tag schema.').optional(),
+  encoder: SearchHighlighterEncoder.optional(),
+  get fields (): z.ZodUnion<readonly [z.ZodRecord<typeof Field, typeof SearchHighlightField>, z.ZodArray<z.ZodRecord<typeof Field, typeof SearchHighlightField>>]> { return z.union([z.record(Field, SearchHighlightField), z.array(z.record(Field, SearchHighlightField))]) }
+}).meta({ id: 'SearchHighlight' })
+export type SearchHighlight = z.infer<typeof SearchHighlight>
+
+export interface ScriptFieldShape {
+  script: ScriptShape
+  ignore_failure?: boolean | undefined
+}
+export const ScriptField = z.object({
+  get script () { return z.union([Script, ScriptSource]) },
+  ignore_failure: z.boolean().optional()
+}).meta({ id: 'ScriptField' })
+export type ScriptField = z.infer<typeof ScriptField>
+
+export const SortOrder = z.enum(['asc', 'desc']).meta({ id: 'SortOrder' })
+export type SortOrder = z.infer<typeof SortOrder>
+
+export const ScoreSort = z.object({
+  order: SortOrder.optional()
+}).meta({ id: 'ScoreSort' })
+export type ScoreSort = z.infer<typeof ScoreSort>
+
+export const SortMode = z.enum(['min', 'max', 'sum', 'avg', 'median']).meta({ id: 'SortMode' })
+export type SortMode = z.infer<typeof SortMode>
+
+export const DistanceUnit = z.enum(['in', 'ft', 'yd', 'mi', 'nmi', 'km', 'm', 'cm', 'mm']).meta({ id: 'DistanceUnit' })
+export type DistanceUnit = z.infer<typeof DistanceUnit>
+
+export interface NestedSortValueShape {
+  filter?: QueryDslQueryContainerShape | undefined
+  max_children?: integer | undefined
+  nested?: NestedSortValueShape | undefined
+  path: Field
+}
+export const NestedSortValue = z.object({
+  get filter () { return QueryDslQueryContainer.optional() },
+  max_children: integer.optional(),
+  get nested () { return NestedSortValue.optional() },
+  path: Field
+}).meta({ id: 'NestedSortValue' })
+export type NestedSortValue = z.infer<typeof NestedSortValue>
+
+export interface GeoDistanceSortShape {
+  mode?: SortMode | undefined
+  distance_type?: GeoDistanceType | undefined
+  ignore_unmapped?: boolean | undefined
+  order?: SortOrder | undefined
+  unit?: DistanceUnit | undefined
+  nested?: NestedSortValueShape | undefined
+}
+export const GeoDistanceSort = z.looseObject({
+  mode: SortMode.optional(),
+  distance_type: GeoDistanceType.optional(),
+  ignore_unmapped: z.boolean().optional(),
+  order: SortOrder.optional(),
+  unit: DistanceUnit.optional(),
+  get nested () { return NestedSortValue.optional() }
+}).meta({ id: 'GeoDistanceSort' })
+export type GeoDistanceSort = z.infer<typeof GeoDistanceSort>
+
+export const ScriptSortType = z.enum(['string', 'number', 'version']).meta({ id: 'ScriptSortType' })
+export type ScriptSortType = z.infer<typeof ScriptSortType>
+
+export interface ScriptSortShape {
+  order?: SortOrder | undefined
+  script: ScriptShape
+  type?: ScriptSortType | undefined
+  mode?: SortMode | undefined
+  nested?: NestedSortValueShape | undefined
+}
+export const ScriptSort = z.object({
+  order: SortOrder.optional(),
+  get script () { return z.union([Script, ScriptSource]) },
+  type: ScriptSortType.optional(),
+  mode: SortMode.optional(),
+  get nested () { return NestedSortValue.optional() }
+}).meta({ id: 'ScriptSort' })
+export type ScriptSort = z.infer<typeof ScriptSort>
+
+export interface SortOptionsShape {
+  _score?: ScoreSort | undefined
+  _doc?: ScoreSort | undefined
+  _geo_distance?: GeoDistanceSortShape | undefined
+  _script?: ScriptSortShape | undefined
+}
+export const SortOptions = z.looseObject({
+  _score: ScoreSort.optional(),
+  _doc: ScoreSort.optional(),
+  get _geo_distance () { return GeoDistanceSort.optional() },
+  get _script () { return ScriptSort.optional() }
+}).meta({ id: 'SortOptions' })
+export type SortOptions = z.infer<typeof SortOptions>
+
+export type SortCombinationsShape = Field | SortOptionsShape
+export const SortCombinations: z.ZodType<SortCombinationsShape> = z.union([Field, z.lazy(() => SortOptions)]).meta({ id: 'SortCombinations' })
+export type SortCombinations = z.infer<typeof SortCombinations>
+
+export type SortShape = SortCombinationsShape | SortCombinationsShape[]
+export const Sort: z.ZodType<SortShape> = z.union([z.lazy(() => SortCombinations), z.array(z.lazy(() => SortCombinations))]).meta({ id: 'Sort' })
+export type Sort = z.infer<typeof Sort>
+
+export const SearchSourceFilter = z.object({
+  exclude_vectors: z.boolean().describe('If `true`, vector fields are excluded from the returned source. This option takes precedence over `includes`: any vector field will remain excluded even if it matches an `includes` rule.').optional(),
+  excludes: Fields.describe('A list of fields to exclude from the returned source.').optional(),
+  exclude: Fields.describe('A list of fields to exclude from the returned source.').optional(),
+  includes: Fields.describe('A list of fields to include in the returned source.').optional(),
+  include: Fields.describe('A list of fields to include in the returned source.').optional()
+}).meta({ id: 'SearchSourceFilter' })
+export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
+
+/** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
+export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
+
+export interface SearchInnerHitsShape {
+  name?: Name | undefined
+  size?: integer | undefined
+  from?: integer | undefined
+  collapse?: SearchFieldCollapseShape | undefined
+  docvalue_fields?: QueryDslFieldAndFormat[] | undefined
+  explain?: boolean | undefined
+  highlight?: SearchHighlightShape | undefined
+  ignore_unmapped?: boolean | undefined
+  script_fields?: Record<Field, ScriptFieldShape> | undefined
+  seq_no_primary_term?: boolean | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
+  sort?: SortShape | undefined
+  _source?: SearchSourceConfig | undefined
+  stored_fields?: Fields | undefined
+  track_scores?: boolean | undefined
+  version?: boolean | undefined
+}
+export const SearchInnerHits = z.object({
+  name: Name.describe('The name for the particular inner hit definition in the response. Useful when a search request contains multiple inner hits.').optional(),
+  size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
+  from: integer.describe('Inner hit starting document offset.').optional(),
+  get collapse () { return SearchFieldCollapse.optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
+  explain: z.boolean().optional(),
+  get highlight () { return SearchHighlight.optional() },
+  ignore_unmapped: z.boolean().optional(),
+  get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
+  seq_no_primary_term: z.boolean().optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
+  get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
+  _source: SearchSourceConfig.optional(),
+  stored_fields: Fields.optional(),
+  track_scores: z.boolean().optional(),
+  version: z.boolean().optional()
+}).meta({ id: 'SearchInnerHits' })
+export type SearchInnerHits = z.infer<typeof SearchInnerHits>
+
+export const QueryDslChildScoreMode = z.enum(['none', 'avg', 'sum', 'max', 'min']).meta({ id: 'QueryDslChildScoreMode' })
+export type QueryDslChildScoreMode = z.infer<typeof QueryDslChildScoreMode>
+
+export const RelationName = z.string().meta({ id: 'RelationName' })
+export type RelationName = z.infer<typeof RelationName>
+
+export interface QueryDslHasChildQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  ignore_unmapped?: boolean | undefined
+  inner_hits?: SearchInnerHitsShape | undefined
+  max_children?: integer | undefined
+  min_children?: integer | undefined
+  query: QueryDslQueryContainerShape
+  score_mode?: QueryDslChildScoreMode | undefined
+  type: RelationName
+}
+export const QueryDslHasChildQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  ignore_unmapped: z.boolean().describe('Indicates whether to ignore an unmapped `type` and not return any documents instead of an error.').optional(),
+  get inner_hits () { return SearchInnerHits.describe('If defined, each search hit will contain inner hits.').optional() },
+  max_children: integer.describe('Maximum number of child documents that match the query allowed for a returned parent document. If the parent document exceeds this limit, it is excluded from the search results.').optional(),
+  min_children: integer.describe('Minimum number of child documents that match the query required to match the query for a returned parent document. If the parent document does not meet this limit, it is excluded from the search results.').optional(),
+  get query () { return QueryDslQueryContainer.describe('Query you wish to run on child documents of the `type` field. If a child document matches the search, the query returns the parent document.') },
+  score_mode: QueryDslChildScoreMode.describe('Indicates how scores for matching child documents affect the root parent document’s relevance score.').optional(),
+  type: RelationName.describe('Name of the child relationship mapped for the `join` field.')
+}).meta({ id: 'QueryDslHasChildQuery' })
+export type QueryDslHasChildQuery = z.infer<typeof QueryDslHasChildQuery>
+
+export interface QueryDslHasParentQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  ignore_unmapped?: boolean | undefined
+  inner_hits?: SearchInnerHitsShape | undefined
+  parent_type: RelationName
+  query: QueryDslQueryContainerShape
+  score?: boolean | undefined
+}
+export const QueryDslHasParentQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  ignore_unmapped: z.boolean().describe('Indicates whether to ignore an unmapped `parent_type` and not return any documents instead of an error. You can use this parameter to query multiple indices that may not contain the `parent_type`.').optional(),
+  get inner_hits () { return SearchInnerHits.describe('If defined, each search hit will contain inner hits.').optional() },
+  parent_type: RelationName.describe('Name of the parent relationship mapped for the `join` field.'),
+  get query () { return QueryDslQueryContainer.describe('Query you wish to run on parent documents of the `parent_type` field. If a parent document matches the search, the query returns its child documents.') },
+  score: z.boolean().describe('Indicates whether the relevance score of a matching parent document is aggregated into its child documents.').optional()
+}).meta({ id: 'QueryDslHasParentQuery' })
+export type QueryDslHasParentQuery = z.infer<typeof QueryDslHasParentQuery>
+
+export const Ids = z.union([Id, z.array(Id)]).meta({ id: 'Ids' })
+export type Ids = z.infer<typeof Ids>
+
+export const QueryDslIdsQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  values: Ids.describe('An array of document IDs.').optional()
+}).meta({ id: 'QueryDslIdsQuery' })
+export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
+
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
+
+export interface QueryDslIntervalsFilterShape {
+  after?: QueryDslIntervalsContainer | undefined
+  before?: QueryDslIntervalsContainer | undefined
+  contained_by?: QueryDslIntervalsContainer | undefined
+  containing?: QueryDslIntervalsContainer | undefined
+  not_contained_by?: QueryDslIntervalsContainer | undefined
+  not_containing?: QueryDslIntervalsContainer | undefined
+  not_overlapping?: QueryDslIntervalsContainer | undefined
+  overlapping?: QueryDslIntervalsContainer | undefined
+  script?: Script | undefined
+}
+export const QueryDslIntervalsFilter: z.ZodType<QueryDslIntervalsFilterShape> = QueryDslIntervalsFilterExclusiveProps.meta({ id: 'QueryDslIntervalsFilter' })
+export type QueryDslIntervalsFilter = z.infer<typeof QueryDslIntervalsFilter>
+
+export interface QueryDslIntervalsAnyOfShape {
+  intervals: QueryDslIntervalsContainerShape[]
+  filter?: QueryDslIntervalsFilterShape | undefined
+}
+export const QueryDslIntervalsAnyOf = z.object({
+  get intervals () { return QueryDslIntervalsContainer.array().describe('An array of rules to match.') },
+  get filter () { return QueryDslIntervalsFilter.describe('Rule used to filter returned intervals.').optional() }
+}).meta({ id: 'QueryDslIntervalsAnyOf' })
+export type QueryDslIntervalsAnyOf = z.infer<typeof QueryDslIntervalsAnyOf>
+
+export const QueryDslIntervalsFuzzy = z.object({
+  analyzer: z.string().describe('Analyzer used to normalize the term.').optional(),
+  fuzziness: Fuzziness.describe('Maximum edit distance allowed for matching.').optional(),
+  prefix_length: integer.describe('Number of beginning characters left unchanged when creating expansions.').optional(),
+  term: z.string().describe('The term to match.'),
+  transpositions: z.boolean().describe('Indicates whether edits include transpositions of two adjacent characters (for example, `ab` to `ba`).').optional(),
+  use_field: Field.describe('If specified, match intervals from this field rather than the top-level field. The `term` is normalized using the search analyzer from this field, unless `analyzer` is specified separately.').optional()
+}).meta({ id: 'QueryDslIntervalsFuzzy' })
+export type QueryDslIntervalsFuzzy = z.infer<typeof QueryDslIntervalsFuzzy>
+
+export interface QueryDslIntervalsMatchShape {
+  analyzer?: string | undefined
+  max_gaps?: integer | undefined
+  ordered?: boolean | undefined
+  query: string
+  use_field?: Field | undefined
+  filter?: QueryDslIntervalsFilterShape | undefined
+}
+export const QueryDslIntervalsMatch = z.object({
+  analyzer: z.string().describe('Analyzer used to analyze terms in the query.').optional(),
+  max_gaps: integer.describe('Maximum number of positions between the matching terms. Terms further apart than this are not considered matches.').optional(),
+  ordered: z.boolean().describe('If `true`, matching terms must appear in their specified order.').optional(),
+  query: z.string().describe('Text you wish to find in the provided field.'),
+  use_field: Field.describe('If specified, match intervals from this field rather than the top-level field. The `term` is normalized using the search analyzer from this field, unless `analyzer` is specified separately.').optional(),
+  get filter () { return QueryDslIntervalsFilter.describe('An optional interval filter.').optional() }
+}).meta({ id: 'QueryDslIntervalsMatch' })
+export type QueryDslIntervalsMatch = z.infer<typeof QueryDslIntervalsMatch>
+
+export const QueryDslIntervalsPrefix = z.object({
+  analyzer: z.string().describe('Analyzer used to analyze the `prefix`.').optional(),
+  prefix: z.string().describe('Beginning characters of terms you wish to find in the top-level field.'),
+  use_field: Field.describe('If specified, match intervals from this field rather than the top-level field. The `prefix` is normalized using the search analyzer from this field, unless `analyzer` is specified separately.').optional()
+}).meta({ id: 'QueryDslIntervalsPrefix' })
+export type QueryDslIntervalsPrefix = z.infer<typeof QueryDslIntervalsPrefix>
+
+export const QueryDslIntervalsRange = z.object({
+  analyzer: z.string().describe('Analyzer used to analyze the `prefix`.').optional(),
+  gte: z.string().describe('Lower term, either gte or gt must be provided.').optional(),
+  gt: z.string().describe('Lower term, either gte or gt must be provided.').optional(),
+  lte: z.string().describe('Upper term, either lte or lt must be provided.').optional(),
+  lt: z.string().describe('Upper term, either lte or lt must be provided.').optional(),
+  use_field: Field.describe('If specified, match intervals from this field rather than the top-level field. The `prefix` is normalized using the search analyzer from this field, unless `analyzer` is specified separately.').optional()
+}).meta({ id: 'QueryDslIntervalsRange' })
+export type QueryDslIntervalsRange = z.infer<typeof QueryDslIntervalsRange>
+
+export const QueryDslIntervalsRegexp = z.object({
+  analyzer: z.string().describe('Analyzer used to analyze the `prefix`.').optional(),
+  pattern: z.string().describe('Regex pattern.'),
+  use_field: Field.describe('If specified, match intervals from this field rather than the top-level field. The `prefix` is normalized using the search analyzer from this field, unless `analyzer` is specified separately.').optional()
+}).meta({ id: 'QueryDslIntervalsRegexp' })
+export type QueryDslIntervalsRegexp = z.infer<typeof QueryDslIntervalsRegexp>
+
+export const QueryDslIntervalsWildcard = z.object({
+  analyzer: z.string().describe('Analyzer used to analyze the `pattern`. Defaults to the top-level field\'s analyzer.').optional(),
+  pattern: z.string().describe('Wildcard pattern used to find matching terms.'),
+  use_field: Field.describe('If specified, match intervals from this field rather than the top-level field. The `pattern` is normalized using the search analyzer from this field, unless `analyzer` is specified separately.').optional()
+}).meta({ id: 'QueryDslIntervalsWildcard' })
+export type QueryDslIntervalsWildcard = z.infer<typeof QueryDslIntervalsWildcard>
+
+const QueryDslIntervalsContainerExclusiveProps = z.union([z.object({ all_of: z.lazy(() => QueryDslIntervalsAllOf) }), z.object({ any_of: z.lazy(() => QueryDslIntervalsAnyOf) }), z.object({ fuzzy: QueryDslIntervalsFuzzy }), z.object({ match: z.lazy(() => QueryDslIntervalsMatch) }), z.object({ prefix: QueryDslIntervalsPrefix }), z.object({ range: QueryDslIntervalsRange }), z.object({ regexp: QueryDslIntervalsRegexp }), z.object({ wildcard: QueryDslIntervalsWildcard })])
+
+export interface QueryDslIntervalsContainerShape {
+  all_of?: QueryDslIntervalsAllOf | undefined
+  any_of?: QueryDslIntervalsAnyOf | undefined
+  fuzzy?: QueryDslIntervalsFuzzy | undefined
+  match?: QueryDslIntervalsMatch | undefined
+  prefix?: QueryDslIntervalsPrefix | undefined
+  range?: QueryDslIntervalsRange | undefined
+  regexp?: QueryDslIntervalsRegexp | undefined
+  wildcard?: QueryDslIntervalsWildcard | undefined
+}
+export const QueryDslIntervalsContainer: z.ZodType<QueryDslIntervalsContainerShape> = QueryDslIntervalsContainerExclusiveProps.meta({ id: 'QueryDslIntervalsContainer' })
+export type QueryDslIntervalsContainer = z.infer<typeof QueryDslIntervalsContainer>
+
+export interface QueryDslIntervalsAllOfShape {
+  intervals: QueryDslIntervalsContainerShape[]
+  max_gaps?: integer | undefined
+  ordered?: boolean | undefined
+  filter?: QueryDslIntervalsFilterShape | undefined
+}
+export const QueryDslIntervalsAllOf = z.object({
+  get intervals () { return QueryDslIntervalsContainer.array().describe('An array of rules to combine. All rules must produce a match in a document for the overall source to match.') },
+  max_gaps: integer.describe('Maximum number of positions between the matching terms. Intervals produced by the rules further apart than this are not considered matches.').optional(),
+  ordered: z.boolean().describe('If `true`, intervals produced by the rules should appear in the order in which they are specified.').optional(),
+  get filter () { return QueryDslIntervalsFilter.describe('Rule used to filter returned intervals.').optional() }
+}).meta({ id: 'QueryDslIntervalsAllOf' })
+export type QueryDslIntervalsAllOf = z.infer<typeof QueryDslIntervalsAllOf>
+
+const QueryDslIntervalsQueryExclusiveProps = z.union([z.object({ all_of: z.lazy(() => QueryDslIntervalsAllOf) }), z.object({ any_of: z.lazy(() => QueryDslIntervalsAnyOf) }), z.object({ fuzzy: QueryDslIntervalsFuzzy }), z.object({ match: z.lazy(() => QueryDslIntervalsMatch) }), z.object({ prefix: QueryDslIntervalsPrefix }), z.object({ range: QueryDslIntervalsRange }), z.object({ regexp: QueryDslIntervalsRegexp }), z.object({ wildcard: QueryDslIntervalsWildcard })])
+
+export interface QueryDslIntervalsQueryShape {
+  all_of?: QueryDslIntervalsAllOf | undefined
+  any_of?: QueryDslIntervalsAnyOf | undefined
+  fuzzy?: QueryDslIntervalsFuzzy | undefined
+  match?: QueryDslIntervalsMatch | undefined
+  prefix?: QueryDslIntervalsPrefix | undefined
+  range?: QueryDslIntervalsRange | undefined
+  regexp?: QueryDslIntervalsRegexp | undefined
+  wildcard?: QueryDslIntervalsWildcard | undefined
+}
+export const QueryDslIntervalsQuery: z.ZodType<QueryDslIntervalsQueryShape> = QueryDslIntervalsQueryExclusiveProps.meta({ id: 'QueryDslIntervalsQuery' })
+export type QueryDslIntervalsQuery = z.infer<typeof QueryDslIntervalsQuery>
+
+export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
+export type QueryVector = z.infer<typeof QueryVector>
+
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
+export const TextEmbedding = z.object({
+  model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
+  model_text: z.string().describe('The text to be converted into a vector by the specified model')
+}).meta({ id: 'TextEmbedding' })
+export type TextEmbedding = z.infer<typeof TextEmbedding>
+
+export const LookupQueryVectorBuilder = z.object({
+  id: z.string().describe('The ID of the document to fetch the vector from'),
+  index: z.string().describe('The name of the index to fetch the document from'),
+  path: z.string().describe('The name of the field containing the vector'),
+  routing: z.string().describe('The routing value to use when fetching the document').optional()
+}).meta({ id: 'LookupQueryVectorBuilder' })
+export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
+
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+
+export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
+export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
+
+export const RescoreVector = z.object({
+  oversample: float.describe('Applies the specified oversample factor to k on the approximate kNN search')
+}).meta({ id: 'RescoreVector' })
+export type RescoreVector = z.infer<typeof RescoreVector>
+
+export interface KnnQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  field: Field
+  query_vector?: QueryVector | undefined
+  query_vector_builder?: QueryVectorBuilder | undefined
+  num_candidates?: integer | undefined
+  visit_percentage?: float | undefined
+  k?: integer | undefined
+  filter?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+  similarity?: float | undefined
+  rescore_vector?: RescoreVector | undefined
+}
+export const KnnQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  field: Field.describe('The name of the vector field to search against'),
+  query_vector: QueryVector.describe('The query vector').optional(),
+  query_vector_builder: QueryVectorBuilder.describe('The query vector builder. You must provide a query_vector_builder or query_vector, but not both.').optional(),
+  num_candidates: integer.describe('The number of nearest neighbor candidates to consider per shard').optional(),
+  visit_percentage: float.describe('The percentage of vectors to explore per shard while doing knn search with bbq_disk').optional(),
+  k: integer.describe('The final number of nearest neighbors to return as top hits').optional(),
+  get filter (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('Filters for the kNN search query').optional() },
+  similarity: float.describe('The minimum similarity for a vector to be considered a match').optional(),
+  rescore_vector: RescoreVector.describe('Apply oversampling and rescoring to quantized vectors').optional()
+}).meta({ id: 'KnnQuery' })
+export type KnnQuery = z.infer<typeof KnnQuery>
+
+export const QueryDslZeroTermsQuery = z.enum(['all', 'none']).meta({ id: 'QueryDslZeroTermsQuery' })
+export type QueryDslZeroTermsQuery = z.infer<typeof QueryDslZeroTermsQuery>
+
+export const QueryDslMatchQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  analyzer: z.string().describe('Analyzer used to convert the text in the query value into tokens.').optional(),
+  auto_generate_synonyms_phrase_query: z.boolean().describe('If `true`, match phrase queries are automatically created for multi-term synonyms.').optional(),
+  cutoff_frequency: double.optional(),
+  fuzziness: Fuzziness.describe('Maximum edit distance allowed for matching.').optional(),
+  fuzzy_rewrite: MultiTermQueryRewrite.describe('Method used to rewrite the query.').optional(),
+  fuzzy_transpositions: z.boolean().describe('If `true`, edits for fuzzy matching include transpositions of two adjacent characters (for example, `ab` to `ba`).').optional(),
+  lenient: z.boolean().describe('If `true`, format-based errors, such as providing a text query value for a numeric field, are ignored.').optional(),
+  max_expansions: integer.describe('Maximum number of terms to which the query will expand.').optional(),
+  minimum_should_match: MinimumShouldMatch.describe('Minimum number of clauses that must match for a document to be returned.').optional(),
+  operator: QueryDslOperator.describe('Boolean logic used to interpret text in the query value.').optional(),
+  prefix_length: integer.describe('Number of beginning characters left unchanged for fuzzy matching.').optional(),
+  query: z.union([z.string(), float, z.boolean()]).describe('Text, number, boolean value or date you wish to find in the provided field.'),
+  zero_terms_query: QueryDslZeroTermsQuery.describe('Indicates whether no documents are returned if the `analyzer` removes all tokens, such as when using a `stop` filter.').optional()
+}).meta({ id: 'QueryDslMatchQuery' })
+export type QueryDslMatchQuery = z.infer<typeof QueryDslMatchQuery>
+
+export const QueryDslMatchAllQuery = z.object({
+  ...QueryDslQueryBase.shape
+}).meta({ id: 'QueryDslMatchAllQuery' })
+export type QueryDslMatchAllQuery = z.infer<typeof QueryDslMatchAllQuery>
+
+export const QueryDslMatchBoolPrefixQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  analyzer: z.string().describe('Analyzer used to convert the text in the query value into tokens.').optional(),
+  fuzziness: Fuzziness.describe('Maximum edit distance allowed for matching. Can be applied to the term subqueries constructed for all terms but the final term.').optional(),
+  fuzzy_rewrite: MultiTermQueryRewrite.describe('Method used to rewrite the query. Can be applied to the term subqueries constructed for all terms but the final term.').optional(),
+  fuzzy_transpositions: z.boolean().describe('If `true`, edits for fuzzy matching include transpositions of two adjacent characters (for example, `ab` to `ba`). Can be applied to the term subqueries constructed for all terms but the final term.').optional(),
+  max_expansions: integer.describe('Maximum number of terms to which the query will expand. Can be applied to the term subqueries constructed for all terms but the final term.').optional(),
+  minimum_should_match: MinimumShouldMatch.describe('Minimum number of clauses that must match for a document to be returned. Applied to the constructed bool query.').optional(),
+  operator: QueryDslOperator.describe('Boolean logic used to interpret text in the query value. Applied to the constructed bool query.').optional(),
+  prefix_length: integer.describe('Number of beginning characters left unchanged for fuzzy matching. Can be applied to the term subqueries constructed for all terms but the final term.').optional(),
+  query: z.string().describe('Terms you wish to find in the provided field. The last term is used in a prefix query.')
+}).meta({ id: 'QueryDslMatchBoolPrefixQuery' })
+export type QueryDslMatchBoolPrefixQuery = z.infer<typeof QueryDslMatchBoolPrefixQuery>
+
+export const QueryDslMatchNoneQuery = z.object({
+  ...QueryDslQueryBase.shape
+}).meta({ id: 'QueryDslMatchNoneQuery' })
+export type QueryDslMatchNoneQuery = z.infer<typeof QueryDslMatchNoneQuery>
+
+export const QueryDslMatchPhraseQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  analyzer: z.string().describe('Analyzer used to convert the text in the query value into tokens.').optional(),
+  query: z.string().describe('Query terms that are analyzed and turned into a phrase query.'),
+  slop: integer.describe('Maximum number of positions allowed between matching tokens.').optional(),
+  zero_terms_query: QueryDslZeroTermsQuery.describe('Indicates whether no documents are returned if the `analyzer` removes all tokens, such as when using a `stop` filter.').optional()
+}).meta({ id: 'QueryDslMatchPhraseQuery' })
+export type QueryDslMatchPhraseQuery = z.infer<typeof QueryDslMatchPhraseQuery>
+
+export const QueryDslMatchPhrasePrefixQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  analyzer: z.string().describe('Analyzer used to convert text in the query value into tokens.').optional(),
+  max_expansions: integer.describe('Maximum number of terms to which the last provided term of the query value will expand.').optional(),
+  query: z.string().describe('Text you wish to find in the provided field.'),
+  slop: integer.describe('Maximum number of positions allowed between matching tokens.').optional(),
+  zero_terms_query: QueryDslZeroTermsQuery.describe('Indicates whether no documents are returned if the analyzer removes all tokens, such as when using a `stop` filter.').optional()
+}).meta({ id: 'QueryDslMatchPhrasePrefixQuery' })
+export type QueryDslMatchPhrasePrefixQuery = z.infer<typeof QueryDslMatchPhrasePrefixQuery>
+
+/** Only to be used in query and path parameters, as the array form is actually a csv */
+export const Routing = z.union([z.string(), z.array(z.string())]).meta({ id: 'Routing' })
+export type Routing = z.infer<typeof Routing>
+
+export const VersionType = z.enum(['internal', 'external', 'external_gte']).meta({ id: 'VersionType' })
+export type VersionType = z.infer<typeof VersionType>
+
+export const QueryDslLikeDocument = z.object({
+  doc: z.any().describe('A document not present in the index.').optional(),
+  fields: z.array(Field).optional(),
+  _id: Id.describe('ID of a document.').optional(),
+  _index: IndexName.describe('Index of a document.').optional(),
+  per_field_analyzer: z.record(Field, z.string()).describe('Overrides the default analyzer.').optional(),
+  routing: Routing.optional(),
+  version: VersionNumber.optional(),
+  version_type: VersionType.optional()
+}).meta({ id: 'QueryDslLikeDocument' })
+export type QueryDslLikeDocument = z.infer<typeof QueryDslLikeDocument>
+
+/** Text that we want similar documents for or a lookup to a document's field for the text. */
+export const QueryDslLike = z.union([z.string(), QueryDslLikeDocument]).meta({ id: 'QueryDslLike' })
+export type QueryDslLike = z.infer<typeof QueryDslLike>
+
+export const AnalysisStopWordLanguage = z.enum(['_arabic_', '_armenian_', '_basque_', '_bengali_', '_brazilian_', '_bulgarian_', '_catalan_', '_cjk_', '_czech_', '_danish_', '_dutch_', '_english_', '_estonian_', '_finnish_', '_french_', '_galician_', '_german_', '_greek_', '_hindi_', '_hungarian_', '_indonesian_', '_irish_', '_italian_', '_latvian_', '_lithuanian_', '_norwegian_', '_persian_', '_portuguese_', '_romanian_', '_russian_', '_serbian_', '_sorani_', '_spanish_', '_swedish_', '_thai_', '_turkish_', '_none_']).meta({ id: 'AnalysisStopWordLanguage' })
+export type AnalysisStopWordLanguage = z.infer<typeof AnalysisStopWordLanguage>
+
+/**
+ * Language value, such as _arabic_ or _thai_. Defaults to _english_.
+ * Each language value corresponds to a predefined list of stop words in Lucene. See Stop words by language for supported language values and their stop words.
+ * Also accepts an array of stop words.
+ */
+export const AnalysisStopWords = z.union([AnalysisStopWordLanguage, z.array(z.string())]).meta({ id: 'AnalysisStopWords' })
+export type AnalysisStopWords = z.infer<typeof AnalysisStopWords>
+
+export const QueryDslMoreLikeThisQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  analyzer: z.string().describe('The analyzer that is used to analyze the free form text. Defaults to the analyzer associated with the first field in fields.').optional(),
+  boost_terms: double.describe('Each term in the formed query could be further boosted by their tf-idf score. This sets the boost factor to use when using this feature. Defaults to deactivated (0).').optional(),
+  fail_on_unsupported_field: z.boolean().describe('Controls whether the query should fail (throw an exception) if any of the specified fields are not of the supported types (`text` or `keyword`).').optional(),
+  fields: z.array(Field).describe('A list of fields to fetch and analyze the text from. Defaults to the `index.query.default_field` index setting, which has a default value of `*`.').optional(),
+  include: z.boolean().describe('Specifies whether the input documents should also be included in the search results returned.').optional(),
+  like: z.union([QueryDslLike, z.array(QueryDslLike)]).describe('Specifies free form text and/or a single or multiple documents for which you want to find similar documents.'),
+  max_doc_freq: integer.describe('The maximum document frequency above which the terms are ignored from the input document.').optional(),
+  max_query_terms: integer.describe('The maximum number of query terms that can be selected.').optional(),
+  max_word_length: integer.describe('The maximum word length above which the terms are ignored. Defaults to unbounded (`0`).').optional(),
+  min_doc_freq: integer.describe('The minimum document frequency below which the terms are ignored from the input document.').optional(),
+  minimum_should_match: MinimumShouldMatch.describe('After the disjunctive query has been formed, this parameter controls the number of terms that must match.').optional(),
+  min_term_freq: integer.describe('The minimum term frequency below which the terms are ignored from the input document.').optional(),
+  min_word_length: integer.describe('The minimum word length below which the terms are ignored.').optional(),
+  routing: z.string().optional(),
+  stop_words: AnalysisStopWords.describe('An array of stop words. Any word in this set is ignored.').optional(),
+  unlike: z.union([QueryDslLike, z.array(QueryDslLike)]).describe('Used in combination with `like` to exclude documents that match a set of terms.').optional(),
+  version: VersionNumber.optional(),
+  version_type: VersionType.optional()
+}).meta({ id: 'QueryDslMoreLikeThisQuery' })
+export type QueryDslMoreLikeThisQuery = z.infer<typeof QueryDslMoreLikeThisQuery>
+
+export const QueryDslTextQueryType = z.enum(['best_fields', 'most_fields', 'cross_fields', 'phrase', 'phrase_prefix', 'bool_prefix']).meta({ id: 'QueryDslTextQueryType' })
+export type QueryDslTextQueryType = z.infer<typeof QueryDslTextQueryType>
+
+export const QueryDslMultiMatchQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  analyzer: z.string().describe('Analyzer used to convert the text in the query value into tokens.').optional(),
+  auto_generate_synonyms_phrase_query: z.boolean().describe('If `true`, match phrase queries are automatically created for multi-term synonyms.').optional(),
+  cutoff_frequency: double.optional(),
+  fields: Fields.describe('The fields to be queried. Defaults to the `index.query.default_field` index settings, which in turn defaults to `*`.').optional(),
+  fuzziness: Fuzziness.describe('Maximum edit distance allowed for matching.').optional(),
+  fuzzy_rewrite: MultiTermQueryRewrite.describe('Method used to rewrite the query.').optional(),
+  fuzzy_transpositions: z.boolean().describe('If `true`, edits for fuzzy matching include transpositions of two adjacent characters (for example, `ab` to `ba`). Can be applied to the term subqueries constructed for all terms but the final term.').optional(),
+  lenient: z.boolean().describe('If `true`, format-based errors, such as providing a text query value for a numeric field, are ignored.').optional(),
+  max_expansions: integer.describe('Maximum number of terms to which the query will expand.').optional(),
+  minimum_should_match: MinimumShouldMatch.describe('Minimum number of clauses that must match for a document to be returned.').optional(),
+  operator: QueryDslOperator.describe('Boolean logic used to interpret text in the query value.').optional(),
+  prefix_length: integer.describe('Number of beginning characters left unchanged for fuzzy matching.').optional(),
+  query: z.string().describe('Text, number, boolean value or date you wish to find in the provided field.'),
+  slop: integer.describe('Maximum number of positions allowed between matching tokens.').optional(),
+  tie_breaker: double.describe('Determines how scores for each per-term blended query and scores across groups are combined.').optional(),
+  type: QueryDslTextQueryType.describe('How `the` multi_match query is executed internally.').optional(),
+  zero_terms_query: QueryDslZeroTermsQuery.describe('Indicates whether no documents are returned if the `analyzer` removes all tokens, such as when using a `stop` filter.').optional()
+}).meta({ id: 'QueryDslMultiMatchQuery' })
+export type QueryDslMultiMatchQuery = z.infer<typeof QueryDslMultiMatchQuery>
+
+export interface QueryDslNestedQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  ignore_unmapped?: boolean | undefined
+  inner_hits?: SearchInnerHitsShape | undefined
+  path: Field
+  query: QueryDslQueryContainerShape
+  score_mode?: QueryDslChildScoreMode | undefined
+}
+export const QueryDslNestedQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  ignore_unmapped: z.boolean().describe('Indicates whether to ignore an unmapped path and not return any documents instead of an error.').optional(),
+  get inner_hits () { return SearchInnerHits.describe('If defined, each search hit will contain inner hits.').optional() },
+  path: Field.describe('Path to the nested object you wish to search.'),
+  get query () { return QueryDslQueryContainer.describe('Query you wish to run on nested objects in the path.') },
+  score_mode: QueryDslChildScoreMode.describe('How scores for matching child objects affect the root parent document’s relevance score.').optional()
+}).meta({ id: 'QueryDslNestedQuery' })
+export type QueryDslNestedQuery = z.infer<typeof QueryDslNestedQuery>
+
+export const QueryDslParentIdQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  id: Id.describe('ID of the parent document.').optional(),
+  ignore_unmapped: z.boolean().describe('Indicates whether to ignore an unmapped `type` and not return any documents instead of an error.').optional(),
+  type: RelationName.describe('Name of the child relationship mapped for the `join` field.').optional()
+}).meta({ id: 'QueryDslParentIdQuery' })
+export type QueryDslParentIdQuery = z.infer<typeof QueryDslParentIdQuery>
+
+export const QueryDslPercolateQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  document: z.any().describe('The source of the document being percolated.').optional(),
+  documents: z.array(z.any()).describe('An array of sources of the documents being percolated.').optional(),
+  field: Field.describe('Field that holds the indexed queries. The field must use the `percolator` mapping type.'),
+  id: Id.describe('The ID of a stored document to percolate.').optional(),
+  index: IndexName.describe('The index of a stored document to percolate.').optional(),
+  name: z.string().describe('The suffix used for the `_percolator_document_slot` field when multiple `percolate` queries are specified.').optional(),
+  preference: z.string().describe('Preference used to fetch document to percolate.').optional(),
+  routing: z.string().describe('Routing used to fetch document to percolate.').optional(),
+  version: VersionNumber.describe('The expected version of a stored document to percolate.').optional()
+}).meta({ id: 'QueryDslPercolateQuery' })
+export type QueryDslPercolateQuery = z.infer<typeof QueryDslPercolateQuery>
+
+export const QueryDslPinnedDoc = z.object({
+  _id: Id.describe('The unique document ID.'),
+  _index: IndexName.describe('The index that contains the document.').optional()
+}).meta({ id: 'QueryDslPinnedDoc' })
+export type QueryDslPinnedDoc = z.infer<typeof QueryDslPinnedDoc>
+
+const QueryDslPinnedQueryCommonProps = z.object({
+  organic: z.lazy(() => QueryDslQueryContainer).describe('Any choice of query used to rank documents which will be ranked below the "pinned" documents.')
+})
+
+const QueryDslPinnedQueryExclusiveProps = z.union([z.object({ ids: z.array(Id) }), z.object({ docs: z.array(QueryDslPinnedDoc) })])
+
+export interface QueryDslPinnedQueryShape {
+  organic: QueryDslQueryContainerShape
+  ids?: Id[] | undefined
+  docs?: QueryDslPinnedDoc[] | undefined
+}
+export const QueryDslPinnedQuery: z.ZodType<QueryDslPinnedQueryShape> = QueryDslPinnedQueryCommonProps.and(QueryDslPinnedQueryExclusiveProps).meta({ id: 'QueryDslPinnedQuery' })
+export type QueryDslPinnedQuery = z.infer<typeof QueryDslPinnedQuery>
+
+export const QueryDslPrefixQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  rewrite: MultiTermQueryRewrite.describe('Method used to rewrite the query.').optional(),
+  value: z.string().describe('Beginning characters of terms you wish to find in the provided field.'),
+  case_insensitive: z.boolean().describe('Allows ASCII case insensitive matching of the value with the indexed field values when set to `true`. Default is `false` which means the case sensitivity of matching depends on the underlying field’s mapping.').optional()
+}).meta({ id: 'QueryDslPrefixQuery' })
+export type QueryDslPrefixQuery = z.infer<typeof QueryDslPrefixQuery>
+
+export const TimeZone = z.string().meta({ id: 'TimeZone' })
+export type TimeZone = z.infer<typeof TimeZone>
+
+export const QueryDslQueryStringQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  allow_leading_wildcard: z.boolean().describe('If `true`, the wildcard characters `*` and `?` are allowed as the first character of the query string.').optional(),
+  analyzer: z.string().describe('Analyzer used to convert text in the query string into tokens.').optional(),
+  analyze_wildcard: z.boolean().describe('If `true`, the query attempts to analyze wildcard terms in the query string.').optional(),
+  auto_generate_synonyms_phrase_query: z.boolean().describe('If `true`, match phrase queries are automatically created for multi-term synonyms.').optional(),
+  default_field: Field.describe('Default field to search if no field is provided in the query string. Supports wildcards (`*`). Defaults to the `index.query.default_field` index setting, which has a default value of `*`.').optional(),
+  default_operator: QueryDslOperator.describe('Default boolean logic used to interpret text in the query string if no operators are specified.').optional(),
+  enable_position_increments: z.boolean().describe('If `true`, enable position increments in queries constructed from a `query_string` search.').optional(),
+  escape: z.boolean().optional(),
+  fields: z.array(Field).describe('Array of fields to search. Supports wildcards (`*`).').optional(),
+  fuzziness: Fuzziness.describe('Maximum edit distance allowed for fuzzy matching.').optional(),
+  fuzzy_max_expansions: integer.describe('Maximum number of terms to which the query expands for fuzzy matching.').optional(),
+  fuzzy_prefix_length: integer.describe('Number of beginning characters left unchanged for fuzzy matching.').optional(),
+  fuzzy_rewrite: MultiTermQueryRewrite.describe('Method used to rewrite the query.').optional(),
+  fuzzy_transpositions: z.boolean().describe('If `true`, edits for fuzzy matching include transpositions of two adjacent characters (for example, `ab` to `ba`).').optional(),
+  lenient: z.boolean().describe('If `true`, format-based errors, such as providing a text value for a numeric field, are ignored.').optional(),
+  max_determinized_states: integer.describe('Maximum number of automaton states required for the query.').optional(),
+  minimum_should_match: MinimumShouldMatch.describe('Minimum number of clauses that must match for a document to be returned.').optional(),
+  phrase_slop: double.describe('Maximum number of positions allowed between matching tokens for phrases.').optional(),
+  query: z.string().describe('Query string you wish to parse and use for search.'),
+  quote_analyzer: z.string().describe('Analyzer used to convert quoted text in the query string into tokens. For quoted text, this parameter overrides the analyzer specified in the `analyzer` parameter.').optional(),
+  quote_field_suffix: z.string().describe('Suffix appended to quoted text in the query string. You can use this suffix to use a different analysis method for exact matches.').optional(),
+  rewrite: MultiTermQueryRewrite.describe('Method used to rewrite the query.').optional(),
+  tie_breaker: double.describe('How to combine the queries generated from the individual search terms in the resulting `dis_max` query.').optional(),
+  time_zone: TimeZone.describe('Coordinated Universal Time (UTC) offset or IANA time zone used to convert date values in the query string to UTC.').optional(),
+  type: QueryDslTextQueryType.describe('Determines how the query matches and scores documents.').optional()
+}).meta({ id: 'QueryDslQueryStringQuery' })
+export type QueryDslQueryStringQuery = z.infer<typeof QueryDslQueryStringQuery>
+
+export const QueryDslRangeRelation = z.enum(['within', 'contains', 'intersects']).meta({ id: 'QueryDslRangeRelation' })
+export type QueryDslRangeRelation = z.infer<typeof QueryDslRangeRelation>
+
+export const QueryDslRangeQueryBase = z.object({
+  ...QueryDslQueryBase.shape,
+  relation: QueryDslRangeRelation.describe('Indicates how the range query matches values for `range` fields.').optional(),
+  gt: z.any().describe('Greater than.').optional(),
+  gte: z.any().describe('Greater than or equal to.').optional(),
+  lt: z.any().describe('Less than.').optional(),
+  lte: z.any().describe('Less than or equal to.').optional()
+}).meta({ id: 'QueryDslRangeQueryBase' })
+export type QueryDslRangeQueryBase = z.infer<typeof QueryDslRangeQueryBase>
+
+export const DateFormat = z.string().meta({ id: 'DateFormat' })
+export type DateFormat = z.infer<typeof DateFormat>
+
+export const QueryDslUntypedRangeQuery = z.object({
+  ...QueryDslRangeQueryBase.shape,
+  format: DateFormat.describe('Date format used to convert `date` values in the query.').optional(),
+  time_zone: TimeZone.describe('Coordinated Universal Time (UTC) offset or IANA time zone used to convert `date` values in the query to UTC.').optional()
+}).meta({ id: 'QueryDslUntypedRangeQuery' })
+export type QueryDslUntypedRangeQuery = z.infer<typeof QueryDslUntypedRangeQuery>
+
+export const QueryDslDateRangeQuery = z.object({
+  ...QueryDslRangeQueryBase.shape,
+  format: DateFormat.describe('Date format used to convert `date` values in the query.').optional(),
+  time_zone: TimeZone.describe('Coordinated Universal Time (UTC) offset or IANA time zone used to convert `date` values in the query to UTC.').optional()
+}).meta({ id: 'QueryDslDateRangeQuery' })
+export type QueryDslDateRangeQuery = z.infer<typeof QueryDslDateRangeQuery>
+
+export const QueryDslNumberRangeQuery = z.object({
+  ...QueryDslRangeQueryBase.shape
+}).meta({ id: 'QueryDslNumberRangeQuery' })
+export type QueryDslNumberRangeQuery = z.infer<typeof QueryDslNumberRangeQuery>
+
+export const QueryDslLongNumberRangeQuery = z.object({
+  ...QueryDslRangeQueryBase.shape
+}).meta({ id: 'QueryDslLongNumberRangeQuery' })
+export type QueryDslLongNumberRangeQuery = z.infer<typeof QueryDslLongNumberRangeQuery>
+
+export const QueryDslTermRangeQuery = z.object({
+  ...QueryDslRangeQueryBase.shape
+}).meta({ id: 'QueryDslTermRangeQuery' })
+export type QueryDslTermRangeQuery = z.infer<typeof QueryDslTermRangeQuery>
+
+export const QueryDslRangeQuery = z.union([QueryDslUntypedRangeQuery, QueryDslDateRangeQuery, QueryDslNumberRangeQuery, QueryDslLongNumberRangeQuery, QueryDslTermRangeQuery]).meta({ id: 'QueryDslRangeQuery' })
+export type QueryDslRangeQuery = z.infer<typeof QueryDslRangeQuery>
+
+export const QueryDslRankFeatureFunction = z.object({
+}).meta({ id: 'QueryDslRankFeatureFunction' })
+export type QueryDslRankFeatureFunction = z.infer<typeof QueryDslRankFeatureFunction>
+
+export const QueryDslRankFeatureFunctionSaturation = z.object({
+  pivot: float.describe('Configurable pivot value so that the result will be less than 0.5.').optional()
+}).meta({ id: 'QueryDslRankFeatureFunctionSaturation' })
+export type QueryDslRankFeatureFunctionSaturation = z.infer<typeof QueryDslRankFeatureFunctionSaturation>
+
+export const QueryDslRankFeatureFunctionLogarithm = z.object({
+  scaling_factor: float.describe('Configurable scaling factor.')
+}).meta({ id: 'QueryDslRankFeatureFunctionLogarithm' })
+export type QueryDslRankFeatureFunctionLogarithm = z.infer<typeof QueryDslRankFeatureFunctionLogarithm>
+
+export const QueryDslRankFeatureFunctionLinear = z.object({
+}).meta({ id: 'QueryDslRankFeatureFunctionLinear' })
+export type QueryDslRankFeatureFunctionLinear = z.infer<typeof QueryDslRankFeatureFunctionLinear>
+
+export const QueryDslRankFeatureFunctionSigmoid = z.object({
+  pivot: float.describe('Configurable pivot value so that the result will be less than 0.5.'),
+  exponent: float.describe('Configurable Exponent.')
+}).meta({ id: 'QueryDslRankFeatureFunctionSigmoid' })
+export type QueryDslRankFeatureFunctionSigmoid = z.infer<typeof QueryDslRankFeatureFunctionSigmoid>
+
+export const QueryDslRankFeatureQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  field: Field.describe('`rank_feature` or `rank_features` field used to boost relevance scores.'),
+  saturation: QueryDslRankFeatureFunctionSaturation.describe('Saturation function used to boost relevance scores based on the value of the rank feature `field`.').optional(),
+  log: QueryDslRankFeatureFunctionLogarithm.describe('Logarithmic function used to boost relevance scores based on the value of the rank feature `field`.').optional(),
+  linear: QueryDslRankFeatureFunctionLinear.describe('Linear function used to boost relevance scores based on the value of the rank feature `field`.').optional(),
+  sigmoid: QueryDslRankFeatureFunctionSigmoid.describe('Sigmoid function used to boost relevance scores based on the value of the rank feature `field`.').optional()
+}).meta({ id: 'QueryDslRankFeatureQuery' })
+export type QueryDslRankFeatureQuery = z.infer<typeof QueryDslRankFeatureQuery>
+
+export const QueryDslRegexpQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  case_insensitive: z.boolean().describe('Allows case insensitive matching of the regular expression value with the indexed field values when set to `true`. When `false`, case sensitivity of matching depends on the underlying field’s mapping.').optional(),
+  flags: z.string().describe('Enables optional operators for the regular expression.').optional(),
+  max_determinized_states: integer.describe('Maximum number of automaton states required for the query.').optional(),
+  rewrite: MultiTermQueryRewrite.describe('Method used to rewrite the query.').optional(),
+  value: z.string().describe('Regular expression for terms you wish to find in the provided field.')
+}).meta({ id: 'QueryDslRegexpQuery' })
+export type QueryDslRegexpQuery = z.infer<typeof QueryDslRegexpQuery>
+
+export interface QueryDslRuleQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  organic: QueryDslQueryContainerShape
+  ruleset_ids?: Id | Id[] | undefined
+  ruleset_id?: string | undefined
+  match_criteria: unknown
+}
+export const QueryDslRuleQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  get organic () { return QueryDslQueryContainer },
+  ruleset_ids: z.union([Id, z.array(Id)]).optional(),
+  ruleset_id: z.string().optional(),
+  match_criteria: z.any()
+}).meta({ id: 'QueryDslRuleQuery' })
+export type QueryDslRuleQuery = z.infer<typeof QueryDslRuleQuery>
+
+export interface QueryDslScriptQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  script: ScriptShape
+}
+export const QueryDslScriptQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+}).meta({ id: 'QueryDslScriptQuery' })
+export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
+
+export interface QueryDslScriptScoreQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  min_score?: float | undefined
+  query: QueryDslQueryContainerShape
+  script: ScriptShape
+}
+export const QueryDslScriptScoreQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
+  get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+}).meta({ id: 'QueryDslScriptScoreQuery' })
+export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
+
+export const QueryDslSemanticQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  field: z.string().describe('The field to query, which must be a semantic_text field type'),
+  query: z.string().describe('The query text')
+}).meta({ id: 'QueryDslSemanticQuery' })
+export type QueryDslSemanticQuery = z.infer<typeof QueryDslSemanticQuery>
+
+export const QueryDslShapeQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  ignore_unmapped: z.boolean().describe('When set to `true` the query ignores an unmapped field and will not match any documents.').optional()
+}).catchall(z.any()).meta({ id: 'QueryDslShapeQuery' })
+export type QueryDslShapeQuery = z.infer<typeof QueryDslShapeQuery>
+
+/**
+ * A set of flags that can be represented as a single enum value or a set of values that are encoded
+ * as a pipe-separated string
+ *
+ * Depending on the target language, code generators can use this hint to generate language specific
+ * flags enum constructs and the corresponding (de-)serialization code.
+ */
+export const SpecUtilsPipeSeparatedFlags = z.union([z.any(), z.string()]).meta({ id: 'SpecUtilsPipeSeparatedFlags' })
+export type SpecUtilsPipeSeparatedFlags = z.infer<typeof SpecUtilsPipeSeparatedFlags>
+
+/** Query flags can be either a single flag or a combination of flags, e.g. `OR|AND|PREFIX` */
+export const QueryDslSimpleQueryStringFlags = SpecUtilsPipeSeparatedFlags.meta({ id: 'QueryDslSimpleQueryStringFlags' })
+export type QueryDslSimpleQueryStringFlags = z.infer<typeof QueryDslSimpleQueryStringFlags>
+
+export const QueryDslSimpleQueryStringQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  analyzer: z.string().describe('Analyzer used to convert text in the query string into tokens.').optional(),
+  analyze_wildcard: z.boolean().describe('If `true`, the query attempts to analyze wildcard terms in the query string.').optional(),
+  auto_generate_synonyms_phrase_query: z.boolean().describe('If `true`, the parser creates a match_phrase query for each multi-position token.').optional(),
+  default_operator: QueryDslOperator.describe('Default boolean logic used to interpret text in the query string if no operators are specified.').optional(),
+  fields: z.array(Field).describe('Array of fields you wish to search. Accepts wildcard expressions. You also can boost relevance scores for matches to particular fields using a caret (`^`) notation. Defaults to the `index.query.default_field index` setting, which has a default value of `*`.').optional(),
+  flags: QueryDslSimpleQueryStringFlags.describe('List of enabled operators for the simple query string syntax.').optional(),
+  fuzzy_max_expansions: integer.describe('Maximum number of terms to which the query expands for fuzzy matching.').optional(),
+  fuzzy_prefix_length: integer.describe('Number of beginning characters left unchanged for fuzzy matching.').optional(),
+  fuzzy_transpositions: z.boolean().describe('If `true`, edits for fuzzy matching include transpositions of two adjacent characters (for example, `ab` to `ba`).').optional(),
+  lenient: z.boolean().describe('If `true`, format-based errors, such as providing a text value for a numeric field, are ignored.').optional(),
+  minimum_should_match: MinimumShouldMatch.describe('Minimum number of clauses that must match for a document to be returned.').optional(),
+  query: z.string().describe('Query string in the simple query string syntax you wish to parse and use for search.'),
+  quote_field_suffix: z.string().describe('Suffix appended to quoted text in the query string.').optional()
+}).meta({ id: 'QueryDslSimpleQueryStringQuery' })
+export type QueryDslSimpleQueryStringQuery = z.infer<typeof QueryDslSimpleQueryStringQuery>
+
+export interface QueryDslSpanFieldMaskingQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  field: Field
+  query: QueryDslSpanQueryShape
+}
+export const QueryDslSpanFieldMaskingQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  field: Field,
+  get query () { return QueryDslSpanQuery }
+}).meta({ id: 'QueryDslSpanFieldMaskingQuery' })
+export type QueryDslSpanFieldMaskingQuery = z.infer<typeof QueryDslSpanFieldMaskingQuery>
+
+export interface QueryDslSpanFirstQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  end: integer
+  match: QueryDslSpanQueryShape
+}
+export const QueryDslSpanFirstQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  end: integer.describe('Controls the maximum end position permitted in a match.'),
+  get match () { return QueryDslSpanQuery.describe('Can be any other span type query.') }
+}).meta({ id: 'QueryDslSpanFirstQuery' })
+export type QueryDslSpanFirstQuery = z.infer<typeof QueryDslSpanFirstQuery>
+
+/** Can only be used as a clause in a span_near query. */
+export const QueryDslSpanGapQuery = z.record(Field, integer).meta({ id: 'QueryDslSpanGapQuery' })
+export type QueryDslSpanGapQuery = z.infer<typeof QueryDslSpanGapQuery>
+
+export interface QueryDslSpanMultiTermQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  match: QueryDslQueryContainerShape
+}
+export const QueryDslSpanMultiTermQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  get match () { return QueryDslQueryContainer.describe('Should be a multi term query (one of `wildcard`, `fuzzy`, `prefix`, `range`, or `regexp` query).') }
+}).meta({ id: 'QueryDslSpanMultiTermQuery' })
+export type QueryDslSpanMultiTermQuery = z.infer<typeof QueryDslSpanMultiTermQuery>
+
+export interface QueryDslSpanNearQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  clauses: QueryDslSpanQueryShape[]
+  in_order?: boolean | undefined
+  slop?: integer | undefined
+}
+export const QueryDslSpanNearQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  get clauses () { return QueryDslSpanQuery.array().describe('Array of one or more other span type queries.') },
+  in_order: z.boolean().describe('Controls whether matches are required to be in-order.').optional(),
+  slop: integer.describe('Controls the maximum number of intervening unmatched positions permitted.').optional()
+}).meta({ id: 'QueryDslSpanNearQuery' })
+export type QueryDslSpanNearQuery = z.infer<typeof QueryDslSpanNearQuery>
+
+export interface QueryDslSpanNotQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  dist?: integer | undefined
+  exclude: QueryDslSpanQueryShape
+  include: QueryDslSpanQueryShape
+  post?: integer | undefined
+  pre?: integer | undefined
+}
+export const QueryDslSpanNotQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  dist: integer.describe('The number of tokens from within the include span that can’t have overlap with the exclude span. Equivalent to setting both `pre` and `post`.').optional(),
+  get exclude () { return QueryDslSpanQuery.describe('Span query whose matches must not overlap those returned.') },
+  get include () { return QueryDslSpanQuery.describe('Span query whose matches are filtered.') },
+  post: integer.describe('The number of tokens after the include span that can’t have overlap with the exclude span.').optional(),
+  pre: integer.describe('The number of tokens before the include span that can’t have overlap with the exclude span.').optional()
+}).meta({ id: 'QueryDslSpanNotQuery' })
+export type QueryDslSpanNotQuery = z.infer<typeof QueryDslSpanNotQuery>
+
+export interface QueryDslSpanOrQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  clauses: QueryDslSpanQueryShape[]
+}
+export const QueryDslSpanOrQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  get clauses () { return QueryDslSpanQuery.array().describe('Array of one or more other span type queries.') }
+}).meta({ id: 'QueryDslSpanOrQuery' })
+export type QueryDslSpanOrQuery = z.infer<typeof QueryDslSpanOrQuery>
+
+export const QueryDslSpanTermQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  value: FieldValue,
+  term: FieldValue
+}).meta({ id: 'QueryDslSpanTermQuery' })
+export type QueryDslSpanTermQuery = z.infer<typeof QueryDslSpanTermQuery>
+
+export interface QueryDslSpanWithinQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  big: QueryDslSpanQueryShape
+  little: QueryDslSpanQueryShape
+}
+export const QueryDslSpanWithinQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  get big () { return QueryDslSpanQuery.describe('Can be any span query. Matching spans from `little` that are enclosed within `big` are returned.') },
+  get little () { return QueryDslSpanQuery.describe('Can be any span query. Matching spans from `little` that are enclosed within `big` are returned.') }
+}).meta({ id: 'QueryDslSpanWithinQuery' })
+export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
+
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+
+export interface QueryDslSpanQueryShape {
+  span_containing?: QueryDslSpanContainingQuery | undefined
+  span_field_masking?: QueryDslSpanFieldMaskingQuery | undefined
+  span_first?: QueryDslSpanFirstQuery | undefined
+  span_gap?: QueryDslSpanGapQuery | undefined
+  span_multi?: QueryDslSpanMultiTermQuery | undefined
+  span_near?: QueryDslSpanNearQuery | undefined
+  span_not?: QueryDslSpanNotQuery | undefined
+  span_or?: QueryDslSpanOrQuery | undefined
+  span_term?: Record<Field, QueryDslSpanTermQuery> | undefined
+  span_within?: QueryDslSpanWithinQuery | undefined
+}
+export const QueryDslSpanQuery: z.ZodType<QueryDslSpanQueryShape> = QueryDslSpanQueryExclusiveProps.meta({ id: 'QueryDslSpanQuery' })
+export type QueryDslSpanQuery = z.infer<typeof QueryDslSpanQuery>
+
+export interface QueryDslSpanContainingQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  big: QueryDslSpanQueryShape
+  little: QueryDslSpanQueryShape
+}
+export const QueryDslSpanContainingQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  get big () { return QueryDslSpanQuery.describe('Can be any span query. Matching spans from `big` that contain matches from `little` are returned.') },
+  get little () { return QueryDslSpanQuery.describe('Can be any span query. Matching spans from `big` that contain matches from `little` are returned.') }
+}).meta({ id: 'QueryDslSpanContainingQuery' })
+export type QueryDslSpanContainingQuery = z.infer<typeof QueryDslSpanContainingQuery>
+
+export const TokenPruningConfig = z.object({
+  tokens_freq_ratio_threshold: integer.describe('Tokens whose frequency is more than this threshold times the average frequency of all tokens in the specified field are considered outliers and pruned.').optional(),
+  tokens_weight_threshold: float.describe('Tokens whose weight is less than this threshold are considered nonsignificant and pruned.').optional(),
+  only_score_pruned_tokens: z.boolean().describe('Whether to only score pruned tokens, vs only scoring kept tokens.').optional()
+}).meta({ id: 'TokenPruningConfig' })
+export type TokenPruningConfig = z.infer<typeof TokenPruningConfig>
+
+const QueryDslSparseVectorQueryCommonProps = z.object({
+  field: Field.describe('The name of the field that contains the token-weight pairs to be searched against. This field must be a mapped sparse_vector field.'),
+  query: z.string().describe('The query text you want to use for search. If inference_id is specified, query must also be specified.').optional(),
+  prune: z.boolean().describe('Whether to perform pruning, omitting the non-significant tokens from the query to improve query performance. If prune is true but the pruning_config is not specified, pruning will occur but default values will be used. Default: false').optional(),
+  pruning_config: TokenPruningConfig.describe('Optional pruning configuration. If enabled, this will omit non-significant tokens from the query in order to improve query performance. This is only used if prune is set to true. If prune is set to true but pruning_config is not specified, default values will be used.').optional()
+})
+
+const QueryDslSparseVectorQueryExclusiveProps = z.union([z.object({ query_vector: z.record(z.string(), float) }), z.object({ inference_id: Id })])
+
+export const QueryDslSparseVectorQuery = QueryDslSparseVectorQueryCommonProps.and(QueryDslSparseVectorQueryExclusiveProps).meta({ id: 'QueryDslSparseVectorQuery' })
+export type QueryDslSparseVectorQuery = z.infer<typeof QueryDslSparseVectorQuery>
+
+export const QueryDslTermQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  value: FieldValue.describe('Term you wish to find in the provided field.'),
+  case_insensitive: z.boolean().describe('Allows ASCII case insensitive matching of the value with the indexed field values when set to `true`. When `false`, the case sensitivity of matching depends on the underlying field’s mapping.').optional()
+}).meta({ id: 'QueryDslTermQuery' })
+export type QueryDslTermQuery = z.infer<typeof QueryDslTermQuery>
+
+export const QueryDslTermsQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional()
+}).catchall(z.any()).meta({ id: 'QueryDslTermsQuery' })
+export type QueryDslTermsQuery = z.infer<typeof QueryDslTermsQuery>
+
+export interface QueryDslTermsSetQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  minimum_should_match?: MinimumShouldMatch | undefined
+  minimum_should_match_field?: Field | undefined
+  minimum_should_match_script?: ScriptShape | undefined
+  terms: FieldValue[]
+}
+export const QueryDslTermsSetQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
+  minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
+}).meta({ id: 'QueryDslTermsSetQuery' })
+export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
+
+export const QueryDslTextExpansionQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  model_id: z.string().describe('The text expansion NLP model to use'),
+  model_text: z.string().describe('The query text'),
+  pruning_config: TokenPruningConfig.describe('Token pruning configurations').optional()
+}).meta({ id: 'QueryDslTextExpansionQuery' })
+export type QueryDslTextExpansionQuery = z.infer<typeof QueryDslTextExpansionQuery>
+
+export const QueryDslWeightedTokensQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  tokens: z.union([z.record(z.string(), float), z.array(z.record(z.string(), float))]).describe('The tokens representing this query'),
+  pruning_config: TokenPruningConfig.describe('Token pruning configurations').optional()
+}).meta({ id: 'QueryDslWeightedTokensQuery' })
+export type QueryDslWeightedTokensQuery = z.infer<typeof QueryDslWeightedTokensQuery>
+
+export const QueryDslWildcardQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  case_insensitive: z.boolean().describe('Allows case insensitive matching of the pattern with the indexed field values when set to true. Default is false which means the case sensitivity of matching depends on the underlying field’s mapping.').optional(),
+  rewrite: MultiTermQueryRewrite.describe('Method used to rewrite the query.').optional(),
+  value: z.string().describe('Wildcard pattern for terms you wish to find in the provided field. Required, when wildcard is not set.').optional(),
+  wildcard: z.string().describe('Wildcard pattern for terms you wish to find in the provided field. Required, when value is not set.').optional()
+}).meta({ id: 'QueryDslWildcardQuery' })
+export type QueryDslWildcardQuery = z.infer<typeof QueryDslWildcardQuery>
+
+export const QueryDslWrapperQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  query: z.string().describe('A base64 encoded query. The binary data format can be any of JSON, YAML, CBOR or SMILE encodings')
+}).meta({ id: 'QueryDslWrapperQuery' })
+export type QueryDslWrapperQuery = z.infer<typeof QueryDslWrapperQuery>
+
+export const QueryDslTypeQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  value: z.string()
+}).meta({ id: 'QueryDslTypeQuery' })
+export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
+
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+
+export interface QueryDslQueryContainerShape {
+  bool?: QueryDslBoolQuery | undefined
+  boosting?: QueryDslBoostingQuery | undefined
+  common?: Record<Field, QueryDslCommonTermsQuery> | undefined
+  combined_fields?: QueryDslCombinedFieldsQuery | undefined
+  constant_score?: QueryDslConstantScoreQuery | undefined
+  dis_max?: QueryDslDisMaxQuery | undefined
+  distance_feature?: QueryDslDistanceFeatureQuery | undefined
+  exists?: QueryDslExistsQuery | undefined
+  function_score?: QueryDslFunctionScoreQuery | undefined
+  fuzzy?: Record<Field, QueryDslFuzzyQuery> | undefined
+  geo_bounding_box?: QueryDslGeoBoundingBoxQuery | undefined
+  geo_distance?: QueryDslGeoDistanceQuery | undefined
+  geo_grid?: Record<Field, QueryDslGeoGridQuery> | undefined
+  geo_polygon?: QueryDslGeoPolygonQuery | undefined
+  geo_shape?: QueryDslGeoShapeQuery | undefined
+  has_child?: QueryDslHasChildQuery | undefined
+  has_parent?: QueryDslHasParentQuery | undefined
+  ids?: QueryDslIdsQuery | undefined
+  intervals?: Record<Field, QueryDslIntervalsQuery> | undefined
+  knn?: KnnQuery | undefined
+  match?: Record<Field, QueryDslMatchQuery> | undefined
+  match_all?: QueryDslMatchAllQuery | undefined
+  match_bool_prefix?: Record<Field, QueryDslMatchBoolPrefixQuery> | undefined
+  match_none?: QueryDslMatchNoneQuery | undefined
+  match_phrase?: Record<Field, QueryDslMatchPhraseQuery> | undefined
+  match_phrase_prefix?: Record<Field, QueryDslMatchPhrasePrefixQuery> | undefined
+  more_like_this?: QueryDslMoreLikeThisQuery | undefined
+  multi_match?: QueryDslMultiMatchQuery | undefined
+  nested?: QueryDslNestedQuery | undefined
+  parent_id?: QueryDslParentIdQuery | undefined
+  percolate?: QueryDslPercolateQuery | undefined
+  pinned?: QueryDslPinnedQuery | undefined
+  prefix?: Record<Field, QueryDslPrefixQuery> | undefined
+  query_string?: QueryDslQueryStringQuery | undefined
+  range?: Record<Field, QueryDslRangeQuery> | undefined
+  rank_feature?: QueryDslRankFeatureQuery | undefined
+  regexp?: Record<Field, QueryDslRegexpQuery> | undefined
+  rule?: QueryDslRuleQuery | undefined
+  script?: QueryDslScriptQuery | undefined
+  script_score?: QueryDslScriptScoreQuery | undefined
+  semantic?: QueryDslSemanticQuery | undefined
+  shape?: QueryDslShapeQuery | undefined
+  simple_query_string?: QueryDslSimpleQueryStringQuery | undefined
+  span_containing?: QueryDslSpanContainingQuery | undefined
+  span_field_masking?: QueryDslSpanFieldMaskingQuery | undefined
+  span_first?: QueryDslSpanFirstQuery | undefined
+  span_multi?: QueryDslSpanMultiTermQuery | undefined
+  span_near?: QueryDslSpanNearQuery | undefined
+  span_not?: QueryDslSpanNotQuery | undefined
+  span_or?: QueryDslSpanOrQuery | undefined
+  span_term?: Record<Field, QueryDslSpanTermQuery> | undefined
+  span_within?: QueryDslSpanWithinQuery | undefined
+  sparse_vector?: QueryDslSparseVectorQuery | undefined
+  term?: Record<Field, QueryDslTermQuery> | undefined
+  terms?: QueryDslTermsQuery | undefined
+  terms_set?: Record<Field, QueryDslTermsSetQuery> | undefined
+  text_expansion?: Record<Field, QueryDslTextExpansionQuery> | undefined
+  weighted_tokens?: Record<Field, QueryDslWeightedTokensQuery> | undefined
+  wildcard?: Record<Field, QueryDslWildcardQuery> | undefined
+  wrapper?: QueryDslWrapperQuery | undefined
+  type?: QueryDslTypeQuery | undefined
+}
+/** An Elasticsearch Query DSL (Domain Specific Language) object that defines a query. */
+export const QueryDslQueryContainer: z.ZodType<QueryDslQueryContainerShape> = QueryDslQueryContainerExclusiveProps.meta({ id: 'QueryDslQueryContainer' })
+export type QueryDslQueryContainer = z.infer<typeof QueryDslQueryContainer>
+
+export interface AggregationsAdjacencyMatrixAggregationShape {
+  filters?: Record<string, QueryDslQueryContainerShape> | undefined
+  separator?: string | undefined
+}
+export const AggregationsAdjacencyMatrixAggregation = z.object({
+  get filters (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof QueryDslQueryContainer>> { return z.record(z.string(), QueryDslQueryContainer).describe('Filters used to create buckets. At least one filter is required.').optional() },
+  separator: z.string().describe('Separator used to concatenate filter names. Defaults to &.').optional()
+}).meta({ id: 'AggregationsAdjacencyMatrixAggregation' })
+export type AggregationsAdjacencyMatrixAggregation = z.infer<typeof AggregationsAdjacencyMatrixAggregation>
+
+export const AggregationsMinimumInterval = z.enum(['second', 'minute', 'hour', 'day', 'month', 'year']).meta({ id: 'AggregationsMinimumInterval' })
+export type AggregationsMinimumInterval = z.infer<typeof AggregationsMinimumInterval>
+
+export const EpochTime = z.any().meta({ id: 'EpochTime' })
+export type EpochTime = z.infer<typeof EpochTime>
+
+/**
+ * A date and time, either as a string whose format can depend on the context (defaulting to ISO 8601), or a
+ * number of milliseconds since the Epoch. Elasticsearch accepts both as input, but will generally output a string
+ * representation.
+ */
+export const DateTime = z.union([z.string(), EpochTime]).meta({ id: 'DateTime' })
+export type DateTime = z.infer<typeof DateTime>
+
+export interface AggregationsAutoDateHistogramAggregationShape {
+  buckets?: integer | undefined
+  field?: Field | undefined
+  format?: string | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
+  missing?: DateTime | undefined
+  offset?: string | undefined
+  params?: Record<string, unknown> | undefined
+  script?: ScriptShape | undefined
+  time_zone?: TimeZone | undefined
+}
+export const AggregationsAutoDateHistogramAggregation = z.object({
+  buckets: integer.describe('The target number of buckets.').optional(),
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
+  params: z.record(z.string(), z.any()).optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  time_zone: TimeZone.describe('Time zone ID.').optional()
+}).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
+export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
+
+export const AggregationsMissing = z.union([z.string(), integer, double, z.boolean()]).meta({ id: 'AggregationsMissing' })
+export type AggregationsMissing = z.infer<typeof AggregationsMissing>
+
+export interface AggregationsMetricAggregationBaseShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+}
+export const AggregationsMetricAggregationBase = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() }
+}).meta({ id: 'AggregationsMetricAggregationBase' })
+export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
+
+export interface AggregationsFormatMetricAggregationBaseShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  format?: string | undefined
+}
+export const AggregationsFormatMetricAggregationBase = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  format: z.string().optional()
+}).meta({ id: 'AggregationsFormatMetricAggregationBase' })
+export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
+
+export interface AggregationsAverageAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  format?: string | undefined
+}
+export const AggregationsAverageAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  format: z.string().optional()
+}).meta({ id: 'AggregationsAverageAggregation' })
+export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
+
+/**
+ * Buckets path can be expressed in different ways, and an aggregation may accept some or all of these
+ * forms depending on its type. Please refer to each aggregation's documentation to know what buckets
+ * path forms they accept.
+ */
+export const AggregationsBucketsPath = z.union([z.string(), z.array(z.string()), z.record(z.string(), z.string())]).meta({ id: 'AggregationsBucketsPath' })
+export type AggregationsBucketsPath = z.infer<typeof AggregationsBucketsPath>
+
+export const AggregationsBucketPathAggregation = z.object({
+  buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional()
+}).meta({ id: 'AggregationsBucketPathAggregation' })
+export type AggregationsBucketPathAggregation = z.infer<typeof AggregationsBucketPathAggregation>
+
+export const AggregationsGapPolicy = z.enum(['skip', 'insert_zeros', 'keep_values']).meta({ id: 'AggregationsGapPolicy' })
+export type AggregationsGapPolicy = z.infer<typeof AggregationsGapPolicy>
+
+export const AggregationsPipelineAggregationBase = z.object({
+  ...AggregationsBucketPathAggregation.shape,
+  format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
+  gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional()
+}).meta({ id: 'AggregationsPipelineAggregationBase' })
+export type AggregationsPipelineAggregationBase = z.infer<typeof AggregationsPipelineAggregationBase>
+
+export const AggregationsAverageBucketAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape
+}).meta({ id: 'AggregationsAverageBucketAggregation' })
+export type AggregationsAverageBucketAggregation = z.infer<typeof AggregationsAverageBucketAggregation>
+
+export const AggregationsTDigestExecutionHint = z.enum(['default', 'high_accuracy']).meta({ id: 'AggregationsTDigestExecutionHint' })
+export type AggregationsTDigestExecutionHint = z.infer<typeof AggregationsTDigestExecutionHint>
+
+export interface AggregationsBoxplotAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  compression?: double | undefined
+  execution_hint?: AggregationsTDigestExecutionHint | undefined
+}
+export const AggregationsBoxplotAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
+  execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
+}).meta({ id: 'AggregationsBoxplotAggregation' })
+export type AggregationsBoxplotAggregation = z.infer<typeof AggregationsBoxplotAggregation>
+
+export interface AggregationsBucketScriptAggregationShape {
+  buckets_path?: AggregationsBucketsPath | undefined
+  format?: string | undefined
+  gap_policy?: AggregationsGapPolicy | undefined
+  script?: ScriptShape | undefined
+}
+export const AggregationsBucketScriptAggregation = z.object({
+  buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
+  format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
+  gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
+}).meta({ id: 'AggregationsBucketScriptAggregation' })
+export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
+
+export interface AggregationsBucketSelectorAggregationShape {
+  buckets_path?: AggregationsBucketsPath | undefined
+  format?: string | undefined
+  gap_policy?: AggregationsGapPolicy | undefined
+  script?: ScriptShape | undefined
+}
+export const AggregationsBucketSelectorAggregation = z.object({
+  buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
+  format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
+  gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
+}).meta({ id: 'AggregationsBucketSelectorAggregation' })
+export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
+
+export interface AggregationsBucketSortAggregationShape {
+  from?: integer | undefined
+  gap_policy?: AggregationsGapPolicy | undefined
+  size?: integer | undefined
+  sort?: SortShape | undefined
+}
+export const AggregationsBucketSortAggregation = z.object({
+  from: integer.describe('Buckets in positions prior to `from` will be truncated.').optional(),
+  gap_policy: AggregationsGapPolicy.describe('The policy to apply when gaps are found in the data.').optional(),
+  size: integer.describe('The number of buckets to return. Defaults to all buckets of the parent aggregation.').optional(),
+  get sort () { return Sort.describe('The list of fields to sort on.').optional() }
+}).meta({ id: 'AggregationsBucketSortAggregation' })
+export type AggregationsBucketSortAggregation = z.infer<typeof AggregationsBucketSortAggregation>
+
+/**
+ * A sibling pipeline aggregation which executes a two sample Kolmogorov–Smirnov test (referred
+ * to as a "K-S test" from now on) against a provided distribution, and the distribution implied
+ * by the documents counts in the configured sibling aggregation. Specifically, for some metric,
+ * assuming that the percentile intervals of the metric are known beforehand or have been computed
+ * by an aggregation, then one would use range aggregation for the sibling to compute the p-value
+ * of the distribution difference between the metric and the restriction of that metric to a subset
+ * of the documents. A natural use case is if the sibling aggregation range aggregation nested in a
+ * terms aggregation, in which case one compares the overall distribution of metric to its restriction
+ * to each term.
+ */
+export const AggregationsBucketKsAggregation = z.object({
+  ...AggregationsBucketPathAggregation.shape,
+  alternative: z.array(z.string()).describe('A list of string values indicating which K-S test alternative to calculate. The valid values are: "greater", "less", "two_sided". This parameter is key for determining the K-S statistic used when calculating the K-S test. Default value is all possible alternative hypotheses.').optional(),
+  fractions: z.array(double).describe('A list of doubles indicating the distribution of the samples with which to compare to the `buckets_path` results. In typical usage this is the overall proportion of documents in each bucket, which is compared with the actual document proportions in each bucket from the sibling aggregation counts. The default is to assume that overall documents are uniformly distributed on these buckets, which they would be if one used equal percentiles of a metric to define the bucket end points.').optional(),
+  sampling_method: z.string().describe('Indicates the sampling methodology when calculating the K-S test. Note, this is sampling of the returned values. This determines the cumulative distribution function (CDF) points used comparing the two samples. Default is `upper_tail`, which emphasizes the upper end of the CDF points. Valid options are: `upper_tail`, `uniform`, and `lower_tail`.').optional()
+}).meta({ id: 'AggregationsBucketKsAggregation' })
+export type AggregationsBucketKsAggregation = z.infer<typeof AggregationsBucketKsAggregation>
+
+export const AggregationsBucketCorrelationFunctionCountCorrelationIndicator = z.object({
+  doc_count: integer.describe('The total number of documents that initially created the expectations. It’s required to be greater than or equal to the sum of all values in the buckets_path as this is the originating superset of data to which the term values are correlated.'),
+  expectations: z.array(double).describe('An array of numbers with which to correlate the configured `bucket_path` values. The length of this value must always equal the number of buckets returned by the `bucket_path`.'),
+  fractions: z.array(double).describe('An array of fractions to use when averaging and calculating variance. This should be used if the pre-calculated data and the buckets_path have known gaps. The length of fractions, if provided, must equal expectations.').optional()
+}).meta({ id: 'AggregationsBucketCorrelationFunctionCountCorrelationIndicator' })
+export type AggregationsBucketCorrelationFunctionCountCorrelationIndicator = z.infer<typeof AggregationsBucketCorrelationFunctionCountCorrelationIndicator>
+
+export const AggregationsBucketCorrelationFunctionCountCorrelation = z.object({
+  indicator: AggregationsBucketCorrelationFunctionCountCorrelationIndicator.describe('The indicator with which to correlate the configured `bucket_path` values.')
+}).meta({ id: 'AggregationsBucketCorrelationFunctionCountCorrelation' })
+export type AggregationsBucketCorrelationFunctionCountCorrelation = z.infer<typeof AggregationsBucketCorrelationFunctionCountCorrelation>
+
+export const AggregationsBucketCorrelationFunction = z.object({
+  count_correlation: AggregationsBucketCorrelationFunctionCountCorrelation.describe('The configuration to calculate a count correlation. This function is designed for determining the correlation of a term value and a given metric.')
+}).meta({ id: 'AggregationsBucketCorrelationFunction' })
+export type AggregationsBucketCorrelationFunction = z.infer<typeof AggregationsBucketCorrelationFunction>
+
+/** A sibling pipeline aggregation which executes a correlation function on the configured sibling multi-bucket aggregation. */
+export const AggregationsBucketCorrelationAggregation = z.object({
+  ...AggregationsBucketPathAggregation.shape,
+  function: AggregationsBucketCorrelationFunction.describe('The correlation function to execute.')
+}).meta({ id: 'AggregationsBucketCorrelationAggregation' })
+export type AggregationsBucketCorrelationAggregation = z.infer<typeof AggregationsBucketCorrelationAggregation>
+
+export const AggregationsCardinalityExecutionMode = z.enum(['global_ordinals', 'segment_ordinals', 'direct', 'save_memory_heuristic', 'save_time_heuristic']).meta({ id: 'AggregationsCardinalityExecutionMode' })
+export type AggregationsCardinalityExecutionMode = z.infer<typeof AggregationsCardinalityExecutionMode>
+
+export interface AggregationsCardinalityAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  precision_threshold?: integer | undefined
+  rehash?: boolean | undefined
+  execution_hint?: AggregationsCardinalityExecutionMode | undefined
+}
+export const AggregationsCardinalityAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
+  rehash: z.boolean().optional(),
+  execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
+}).meta({ id: 'AggregationsCardinalityAggregation' })
+export type AggregationsCardinalityAggregation = z.infer<typeof AggregationsCardinalityAggregation>
+
+export interface AggregationsCartesianBoundsAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+}
+export const AggregationsCartesianBoundsAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() }
+}).meta({ id: 'AggregationsCartesianBoundsAggregation' })
+export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
+
+export interface AggregationsCartesianCentroidAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+}
+export const AggregationsCartesianCentroidAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() }
+}).meta({ id: 'AggregationsCartesianCentroidAggregation' })
+export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
+
+export const AggregationsCustomCategorizeTextAnalyzer = z.object({
+  char_filter: z.array(z.string()).optional(),
+  tokenizer: z.string().optional(),
+  filter: z.array(z.string()).optional()
+}).meta({ id: 'AggregationsCustomCategorizeTextAnalyzer' })
+export type AggregationsCustomCategorizeTextAnalyzer = z.infer<typeof AggregationsCustomCategorizeTextAnalyzer>
+
+export const AggregationsCategorizeTextAnalyzer = z.union([z.string(), AggregationsCustomCategorizeTextAnalyzer]).meta({ id: 'AggregationsCategorizeTextAnalyzer' })
+export type AggregationsCategorizeTextAnalyzer = z.infer<typeof AggregationsCategorizeTextAnalyzer>
+
+/**
+ * A multi-bucket aggregation that groups semi-structured text into buckets. Each text
+ * field is re-analyzed using a custom analyzer. The resulting tokens are then categorized
+ * creating buckets of similarly formatted text values. This aggregation works best with machine
+ * generated text like system logs. Only the first 100 analyzed tokens are used to categorize the text.
+ */
+export const AggregationsCategorizeTextAggregation = z.object({
+  field: Field.describe('The semi-structured text field to categorize.'),
+  max_unique_tokens: integer.describe('The maximum number of unique tokens at any position up to max_matched_tokens. Must be larger than 1. Smaller values use less memory and create fewer categories. Larger values will use more memory and create narrower categories. Max allowed value is 100.').optional(),
+  max_matched_tokens: integer.describe('The maximum number of token positions to match on before attempting to merge categories. Larger values will use more memory and create narrower categories. Max allowed value is 100.').optional(),
+  similarity_threshold: integer.describe('The minimum percentage of tokens that must match for text to be added to the category bucket. Must be between 1 and 100. The larger the value the narrower the categories. Larger values will increase memory usage and create narrower categories.').optional(),
+  categorization_filters: z.array(z.string()).describe('This property expects an array of regular expressions. The expressions are used to filter out matching sequences from the categorization field values. You can use this functionality to fine tune the categorization by excluding sequences from consideration when categories are defined. For example, you can exclude SQL statements that appear in your log files. This property cannot be used at the same time as categorization_analyzer. If you only want to define simple regular expression filters that are applied prior to tokenization, setting this property is the easiest method. If you also want to customize the tokenizer or post-tokenization filtering, use the categorization_analyzer property instead and include the filters as pattern_replace character filters.').optional(),
+  categorization_analyzer: AggregationsCategorizeTextAnalyzer.describe('The categorization analyzer specifies how the text is analyzed and tokenized before being categorized. The syntax is very similar to that used to define the analyzer in the analyze API. This property cannot be used at the same time as `categorization_filters`.').optional(),
+  shard_size: integer.describe('The number of categorization buckets to return from each shard before merging all the results.').optional(),
+  size: integer.describe('The number of buckets to return.').optional(),
+  min_doc_count: integer.describe('The minimum number of documents in a bucket to be returned to the results.').optional(),
+  shard_min_doc_count: integer.describe('The minimum number of documents in a bucket to be returned from the shard before merging.').optional()
+}).meta({ id: 'AggregationsCategorizeTextAggregation' })
+export type AggregationsCategorizeTextAggregation = z.infer<typeof AggregationsCategorizeTextAggregation>
+
+export const AggregationsChangePointAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape
+}).meta({ id: 'AggregationsChangePointAggregation' })
+export type AggregationsChangePointAggregation = z.infer<typeof AggregationsChangePointAggregation>
+
+export const AggregationsChildrenAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  type: RelationName.describe('The child type that should be selected.').optional()
+}).meta({ id: 'AggregationsChildrenAggregation' })
+export type AggregationsChildrenAggregation = z.infer<typeof AggregationsChildrenAggregation>
+
+export const AggregationsCompositeAggregateKey = z.record(Field, FieldValue).meta({ id: 'AggregationsCompositeAggregateKey' })
+export type AggregationsCompositeAggregateKey = z.infer<typeof AggregationsCompositeAggregateKey>
+
+export const AggregationsMissingOrder = z.enum(['first', 'last', 'default']).meta({ id: 'AggregationsMissingOrder' })
+export type AggregationsMissingOrder = z.infer<typeof AggregationsMissingOrder>
+
+export const AggregationsValueType = z.enum(['string', 'long', 'double', 'number', 'date', 'date_nanos', 'ip', 'numeric', 'geo_point', 'boolean']).meta({ id: 'AggregationsValueType' })
+export type AggregationsValueType = z.infer<typeof AggregationsValueType>
+
+export interface AggregationsCompositeAggregationBaseShape {
+  field?: Field | undefined
+  missing_bucket?: boolean | undefined
+  missing_order?: AggregationsMissingOrder | undefined
+  script?: ScriptShape | undefined
+  value_type?: AggregationsValueType | undefined
+  order?: SortOrder | undefined
+}
+export const AggregationsCompositeAggregationBase = z.object({
+  field: Field.describe('Either `field` or `script` must be present').optional(),
+  missing_bucket: z.boolean().optional(),
+  missing_order: AggregationsMissingOrder.optional(),
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
+  value_type: AggregationsValueType.optional(),
+  order: SortOrder.optional()
+}).meta({ id: 'AggregationsCompositeAggregationBase' })
+export type AggregationsCompositeAggregationBase = z.infer<typeof AggregationsCompositeAggregationBase>
+
+export interface AggregationsCompositeTermsAggregationShape {
+  field?: Field | undefined
+  missing_bucket?: boolean | undefined
+  missing_order?: AggregationsMissingOrder | undefined
+  script?: ScriptShape | undefined
+  value_type?: AggregationsValueType | undefined
+  order?: SortOrder | undefined
+}
+export const AggregationsCompositeTermsAggregation = z.object({
+  field: Field.describe('Either `field` or `script` must be present').optional(),
+  missing_bucket: z.boolean().optional(),
+  missing_order: AggregationsMissingOrder.optional(),
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
+  value_type: AggregationsValueType.optional(),
+  order: SortOrder.optional()
+}).meta({ id: 'AggregationsCompositeTermsAggregation' })
+export type AggregationsCompositeTermsAggregation = z.infer<typeof AggregationsCompositeTermsAggregation>
+
+export interface AggregationsCompositeHistogramAggregationShape {
+  field?: Field | undefined
+  missing_bucket?: boolean | undefined
+  missing_order?: AggregationsMissingOrder | undefined
+  script?: ScriptShape | undefined
+  value_type?: AggregationsValueType | undefined
+  order?: SortOrder | undefined
+  interval: double
+}
+export const AggregationsCompositeHistogramAggregation = z.object({
+  field: Field.describe('Either `field` or `script` must be present').optional(),
+  missing_bucket: z.boolean().optional(),
+  missing_order: AggregationsMissingOrder.optional(),
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
+  value_type: AggregationsValueType.optional(),
+  order: SortOrder.optional(),
+  interval: double
+}).meta({ id: 'AggregationsCompositeHistogramAggregation' })
+export type AggregationsCompositeHistogramAggregation = z.infer<typeof AggregationsCompositeHistogramAggregation>
+
+/**
+ * A date histogram interval. Similar to `Duration` with additional units: `w` (week), `M` (month), `q` (quarter) and
+ * `y` (year)
+ */
+export const DurationLarge = z.string().meta({ id: 'DurationLarge' })
+export type DurationLarge = z.infer<typeof DurationLarge>
+
+export interface AggregationsCompositeDateHistogramAggregationShape {
+  field?: Field | undefined
+  missing_bucket?: boolean | undefined
+  missing_order?: AggregationsMissingOrder | undefined
+  script?: ScriptShape | undefined
+  value_type?: AggregationsValueType | undefined
+  order?: SortOrder | undefined
+  format?: string | undefined
+  calendar_interval?: DurationLarge | undefined
+  fixed_interval?: DurationLarge | undefined
+  offset?: Duration | undefined
+  time_zone?: TimeZone | undefined
+}
+export const AggregationsCompositeDateHistogramAggregation = z.object({
+  field: Field.describe('Either `field` or `script` must be present').optional(),
+  missing_bucket: z.boolean().optional(),
+  missing_order: AggregationsMissingOrder.optional(),
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
+  value_type: AggregationsValueType.optional(),
+  order: SortOrder.optional(),
+  format: z.string().optional(),
+  calendar_interval: DurationLarge.describe('Either `calendar_interval` or `fixed_interval` must be present').optional(),
+  fixed_interval: DurationLarge.describe('Either `calendar_interval` or `fixed_interval` must be present').optional(),
+  offset: Duration.optional(),
+  time_zone: TimeZone.optional()
+}).meta({ id: 'AggregationsCompositeDateHistogramAggregation' })
+export type AggregationsCompositeDateHistogramAggregation = z.infer<typeof AggregationsCompositeDateHistogramAggregation>
+
+export const CoordsGeoBounds = z.object({
+  top: double,
+  bottom: double,
+  left: double,
+  right: double
+}).meta({ id: 'CoordsGeoBounds' })
+export type CoordsGeoBounds = z.infer<typeof CoordsGeoBounds>
+
+export const LatLonGeoLocation = z.object({
+  lat: double.describe('Latitude'),
+  lon: double.describe('Longitude')
+}).meta({ id: 'LatLonGeoLocation' })
+export type LatLonGeoLocation = z.infer<typeof LatLonGeoLocation>
+
+export const GeoHashLocation = z.object({
+  geohash: GeoHash
+}).meta({ id: 'GeoHashLocation' })
+export type GeoHashLocation = z.infer<typeof GeoHashLocation>
+
+/**
+ * A latitude/longitude as a 2 dimensional point. It can be represented in various ways:
+ * - as a `{lat, long}` object
+ * - as a geo hash value
+ * - as a `[lon, lat]` array
+ * - as a string in `"<lat>, <lon>"` or WKT point formats
+ */
+export const GeoLocation = z.union([LatLonGeoLocation, GeoHashLocation, z.array(double), z.string()]).meta({ id: 'GeoLocation' })
+export type GeoLocation = z.infer<typeof GeoLocation>
+
+export const TopLeftBottomRightGeoBounds = z.object({
+  top_left: GeoLocation,
+  bottom_right: GeoLocation
+}).meta({ id: 'TopLeftBottomRightGeoBounds' })
+export type TopLeftBottomRightGeoBounds = z.infer<typeof TopLeftBottomRightGeoBounds>
+
+export const TopRightBottomLeftGeoBounds = z.object({
+  top_right: GeoLocation,
+  bottom_left: GeoLocation
+}).meta({ id: 'TopRightBottomLeftGeoBounds' })
+export type TopRightBottomLeftGeoBounds = z.infer<typeof TopRightBottomLeftGeoBounds>
+
+export const WktGeoBounds = z.object({
+  wkt: z.string()
+}).meta({ id: 'WktGeoBounds' })
+export type WktGeoBounds = z.infer<typeof WktGeoBounds>
+
+/**
+ * A geo bounding box. It can be represented in various ways:
+ * - as 4 top/bottom/left/right coordinates
+ * - as 2 top_left / bottom_right points
+ * - as 2 top_right / bottom_left points
+ * - as a WKT bounding box
+ */
+export const GeoBounds = z.union([CoordsGeoBounds, TopLeftBottomRightGeoBounds, TopRightBottomLeftGeoBounds, WktGeoBounds]).meta({ id: 'GeoBounds' })
+export type GeoBounds = z.infer<typeof GeoBounds>
+
+export interface AggregationsCompositeGeoTileGridAggregationShape {
+  field?: Field | undefined
+  missing_bucket?: boolean | undefined
+  missing_order?: AggregationsMissingOrder | undefined
+  script?: ScriptShape | undefined
+  value_type?: AggregationsValueType | undefined
+  order?: SortOrder | undefined
+  precision?: integer | undefined
+  bounds?: GeoBounds | undefined
+}
+export const AggregationsCompositeGeoTileGridAggregation = z.object({
+  field: Field.describe('Either `field` or `script` must be present').optional(),
+  missing_bucket: z.boolean().optional(),
+  missing_order: AggregationsMissingOrder.optional(),
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
+  value_type: AggregationsValueType.optional(),
+  order: SortOrder.optional(),
+  precision: integer.optional(),
+  bounds: GeoBounds.optional()
+}).meta({ id: 'AggregationsCompositeGeoTileGridAggregation' })
+export type AggregationsCompositeGeoTileGridAggregation = z.infer<typeof AggregationsCompositeGeoTileGridAggregation>
+
+const AggregationsCompositeAggregationSourceExclusiveProps = z.union([z.object({ terms: z.lazy(() => AggregationsCompositeTermsAggregation) }), z.object({ histogram: z.lazy(() => AggregationsCompositeHistogramAggregation) }), z.object({ date_histogram: z.lazy(() => AggregationsCompositeDateHistogramAggregation) }), z.object({ geotile_grid: z.lazy(() => AggregationsCompositeGeoTileGridAggregation) })])
+
+export interface AggregationsCompositeAggregationSourceShape {
+  terms?: AggregationsCompositeTermsAggregation | undefined
+  histogram?: AggregationsCompositeHistogramAggregation | undefined
+  date_histogram?: AggregationsCompositeDateHistogramAggregation | undefined
+  geotile_grid?: AggregationsCompositeGeoTileGridAggregation | undefined
+}
+export const AggregationsCompositeAggregationSource: z.ZodType<AggregationsCompositeAggregationSourceShape> = AggregationsCompositeAggregationSourceExclusiveProps.meta({ id: 'AggregationsCompositeAggregationSource' })
+export type AggregationsCompositeAggregationSource = z.infer<typeof AggregationsCompositeAggregationSource>
+
+export interface AggregationsCompositeAggregationShape {
+  after?: AggregationsCompositeAggregateKey | undefined
+  size?: integer | undefined
+  sources?: Array<Record<string, AggregationsCompositeAggregationSourceShape>> | undefined
+}
+export const AggregationsCompositeAggregation = z.object({
+  after: AggregationsCompositeAggregateKey.describe('When paginating, use the `after_key` value returned in the previous response to retrieve the next page.').optional(),
+  size: integer.describe('The number of composite buckets that should be returned.').optional(),
+  get sources (): z.ZodOptional<z.ZodArray<z.ZodRecord<z.ZodString, typeof AggregationsCompositeAggregationSource>>> { return z.array(z.record(z.string(), AggregationsCompositeAggregationSource)).describe('The value sources used to build composite buckets. Keys are returned in the order of the `sources` definition.').optional() }
+}).meta({ id: 'AggregationsCompositeAggregation' })
+export type AggregationsCompositeAggregation = z.infer<typeof AggregationsCompositeAggregation>
+
+export const AggregationsCumulativeCardinalityAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape
+}).meta({ id: 'AggregationsCumulativeCardinalityAggregation' })
+export type AggregationsCumulativeCardinalityAggregation = z.infer<typeof AggregationsCumulativeCardinalityAggregation>
+
+export const AggregationsCumulativeSumAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape
+}).meta({ id: 'AggregationsCumulativeSumAggregation' })
+export type AggregationsCumulativeSumAggregation = z.infer<typeof AggregationsCumulativeSumAggregation>
+
+export const AggregationsCalendarInterval = z.enum(['second', '1s', 'minute', '1m', 'hour', '1h', 'day', '1d', 'week', '1w', 'month', '1M', 'quarter', '1q', 'year', '1y']).meta({ id: 'AggregationsCalendarInterval' })
+export type AggregationsCalendarInterval = z.infer<typeof AggregationsCalendarInterval>
+
+export const AggregationsExtendedBounds = z.object({
+  max: z.any().describe('Maximum value for the bound.').optional(),
+  min: z.any().describe('Minimum value for the bound.').optional()
+}).meta({ id: 'AggregationsExtendedBounds' })
+export type AggregationsExtendedBounds = z.infer<typeof AggregationsExtendedBounds>
+
+export const AggregationsAggregateOrder = z.union([z.record(Field, SortOrder), z.array(z.record(Field, SortOrder))]).meta({ id: 'AggregationsAggregateOrder' })
+export type AggregationsAggregateOrder = z.infer<typeof AggregationsAggregateOrder>
+
+export interface AggregationsDateHistogramAggregationShape {
+  calendar_interval?: AggregationsCalendarInterval | undefined
+  extended_bounds?: AggregationsExtendedBounds | undefined
+  hard_bounds?: AggregationsExtendedBounds | undefined
+  field?: Field | undefined
+  fixed_interval?: Duration | undefined
+  format?: string | undefined
+  interval?: Duration | undefined
+  min_doc_count?: integer | undefined
+  missing?: DateTime | undefined
+  offset?: Duration | undefined
+  order?: AggregationsAggregateOrder | undefined
+  params?: Record<string, unknown> | undefined
+  script?: ScriptShape | undefined
+  time_zone?: TimeZone | undefined
+  keyed?: boolean | undefined
+}
+export const AggregationsDateHistogramAggregation = z.object({
+  calendar_interval: AggregationsCalendarInterval.describe('Calendar-aware interval. Can be specified using the unit name, such as `month`, or as a single unit quantity, such as `1M`.').optional(),
+  extended_bounds: AggregationsExtendedBounds.describe('Enables extending the bounds of the histogram beyond the data itself.').optional(),
+  hard_bounds: AggregationsExtendedBounds.describe('Limits the histogram to specified bounds.').optional(),
+  field: Field.describe('The date field whose values are use to build a histogram.').optional(),
+  fixed_interval: Duration.describe('Fixed intervals: a fixed number of SI units and never deviate, regardless of where they fall on the calendar.').optional(),
+  format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
+  interval: Duration.optional(),
+  min_doc_count: integer.describe('Only returns buckets that have `min_doc_count` number of documents. By default, all buckets between the first bucket that matches documents and the last one are returned.').optional(),
+  missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
+  order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
+  params: z.record(z.string(), z.any()).optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
+  keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
+}).meta({ id: 'AggregationsDateHistogramAggregation' })
+export type AggregationsDateHistogramAggregation = z.infer<typeof AggregationsDateHistogramAggregation>
+
+export const DateMath = z.string().meta({ id: 'DateMath' })
+export type DateMath = z.infer<typeof DateMath>
+
+/**
+ * A date range limit, represented either as a DateMath expression or a number expressed
+ * according to the target field's precision.
+ */
+export const AggregationsFieldDateMath = z.union([DateMath, long]).meta({ id: 'AggregationsFieldDateMath' })
+export type AggregationsFieldDateMath = z.infer<typeof AggregationsFieldDateMath>
+
+export const AggregationsDateRangeExpression = z.object({
+  from: AggregationsFieldDateMath.describe('Start of the range (inclusive).').optional(),
+  key: z.string().describe('Custom key to return the range with.').optional(),
+  to: AggregationsFieldDateMath.describe('End of the range (exclusive).').optional()
+}).meta({ id: 'AggregationsDateRangeExpression' })
+export type AggregationsDateRangeExpression = z.infer<typeof AggregationsDateRangeExpression>
+
+export const AggregationsDateRangeAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  field: Field.describe('The date field whose values are use to build ranges.').optional(),
+  format: z.string().describe('The date format used to format `from` and `to` in the response.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  ranges: z.array(AggregationsDateRangeExpression).describe('Array of date ranges.').optional(),
+  time_zone: TimeZone.describe('Time zone used to convert dates from another time zone to UTC.').optional(),
+  keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and returns the ranges as a hash rather than an array.').optional()
+}).meta({ id: 'AggregationsDateRangeAggregation' })
+export type AggregationsDateRangeAggregation = z.infer<typeof AggregationsDateRangeAggregation>
+
+export const AggregationsDerivativeAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape
+}).meta({ id: 'AggregationsDerivativeAggregation' })
+export type AggregationsDerivativeAggregation = z.infer<typeof AggregationsDerivativeAggregation>
+
+export const AggregationsSamplerAggregationExecutionHint = z.enum(['map', 'global_ordinals', 'bytes_hash']).meta({ id: 'AggregationsSamplerAggregationExecutionHint' })
+export type AggregationsSamplerAggregationExecutionHint = z.infer<typeof AggregationsSamplerAggregationExecutionHint>
+
+export interface AggregationsDiversifiedSamplerAggregationShape {
+  execution_hint?: AggregationsSamplerAggregationExecutionHint | undefined
+  max_docs_per_value?: integer | undefined
+  script?: ScriptShape | undefined
+  shard_size?: integer | undefined
+  field?: Field | undefined
+}
+export const AggregationsDiversifiedSamplerAggregation = z.object({
+  execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
+  max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
+  field: Field.describe('The field used to provide values used for de-duplication.').optional()
+}).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
+export type AggregationsDiversifiedSamplerAggregation = z.infer<typeof AggregationsDiversifiedSamplerAggregation>
+
+export interface AggregationsExtendedStatsAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  format?: string | undefined
+  sigma?: double | undefined
+}
+export const AggregationsExtendedStatsAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  format: z.string().optional(),
+  sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
+}).meta({ id: 'AggregationsExtendedStatsAggregation' })
+export type AggregationsExtendedStatsAggregation = z.infer<typeof AggregationsExtendedStatsAggregation>
+
+export const AggregationsExtendedStatsBucketAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape,
+  sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
+}).meta({ id: 'AggregationsExtendedStatsBucketAggregation' })
+export type AggregationsExtendedStatsBucketAggregation = z.infer<typeof AggregationsExtendedStatsBucketAggregation>
+
+export const AggregationsTermsExclude = z.union([z.string(), z.array(z.string())]).meta({ id: 'AggregationsTermsExclude' })
+export type AggregationsTermsExclude = z.infer<typeof AggregationsTermsExclude>
+
+export const AggregationsTermsPartition = z.object({
+  num_partitions: long.describe('The number of partitions.'),
+  partition: long.describe('The partition number for this request.')
+}).meta({ id: 'AggregationsTermsPartition' })
+export type AggregationsTermsPartition = z.infer<typeof AggregationsTermsPartition>
+
+export const AggregationsTermsInclude = z.union([z.string(), z.array(z.string()), AggregationsTermsPartition]).meta({ id: 'AggregationsTermsInclude' })
+export type AggregationsTermsInclude = z.infer<typeof AggregationsTermsInclude>
+
+export const AggregationsFrequentItemSetsField = z.object({
+  field: Field,
+  exclude: AggregationsTermsExclude.describe('Values to exclude. Can be regular expression strings or arrays of strings of exact terms.').optional(),
+  include: AggregationsTermsInclude.describe('Values to include. Can be regular expression strings or arrays of strings of exact terms.').optional()
+}).meta({ id: 'AggregationsFrequentItemSetsField' })
+export type AggregationsFrequentItemSetsField = z.infer<typeof AggregationsFrequentItemSetsField>
+
+export interface AggregationsFrequentItemSetsAggregationShape {
+  fields: AggregationsFrequentItemSetsField[]
+  minimum_set_size?: integer | undefined
+  minimum_support?: double | undefined
+  size?: integer | undefined
+  filter?: QueryDslQueryContainerShape | undefined
+}
+export const AggregationsFrequentItemSetsAggregation = z.object({
+  fields: z.array(AggregationsFrequentItemSetsField).describe('Fields to analyze.'),
+  minimum_set_size: integer.describe('The minimum size of one item set.').optional(),
+  minimum_support: double.describe('The minimum support of one item set.').optional(),
+  size: integer.describe('The number of top item sets to return.').optional(),
+  get filter () { return QueryDslQueryContainer.describe('Query that filters documents from analysis.').optional() }
+}).meta({ id: 'AggregationsFrequentItemSetsAggregation' })
+export type AggregationsFrequentItemSetsAggregation = z.infer<typeof AggregationsFrequentItemSetsAggregation>
+
+/**
+ * Aggregation buckets. By default they are returned as an array, but if the aggregation has keys configured for
+ * the different buckets, the result is a dictionary.
+ */
+export const AggregationsBuckets = z.union([z.record(z.string(), z.any()), z.array(z.any())]).meta({ id: 'AggregationsBuckets' })
+export type AggregationsBuckets = z.infer<typeof AggregationsBuckets>
+
+export const AggregationsFiltersAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  filters: AggregationsBuckets.describe('Collection of queries from which to build buckets.').optional(),
+  other_bucket: z.boolean().describe('Set to `true` to add a bucket to the response which will contain all documents that do not match any of the given filters.').optional(),
+  other_bucket_key: z.string().describe('The key with which the other bucket is returned.').optional(),
+  keyed: z.boolean().describe('By default, the named filters aggregation returns the buckets as an object. Set to `false` to return the buckets as an array of objects.').optional()
+}).meta({ id: 'AggregationsFiltersAggregation' })
+export type AggregationsFiltersAggregation = z.infer<typeof AggregationsFiltersAggregation>
+
+export interface AggregationsGeoBoundsAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  wrap_longitude?: boolean | undefined
+}
+export const AggregationsGeoBoundsAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
+}).meta({ id: 'AggregationsGeoBoundsAggregation' })
+export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
+
+export interface AggregationsGeoCentroidAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  count?: long | undefined
+  location?: GeoLocation | undefined
+}
+export const AggregationsGeoCentroidAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  count: long.optional(),
+  location: GeoLocation.optional()
+}).meta({ id: 'AggregationsGeoCentroidAggregation' })
+export type AggregationsGeoCentroidAggregation = z.infer<typeof AggregationsGeoCentroidAggregation>
+
+export const AggregationsAggregationRange = z.object({
+  from: z.union([double, z.null()]).describe('Start of the range (inclusive).').optional(),
+  key: z.string().describe('Custom key to return the range with.').optional(),
+  to: z.union([double, z.null()]).describe('End of the range (exclusive).').optional()
+}).meta({ id: 'AggregationsAggregationRange' })
+export type AggregationsAggregationRange = z.infer<typeof AggregationsAggregationRange>
+
+export const AggregationsGeoDistanceAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  distance_type: GeoDistanceType.describe('The distance calculation type.').optional(),
+  field: Field.describe('A field of type `geo_point` used to evaluate the distance.').optional(),
+  origin: GeoLocation.describe('The origin  used to evaluate the distance.').optional(),
+  ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
+  unit: DistanceUnit.describe('The distance unit.').optional()
+}).meta({ id: 'AggregationsGeoDistanceAggregation' })
+export type AggregationsGeoDistanceAggregation = z.infer<typeof AggregationsGeoDistanceAggregation>
+
+/** A precision that can be expressed as a geohash length between 1 and 12, or a distance measure like "1km", "10m". */
+export const GeoHashPrecision = z.union([integer, z.string()]).meta({ id: 'GeoHashPrecision' })
+export type GeoHashPrecision = z.infer<typeof GeoHashPrecision>
+
+export const AggregationsGeoHashGridAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  bounds: GeoBounds.describe('The bounding box to filter the points in each bucket.').optional(),
+  field: Field.describe('Field containing indexed `geo_point` or `geo_shape` values. If the field contains an array, `geohash_grid` aggregates all array values.').optional(),
+  precision: GeoHashPrecision.describe('The string length of the geohashes used to define cells/buckets in the results.').optional(),
+  shard_size: integer.describe('Allows for more accurate counting of the top cells returned in the final result the aggregation. Defaults to returning `max(10,(size x number-of-shards))` buckets from each shard.').optional(),
+  size: integer.describe('The maximum number of geohash buckets to return.').optional()
+}).meta({ id: 'AggregationsGeoHashGridAggregation' })
+export type AggregationsGeoHashGridAggregation = z.infer<typeof AggregationsGeoHashGridAggregation>
+
+export const AggregationsGeoLinePoint = z.object({
+  field: Field.describe('The name of the geo_point field.')
+}).meta({ id: 'AggregationsGeoLinePoint' })
+export type AggregationsGeoLinePoint = z.infer<typeof AggregationsGeoLinePoint>
+
+export const AggregationsGeoLineSort = z.object({
+  field: Field.describe('The name of the numeric field to use as the sort key for ordering the points.')
+}).meta({ id: 'AggregationsGeoLineSort' })
+export type AggregationsGeoLineSort = z.infer<typeof AggregationsGeoLineSort>
+
+export const AggregationsGeoLineAggregation = z.object({
+  point: AggregationsGeoLinePoint.describe('The name of the geo_point field.'),
+  sort: AggregationsGeoLineSort.describe('The name of the numeric field to use as the sort key for ordering the points. When the `geo_line` aggregation is nested inside a `time_series` aggregation, this field defaults to `@timestamp`, and any other value will result in error.').optional(),
+  include_sort: z.boolean().describe('When `true`, returns an additional array of the sort values in the feature properties.').optional(),
+  sort_order: SortOrder.describe('The order in which the line is sorted (ascending or descending).').optional(),
+  size: integer.describe('The maximum length of the line represented in the aggregation. Valid sizes are between 1 and 10000.').optional()
+}).meta({ id: 'AggregationsGeoLineAggregation' })
+export type AggregationsGeoLineAggregation = z.infer<typeof AggregationsGeoLineAggregation>
+
+export const GeoTilePrecision = integer.meta({ id: 'GeoTilePrecision' })
+export type GeoTilePrecision = z.infer<typeof GeoTilePrecision>
+
+export const AggregationsGeoTileGridAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  field: Field.describe('Field containing indexed `geo_point` or `geo_shape` values. If the field contains an array, `geotile_grid` aggregates all array values.').optional(),
+  precision: GeoTilePrecision.describe('Integer zoom of the key used to define cells/buckets in the results. Values outside of the range [0,29] will be rejected.').optional(),
+  shard_size: integer.describe('Allows for more accurate counting of the top cells returned in the final result the aggregation. Defaults to returning `max(10,(size x number-of-shards))` buckets from each shard.').optional(),
+  size: integer.describe('The maximum number of buckets to return.').optional(),
+  bounds: GeoBounds.describe('A bounding box to filter the geo-points or geo-shapes in each bucket.').optional()
+}).meta({ id: 'AggregationsGeoTileGridAggregation' })
+export type AggregationsGeoTileGridAggregation = z.infer<typeof AggregationsGeoTileGridAggregation>
+
+export const AggregationsGeohexGridAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  field: Field.describe('Field containing indexed `geo_point` or `geo_shape` values. If the field contains an array, `geohex_grid` aggregates all array values.'),
+  precision: integer.describe('Integer zoom of the key used to defined cells or buckets in the results. Value should be between 0-15.').optional(),
+  bounds: GeoBounds.describe('Bounding box used to filter the geo-points in each bucket.').optional(),
+  size: integer.describe('Maximum number of buckets to return.').optional(),
+  shard_size: integer.describe('Number of buckets returned from each shard.').optional()
+}).meta({ id: 'AggregationsGeohexGridAggregation' })
+export type AggregationsGeohexGridAggregation = z.infer<typeof AggregationsGeohexGridAggregation>
+
+export const AggregationsGlobalAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape
+}).meta({ id: 'AggregationsGlobalAggregation' })
+export type AggregationsGlobalAggregation = z.infer<typeof AggregationsGlobalAggregation>
+
+export interface AggregationsHistogramAggregationShape {
+  extended_bounds?: AggregationsExtendedBounds | undefined
+  hard_bounds?: AggregationsExtendedBounds | undefined
+  field?: Field | undefined
+  interval?: double | undefined
+  min_doc_count?: integer | undefined
+  missing?: double | undefined
+  offset?: double | undefined
+  order?: AggregationsAggregateOrder | undefined
+  script?: ScriptShape | undefined
+  format?: string | undefined
+  keyed?: boolean | undefined
+}
+export const AggregationsHistogramAggregation = z.object({
+  extended_bounds: AggregationsExtendedBounds.describe('Enables extending the bounds of the histogram beyond the data itself.').optional(),
+  hard_bounds: AggregationsExtendedBounds.describe('Limits the range of buckets in the histogram. It is particularly useful in the case of open data ranges that can result in a very large number of buckets.').optional(),
+  field: Field.describe('The name of the field to aggregate on.').optional(),
+  interval: double.describe('The interval for the buckets. Must be a positive decimal.').optional(),
+  min_doc_count: integer.describe('Only returns buckets that have `min_doc_count` number of documents. By default, the response will fill gaps in the histogram with empty buckets.').optional(),
+  missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
+  order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  format: z.string().optional(),
+  keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
+}).meta({ id: 'AggregationsHistogramAggregation' })
+export type AggregationsHistogramAggregation = z.infer<typeof AggregationsHistogramAggregation>
+
+export const AggregationsIpRangeAggregationRange = z.object({
+  from: z.union([z.string(), z.null()]).describe('Start of the range.').optional(),
+  mask: z.string().describe('IP range defined as a CIDR mask.').optional(),
+  to: z.union([z.string(), z.null()]).describe('End of the range.').optional()
+}).meta({ id: 'AggregationsIpRangeAggregationRange' })
+export type AggregationsIpRangeAggregationRange = z.infer<typeof AggregationsIpRangeAggregationRange>
+
+export const AggregationsIpRangeAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  field: Field.describe('The date field whose values are used to build ranges.').optional(),
+  ranges: z.array(AggregationsIpRangeAggregationRange).describe('Array of IP ranges.').optional()
+}).meta({ id: 'AggregationsIpRangeAggregation' })
+export type AggregationsIpRangeAggregation = z.infer<typeof AggregationsIpRangeAggregation>
+
+export const AggregationsIpPrefixAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  field: Field.describe('The IP address field to aggregation on. The field mapping type must be `ip`.'),
+  prefix_length: integer.describe('Length of the network prefix. For IPv4 addresses the accepted range is [0, 32]. For IPv6 addresses the accepted range is [0, 128].'),
+  is_ipv6: z.boolean().describe('Defines whether the prefix applies to IPv6 addresses.').optional(),
+  append_prefix_length: z.boolean().describe('Defines whether the prefix length is appended to IP address keys in the response.').optional(),
+  keyed: z.boolean().describe('Defines whether buckets are returned as a hash rather than an array in the response.').optional(),
+  min_doc_count: long.describe('Minimum number of documents in a bucket for it to be included in the response.').optional()
+}).meta({ id: 'AggregationsIpPrefixAggregation' })
+export type AggregationsIpPrefixAggregation = z.infer<typeof AggregationsIpPrefixAggregation>
+
+export const MlRegressionInferenceOptions = z.object({
+  results_field: Field.describe('The field that is added to incoming documents to contain the inference prediction. Defaults to predicted_value.').optional(),
+  num_top_feature_importance_values: integer.describe('Specifies the maximum number of feature importance values per document.').optional()
+}).meta({ id: 'MlRegressionInferenceOptions' })
+export type MlRegressionInferenceOptions = z.infer<typeof MlRegressionInferenceOptions>
+
+export const MlClassificationInferenceOptions = z.object({
+  num_top_classes: integer.describe('Specifies the number of top class predictions to return. Defaults to 0.').optional(),
+  num_top_feature_importance_values: integer.describe('Specifies the maximum number of feature importance values per document.').optional(),
+  prediction_field_type: z.string().describe('Specifies the type of the predicted field to write. Acceptable values are: string, number, boolean. When boolean is provided 1.0 is transformed to true and 0.0 to false.').optional(),
+  results_field: z.string().describe('The field that is added to incoming documents to contain the inference prediction. Defaults to predicted_value.').optional(),
+  top_classes_results_field: z.string().describe('Specifies the field to which the top classes are written. Defaults to top_classes.').optional()
+}).meta({ id: 'MlClassificationInferenceOptions' })
+export type MlClassificationInferenceOptions = z.infer<typeof MlClassificationInferenceOptions>
+
+const AggregationsInferenceConfigContainerExclusiveProps = z.union([z.object({ regression: MlRegressionInferenceOptions }), z.object({ classification: MlClassificationInferenceOptions })])
+
+export const AggregationsInferenceConfigContainer = AggregationsInferenceConfigContainerExclusiveProps.meta({ id: 'AggregationsInferenceConfigContainer' })
+export type AggregationsInferenceConfigContainer = z.infer<typeof AggregationsInferenceConfigContainer>
+
+export const AggregationsInferenceAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape,
+  model_id: Name.describe('The ID or alias for the trained model.'),
+  inference_config: AggregationsInferenceConfigContainer.describe('Contains the inference type and its options.').optional()
+}).meta({ id: 'AggregationsInferenceAggregation' })
+export type AggregationsInferenceAggregation = z.infer<typeof AggregationsInferenceAggregation>
+
+export const AggregationsMatrixAggregation = z.object({
+  fields: Fields.describe('An array of fields for computing the statistics.').optional(),
+  missing: z.record(Field, double).describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
+}).meta({ id: 'AggregationsMatrixAggregation' })
+export type AggregationsMatrixAggregation = z.infer<typeof AggregationsMatrixAggregation>
+
+export const AggregationsMatrixStatsAggregation = z.object({
+  ...AggregationsMatrixAggregation.shape,
+  mode: SortMode.describe('Array value the aggregation will use for array or multi-valued fields.').optional()
+}).meta({ id: 'AggregationsMatrixStatsAggregation' })
+export type AggregationsMatrixStatsAggregation = z.infer<typeof AggregationsMatrixStatsAggregation>
+
+export interface AggregationsMaxAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  format?: string | undefined
+}
+export const AggregationsMaxAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  format: z.string().optional()
+}).meta({ id: 'AggregationsMaxAggregation' })
+export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
+
+export const AggregationsMaxBucketAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape
+}).meta({ id: 'AggregationsMaxBucketAggregation' })
+export type AggregationsMaxBucketAggregation = z.infer<typeof AggregationsMaxBucketAggregation>
+
+export interface AggregationsMedianAbsoluteDeviationAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  format?: string | undefined
+  compression?: double | undefined
+  execution_hint?: AggregationsTDigestExecutionHint | undefined
+}
+export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  format: z.string().optional(),
+  compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
+  execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
+}).meta({ id: 'AggregationsMedianAbsoluteDeviationAggregation' })
+export type AggregationsMedianAbsoluteDeviationAggregation = z.infer<typeof AggregationsMedianAbsoluteDeviationAggregation>
+
+export interface AggregationsMinAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  format?: string | undefined
+}
+export const AggregationsMinAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  format: z.string().optional()
+}).meta({ id: 'AggregationsMinAggregation' })
+export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
+
+export const AggregationsMinBucketAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape
+}).meta({ id: 'AggregationsMinBucketAggregation' })
+export type AggregationsMinBucketAggregation = z.infer<typeof AggregationsMinBucketAggregation>
+
+export const AggregationsMissingAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  field: Field.describe('The name of the field.').optional(),
+  missing: AggregationsMissing.optional()
+}).meta({ id: 'AggregationsMissingAggregation' })
+export type AggregationsMissingAggregation = z.infer<typeof AggregationsMissingAggregation>
+
+export const AggregationsMovingAverageAggregationBase = z.object({
+  ...AggregationsPipelineAggregationBase.shape,
+  minimize: z.boolean().optional(),
+  predict: integer.optional(),
+  window: integer.optional()
+}).meta({ id: 'AggregationsMovingAverageAggregationBase' })
+export type AggregationsMovingAverageAggregationBase = z.infer<typeof AggregationsMovingAverageAggregationBase>
+
+/** For empty Class assignments */
+export const EmptyObject = z.object({
+}).meta({ id: 'EmptyObject' })
+export type EmptyObject = z.infer<typeof EmptyObject>
+
+export const AggregationsLinearMovingAverageAggregation = z.object({
+  ...AggregationsMovingAverageAggregationBase.shape,
+  model: z.literal('linear'),
+  settings: EmptyObject
+}).meta({ id: 'AggregationsLinearMovingAverageAggregation' })
+export type AggregationsLinearMovingAverageAggregation = z.infer<typeof AggregationsLinearMovingAverageAggregation>
+
+export const AggregationsSimpleMovingAverageAggregation = z.object({
+  ...AggregationsMovingAverageAggregationBase.shape,
+  model: z.literal('simple'),
+  settings: EmptyObject
+}).meta({ id: 'AggregationsSimpleMovingAverageAggregation' })
+export type AggregationsSimpleMovingAverageAggregation = z.infer<typeof AggregationsSimpleMovingAverageAggregation>
+
+export const AggregationsEwmaModelSettings = z.object({
+  alpha: float.optional()
+}).meta({ id: 'AggregationsEwmaModelSettings' })
+export type AggregationsEwmaModelSettings = z.infer<typeof AggregationsEwmaModelSettings>
+
+export const AggregationsEwmaMovingAverageAggregation = z.object({
+  ...AggregationsMovingAverageAggregationBase.shape,
+  model: z.literal('ewma'),
+  settings: AggregationsEwmaModelSettings
+}).meta({ id: 'AggregationsEwmaMovingAverageAggregation' })
+export type AggregationsEwmaMovingAverageAggregation = z.infer<typeof AggregationsEwmaMovingAverageAggregation>
+
+export const AggregationsHoltLinearModelSettings = z.object({
+  alpha: float.optional(),
+  beta: float.optional()
+}).meta({ id: 'AggregationsHoltLinearModelSettings' })
+export type AggregationsHoltLinearModelSettings = z.infer<typeof AggregationsHoltLinearModelSettings>
+
+export const AggregationsHoltMovingAverageAggregation = z.object({
+  ...AggregationsMovingAverageAggregationBase.shape,
+  model: z.literal('holt'),
+  settings: AggregationsHoltLinearModelSettings
+}).meta({ id: 'AggregationsHoltMovingAverageAggregation' })
+export type AggregationsHoltMovingAverageAggregation = z.infer<typeof AggregationsHoltMovingAverageAggregation>
+
+export const AggregationsHoltWintersType = z.enum(['add', 'mult']).meta({ id: 'AggregationsHoltWintersType' })
+export type AggregationsHoltWintersType = z.infer<typeof AggregationsHoltWintersType>
+
+export const AggregationsHoltWintersModelSettings = z.object({
+  alpha: float.optional(),
+  beta: float.optional(),
+  gamma: float.optional(),
+  pad: z.boolean().optional(),
+  period: integer.optional(),
+  type: AggregationsHoltWintersType.optional()
+}).meta({ id: 'AggregationsHoltWintersModelSettings' })
+export type AggregationsHoltWintersModelSettings = z.infer<typeof AggregationsHoltWintersModelSettings>
+
+export const AggregationsHoltWintersMovingAverageAggregation = z.object({
+  ...AggregationsMovingAverageAggregationBase.shape,
+  model: z.literal('holt_winters'),
+  settings: AggregationsHoltWintersModelSettings
+}).meta({ id: 'AggregationsHoltWintersMovingAverageAggregation' })
+export type AggregationsHoltWintersMovingAverageAggregation = z.infer<typeof AggregationsHoltWintersMovingAverageAggregation>
+
+export const AggregationsMovingAverageAggregation = z.union([AggregationsLinearMovingAverageAggregation, AggregationsSimpleMovingAverageAggregation, AggregationsEwmaMovingAverageAggregation, AggregationsHoltMovingAverageAggregation, AggregationsHoltWintersMovingAverageAggregation]).meta({ id: 'AggregationsMovingAverageAggregation' })
+export type AggregationsMovingAverageAggregation = z.infer<typeof AggregationsMovingAverageAggregation>
+
+export const AggregationsMovingPercentilesAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape,
+  window: integer.describe('The size of window to "slide" across the histogram.').optional(),
+  shift: integer.describe('By default, the window consists of the last n values excluding the current bucket. Increasing `shift` by 1, moves the starting window position by 1 to the right.').optional(),
+  keyed: z.boolean().optional()
+}).meta({ id: 'AggregationsMovingPercentilesAggregation' })
+export type AggregationsMovingPercentilesAggregation = z.infer<typeof AggregationsMovingPercentilesAggregation>
+
+export const AggregationsMovingFunctionAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape,
+  script: z.string().describe('The script that should be executed on each window of data.').optional(),
+  shift: integer.describe('By default, the window consists of the last n values excluding the current bucket. Increasing `shift` by 1, moves the starting window position by 1 to the right.').optional(),
+  window: integer.describe('The size of window to "slide" across the histogram.').optional()
+}).meta({ id: 'AggregationsMovingFunctionAggregation' })
+export type AggregationsMovingFunctionAggregation = z.infer<typeof AggregationsMovingFunctionAggregation>
+
+export const AggregationsTermsAggregationCollectMode = z.enum(['depth_first', 'breadth_first']).meta({ id: 'AggregationsTermsAggregationCollectMode' })
+export type AggregationsTermsAggregationCollectMode = z.infer<typeof AggregationsTermsAggregationCollectMode>
+
+const AggregationsMultiTermLookupCommonProps = z.object({
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
+})
+
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
+
+export interface AggregationsMultiTermLookupShape {
+  missing?: AggregationsMissing | undefined
+  field?: Field | undefined
+  script?: Script | undefined
+}
+export const AggregationsMultiTermLookup: z.ZodType<AggregationsMultiTermLookupShape> = AggregationsMultiTermLookupCommonProps.and(AggregationsMultiTermLookupExclusiveProps).meta({ id: 'AggregationsMultiTermLookup' })
+export type AggregationsMultiTermLookup = z.infer<typeof AggregationsMultiTermLookup>
+
+export interface AggregationsMultiTermsAggregationShape {
+  collect_mode?: AggregationsTermsAggregationCollectMode | undefined
+  order?: AggregationsAggregateOrder | undefined
+  min_doc_count?: long | undefined
+  shard_min_doc_count?: long | undefined
+  shard_size?: integer | undefined
+  show_term_doc_count_error?: boolean | undefined
+  size?: integer | undefined
+  terms: AggregationsMultiTermLookupShape[]
+}
+export const AggregationsMultiTermsAggregation = z.object({
+  collect_mode: AggregationsTermsAggregationCollectMode.describe('Specifies the strategy for data collection.').optional(),
+  order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
+  min_doc_count: long.describe('The minimum number of documents in a bucket for it to be returned.').optional(),
+  shard_min_doc_count: long.describe('The minimum number of documents in a bucket on each shard for it to be returned.').optional(),
+  shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
+  show_term_doc_count_error: z.boolean().describe('Calculates the doc count error on per term basis.').optional(),
+  size: integer.describe('The number of term buckets should be returned out of the overall terms list.').optional(),
+  get terms () { return AggregationsMultiTermLookup.array().describe('The field from which to generate sets of terms.') }
+}).meta({ id: 'AggregationsMultiTermsAggregation' })
+export type AggregationsMultiTermsAggregation = z.infer<typeof AggregationsMultiTermsAggregation>
+
+export const AggregationsNestedAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  path: Field.describe('The path to the field of type `nested`.').optional()
+}).meta({ id: 'AggregationsNestedAggregation' })
+export type AggregationsNestedAggregation = z.infer<typeof AggregationsNestedAggregation>
+
+export const AggregationsNormalizeMethod = z.enum(['rescale_0_1', 'rescale_0_100', 'percent_of_sum', 'mean', 'z-score', 'softmax']).meta({ id: 'AggregationsNormalizeMethod' })
+export type AggregationsNormalizeMethod = z.infer<typeof AggregationsNormalizeMethod>
+
+export const AggregationsNormalizeAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape,
+  method: AggregationsNormalizeMethod.describe('The specific method to apply.').optional()
+}).meta({ id: 'AggregationsNormalizeAggregation' })
+export type AggregationsNormalizeAggregation = z.infer<typeof AggregationsNormalizeAggregation>
+
+export const AggregationsParentAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  type: RelationName.describe('The child type that should be selected.').optional()
+}).meta({ id: 'AggregationsParentAggregation' })
+export type AggregationsParentAggregation = z.infer<typeof AggregationsParentAggregation>
+
+export const AggregationsHdrMethod = z.object({
+  number_of_significant_value_digits: integer.describe('Specifies the resolution of values for the histogram in number of significant digits.').optional()
+}).meta({ id: 'AggregationsHdrMethod' })
+export type AggregationsHdrMethod = z.infer<typeof AggregationsHdrMethod>
+
+export const AggregationsTDigest = z.object({
+  compression: integer.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
+  execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
+}).meta({ id: 'AggregationsTDigest' })
+export type AggregationsTDigest = z.infer<typeof AggregationsTDigest>
+
+export interface AggregationsPercentileRanksAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  format?: string | undefined
+  keyed?: boolean | undefined
+  values?: double[] | null | undefined
+  hdr?: AggregationsHdrMethod | undefined
+  tdigest?: AggregationsTDigest | undefined
+}
+export const AggregationsPercentileRanksAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  format: z.string().optional(),
+  keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
+  values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
+  hdr: AggregationsHdrMethod.describe('Uses the alternative High Dynamic Range Histogram algorithm to calculate percentile ranks.').optional(),
+  tdigest: AggregationsTDigest.describe('Sets parameters for the default TDigest algorithm used to calculate percentile ranks.').optional()
+}).meta({ id: 'AggregationsPercentileRanksAggregation' })
+export type AggregationsPercentileRanksAggregation = z.infer<typeof AggregationsPercentileRanksAggregation>
+
+export interface AggregationsPercentilesAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  format?: string | undefined
+  keyed?: boolean | undefined
+  percents?: double | double[] | undefined
+  hdr?: AggregationsHdrMethod | undefined
+  tdigest?: AggregationsTDigest | undefined
+}
+export const AggregationsPercentilesAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  format: z.string().optional(),
+  keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
+  percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
+  hdr: AggregationsHdrMethod.describe('Uses the alternative High Dynamic Range Histogram algorithm to calculate percentiles.').optional(),
+  tdigest: AggregationsTDigest.describe('Sets parameters for the default TDigest algorithm used to calculate percentiles.').optional()
+}).meta({ id: 'AggregationsPercentilesAggregation' })
+export type AggregationsPercentilesAggregation = z.infer<typeof AggregationsPercentilesAggregation>
+
+export const AggregationsPercentilesBucketAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape,
+  percents: z.array(double).describe('The list of percentiles to calculate.').optional()
+}).meta({ id: 'AggregationsPercentilesBucketAggregation' })
+export type AggregationsPercentilesBucketAggregation = z.infer<typeof AggregationsPercentilesBucketAggregation>
+
+export interface AggregationsRangeAggregationShape {
+  field?: Field | undefined
+  missing?: integer | undefined
+  ranges?: AggregationsAggregationRange[] | undefined
+  script?: ScriptShape | undefined
+  keyed?: boolean | undefined
+  format?: string | undefined
+}
+export const AggregationsRangeAggregation = z.object({
+  field: Field.describe('The date field whose values are use to build ranges.').optional(),
+  missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
+  format: z.string().optional()
+}).meta({ id: 'AggregationsRangeAggregation' })
+export type AggregationsRangeAggregation = z.infer<typeof AggregationsRangeAggregation>
+
+export const AggregationsRareTermsAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  exclude: AggregationsTermsExclude.describe('Terms that should be excluded from the aggregation.').optional(),
+  field: Field.describe('The field from which to return rare terms.').optional(),
+  include: AggregationsTermsInclude.describe('Terms that should be included in the aggregation.').optional(),
+  max_doc_count: long.describe('The maximum number of documents a term should appear in.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  precision: double.describe('The precision of the internal CuckooFilters. Smaller precision leads to better approximation, but higher memory usage.').optional(),
+  value_type: z.string().optional()
+}).meta({ id: 'AggregationsRareTermsAggregation' })
+export type AggregationsRareTermsAggregation = z.infer<typeof AggregationsRareTermsAggregation>
+
+export const AggregationsRateMode = z.enum(['sum', 'value_count']).meta({ id: 'AggregationsRateMode' })
+export type AggregationsRateMode = z.infer<typeof AggregationsRateMode>
+
+export interface AggregationsRateAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  format?: string | undefined
+  unit?: AggregationsCalendarInterval | undefined
+  mode?: AggregationsRateMode | undefined
+}
+export const AggregationsRateAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  format: z.string().optional(),
+  unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
+  mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
+}).meta({ id: 'AggregationsRateAggregation' })
+export type AggregationsRateAggregation = z.infer<typeof AggregationsRateAggregation>
+
+export const AggregationsReverseNestedAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  path: Field.describe('Defines the nested object field that should be joined back to. The default is empty, which means that it joins back to the root/main document level.').optional()
+}).meta({ id: 'AggregationsReverseNestedAggregation' })
+export type AggregationsReverseNestedAggregation = z.infer<typeof AggregationsReverseNestedAggregation>
+
+export const AggregationsSamplerAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional()
+}).meta({ id: 'AggregationsSamplerAggregation' })
+export type AggregationsSamplerAggregation = z.infer<typeof AggregationsSamplerAggregation>
+
+export interface AggregationsScriptedMetricAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  combine_script?: ScriptShape | undefined
+  init_script?: ScriptShape | undefined
+  map_script?: ScriptShape | undefined
+  params?: Record<string, unknown> | undefined
+  reduce_script?: ScriptShape | undefined
+}
+export const AggregationsScriptedMetricAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+}).meta({ id: 'AggregationsScriptedMetricAggregation' })
+export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
+
+export const AggregationsSerialDifferencingAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape,
+  lag: integer.describe('The historical bucket to subtract from the current value. Must be a positive, non-zero integer.').optional()
+}).meta({ id: 'AggregationsSerialDifferencingAggregation' })
+export type AggregationsSerialDifferencingAggregation = z.infer<typeof AggregationsSerialDifferencingAggregation>
+
+export const AggregationsChiSquareHeuristic = z.object({
+  background_is_superset: z.boolean().describe('Set to `false` if you defined a custom background filter that represents a different set of documents that you want to compare to.'),
+  include_negatives: z.boolean().describe('Set to `false` to filter out the terms that appear less often in the subset than in documents outside the subset.')
+}).meta({ id: 'AggregationsChiSquareHeuristic' })
+export type AggregationsChiSquareHeuristic = z.infer<typeof AggregationsChiSquareHeuristic>
+
+export const AggregationsTermsAggregationExecutionHint = z.enum(['map', 'global_ordinals', 'global_ordinals_hash', 'global_ordinals_low_cardinality']).meta({ id: 'AggregationsTermsAggregationExecutionHint' })
+export type AggregationsTermsAggregationExecutionHint = z.infer<typeof AggregationsTermsAggregationExecutionHint>
+
+export const AggregationsGoogleNormalizedDistanceHeuristic = z.object({
+  background_is_superset: z.boolean().describe('Set to `false` if you defined a custom background filter that represents a different set of documents that you want to compare to.').optional()
+}).meta({ id: 'AggregationsGoogleNormalizedDistanceHeuristic' })
+export type AggregationsGoogleNormalizedDistanceHeuristic = z.infer<typeof AggregationsGoogleNormalizedDistanceHeuristic>
+
+export const AggregationsMutualInformationHeuristic = z.object({
+  background_is_superset: z.boolean().describe('Set to `false` if you defined a custom background filter that represents a different set of documents that you want to compare to.').optional(),
+  include_negatives: z.boolean().describe('Set to `false` to filter out the terms that appear less often in the subset than in documents outside the subset.').optional()
+}).meta({ id: 'AggregationsMutualInformationHeuristic' })
+export type AggregationsMutualInformationHeuristic = z.infer<typeof AggregationsMutualInformationHeuristic>
+
+export const AggregationsPercentageScoreHeuristic = z.object({
+}).meta({ id: 'AggregationsPercentageScoreHeuristic' })
+export type AggregationsPercentageScoreHeuristic = z.infer<typeof AggregationsPercentageScoreHeuristic>
+
+export interface AggregationsScriptedHeuristicShape {
+  script: ScriptShape
+}
+export const AggregationsScriptedHeuristic = z.object({
+  get script () { return z.union([Script, ScriptSource]) }
+}).meta({ id: 'AggregationsScriptedHeuristic' })
+export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
+
+export const AggregationsPValueHeuristic = z.object({
+  background_is_superset: z.boolean().optional(),
+  normalize_above: long.describe('Should the results be normalized when above the given value. Allows for consistent significance results at various scales. Note: `0` is a special value which means no normalization').optional()
+}).meta({ id: 'AggregationsPValueHeuristic' })
+export type AggregationsPValueHeuristic = z.infer<typeof AggregationsPValueHeuristic>
+
+export interface AggregationsSignificantTermsAggregationShape {
+  background_filter?: QueryDslQueryContainerShape | undefined
+  chi_square?: AggregationsChiSquareHeuristic | undefined
+  exclude?: AggregationsTermsExclude | undefined
+  execution_hint?: AggregationsTermsAggregationExecutionHint | undefined
+  field?: Field | undefined
+  gnd?: AggregationsGoogleNormalizedDistanceHeuristic | undefined
+  include?: AggregationsTermsInclude | undefined
+  jlh?: EmptyObject | undefined
+  min_doc_count?: long | undefined
+  mutual_information?: AggregationsMutualInformationHeuristic | undefined
+  percentage?: AggregationsPercentageScoreHeuristic | undefined
+  script_heuristic?: AggregationsScriptedHeuristicShape | undefined
+  p_value?: AggregationsPValueHeuristic | undefined
+  shard_min_doc_count?: long | undefined
+  shard_size?: integer | undefined
+  size?: integer | undefined
+}
+export const AggregationsSignificantTermsAggregation = z.object({
+  get background_filter () { return QueryDslQueryContainer.describe('A background filter that can be used to focus in on significant terms within a narrower context, instead of the entire index.').optional() },
+  chi_square: AggregationsChiSquareHeuristic.describe('Use Chi square, as described in "Information Retrieval", Manning et al., Chapter 13.5.2, as the significance score.').optional(),
+  exclude: AggregationsTermsExclude.describe('Terms to exclude.').optional(),
+  execution_hint: AggregationsTermsAggregationExecutionHint.describe('Mechanism by which the aggregation should be executed: using field values directly or using global ordinals.').optional(),
+  field: Field.describe('The field from which to return significant terms.').optional(),
+  gnd: AggregationsGoogleNormalizedDistanceHeuristic.describe('Use Google normalized distance as described in "The Google Similarity Distance", Cilibrasi and Vitanyi, 2007, as the significance score.').optional(),
+  include: AggregationsTermsInclude.describe('Terms to include.').optional(),
+  jlh: EmptyObject.describe('Use JLH score as the significance score.').optional(),
+  min_doc_count: long.describe('Only return terms that are found in more than `min_doc_count` hits.').optional(),
+  mutual_information: AggregationsMutualInformationHeuristic.describe('Use mutual information as described in "Information Retrieval", Manning et al., Chapter 13.5.1, as the significance score.').optional(),
+  percentage: AggregationsPercentageScoreHeuristic.describe('A simple calculation of the number of documents in the foreground sample with a term divided by the number of documents in the background with the term.').optional(),
+  get script_heuristic () { return AggregationsScriptedHeuristic.describe('Customized score, implemented via a script.').optional() },
+  p_value: AggregationsPValueHeuristic.describe('Significant terms heuristic that calculates the p-value between the term existing in foreground and background sets. The p-value is the probability of obtaining test results at least as extreme as the results actually observed, under the assumption that the null hypothesis is correct. The p-value is calculated assuming that the foreground set and the background set are independent https://en.wikipedia.org/wiki/Bernoulli_trial, with the null hypothesis that the probabilities are the same.').optional(),
+  shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
+  shard_size: integer.describe('Can be used to control the volumes of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
+  size: integer.describe('The number of buckets returned out of the overall terms list.').optional()
+}).meta({ id: 'AggregationsSignificantTermsAggregation' })
+export type AggregationsSignificantTermsAggregation = z.infer<typeof AggregationsSignificantTermsAggregation>
+
+export interface AggregationsSignificantTextAggregationShape {
+  background_filter?: QueryDslQueryContainerShape | undefined
+  chi_square?: AggregationsChiSquareHeuristic | undefined
+  exclude?: AggregationsTermsExclude | undefined
+  execution_hint?: AggregationsTermsAggregationExecutionHint | undefined
+  field?: Field | undefined
+  filter_duplicate_text?: boolean | undefined
+  gnd?: AggregationsGoogleNormalizedDistanceHeuristic | undefined
+  include?: AggregationsTermsInclude | undefined
+  jlh?: EmptyObject | undefined
+  min_doc_count?: long | undefined
+  mutual_information?: AggregationsMutualInformationHeuristic | undefined
+  percentage?: AggregationsPercentageScoreHeuristic | undefined
+  script_heuristic?: AggregationsScriptedHeuristicShape | undefined
+  shard_min_doc_count?: long | undefined
+  shard_size?: integer | undefined
+  size?: integer | undefined
+  source_fields?: Fields | undefined
+}
+export const AggregationsSignificantTextAggregation = z.object({
+  get background_filter () { return QueryDslQueryContainer.describe('A background filter that can be used to focus in on significant terms within a narrower context, instead of the entire index.').optional() },
+  chi_square: AggregationsChiSquareHeuristic.describe('Use Chi square, as described in "Information Retrieval", Manning et al., Chapter 13.5.2, as the significance score.').optional(),
+  exclude: AggregationsTermsExclude.describe('Values to exclude.').optional(),
+  execution_hint: AggregationsTermsAggregationExecutionHint.describe('Determines whether the aggregation will use field values directly or global ordinals.').optional(),
+  field: Field.describe('The field from which to return significant text.').optional(),
+  filter_duplicate_text: z.boolean().describe('Whether to out duplicate text to deal with noisy data.').optional(),
+  gnd: AggregationsGoogleNormalizedDistanceHeuristic.describe('Use Google normalized distance as described in "The Google Similarity Distance", Cilibrasi and Vitanyi, 2007, as the significance score.').optional(),
+  include: AggregationsTermsInclude.describe('Values to include.').optional(),
+  jlh: EmptyObject.describe('Use JLH score as the significance score.').optional(),
+  min_doc_count: long.describe('Only return values that are found in more than `min_doc_count` hits.').optional(),
+  mutual_information: AggregationsMutualInformationHeuristic.describe('Use mutual information as described in "Information Retrieval", Manning et al., Chapter 13.5.1, as the significance score.').optional(),
+  percentage: AggregationsPercentageScoreHeuristic.describe('A simple calculation of the number of documents in the foreground sample with a term divided by the number of documents in the background with the term.').optional(),
+  get script_heuristic () { return AggregationsScriptedHeuristic.describe('Customized score, implemented via a script.').optional() },
+  shard_min_doc_count: long.describe('Regulates the certainty a shard has if the values should actually be added to the candidate list or not with respect to the min_doc_count. Values will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
+  shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
+  size: integer.describe('The number of buckets returned out of the overall terms list.').optional(),
+  source_fields: Fields.describe('Overrides the JSON `_source` fields from which text will be analyzed.').optional()
+}).meta({ id: 'AggregationsSignificantTextAggregation' })
+export type AggregationsSignificantTextAggregation = z.infer<typeof AggregationsSignificantTextAggregation>
+
+export interface AggregationsStatsAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  format?: string | undefined
+}
+export const AggregationsStatsAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  format: z.string().optional()
+}).meta({ id: 'AggregationsStatsAggregation' })
+export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
+
+export const AggregationsStatsBucketAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape
+}).meta({ id: 'AggregationsStatsBucketAggregation' })
+export type AggregationsStatsBucketAggregation = z.infer<typeof AggregationsStatsBucketAggregation>
+
+export interface AggregationsStringStatsAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  show_distribution?: boolean | undefined
+}
+export const AggregationsStringStatsAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
+}).meta({ id: 'AggregationsStringStatsAggregation' })
+export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
+
+export interface AggregationsSumAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  format?: string | undefined
+}
+export const AggregationsSumAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  format: z.string().optional()
+}).meta({ id: 'AggregationsSumAggregation' })
+export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
+
+export const AggregationsSumBucketAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape
+}).meta({ id: 'AggregationsSumBucketAggregation' })
+export type AggregationsSumBucketAggregation = z.infer<typeof AggregationsSumBucketAggregation>
+
+export interface AggregationsTermsAggregationShape {
+  collect_mode?: AggregationsTermsAggregationCollectMode | undefined
+  exclude?: AggregationsTermsExclude | undefined
+  execution_hint?: AggregationsTermsAggregationExecutionHint | undefined
+  field?: Field | undefined
+  include?: AggregationsTermsInclude | undefined
+  min_doc_count?: integer | undefined
+  missing?: AggregationsMissing | undefined
+  missing_order?: AggregationsMissingOrder | undefined
+  missing_bucket?: boolean | undefined
+  value_type?: string | undefined
+  order?: AggregationsAggregateOrder | undefined
+  script?: ScriptShape | undefined
+  shard_min_doc_count?: long | undefined
+  shard_size?: integer | undefined
+  show_term_doc_count_error?: boolean | undefined
+  size?: integer | undefined
+  format?: string | undefined
+}
+export const AggregationsTermsAggregation = z.object({
+  collect_mode: AggregationsTermsAggregationCollectMode.describe('Determines how child aggregations should be calculated: breadth-first or depth-first.').optional(),
+  exclude: AggregationsTermsExclude.describe('Values to exclude. Accepts regular expressions and partitions.').optional(),
+  execution_hint: AggregationsTermsAggregationExecutionHint.describe('Determines whether the aggregation will use field values directly or global ordinals.').optional(),
+  field: Field.describe('The field from which to return terms.').optional(),
+  include: AggregationsTermsInclude.describe('Values to include. Accepts regular expressions and partitions.').optional(),
+  min_doc_count: integer.describe('Only return values that are found in more than `min_doc_count` hits.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  missing_order: AggregationsMissingOrder.optional(),
+  missing_bucket: z.boolean().optional(),
+  value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
+  order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
+  shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
+  show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
+  size: integer.describe('The number of buckets returned out of the overall terms list.').optional(),
+  format: z.string().optional()
+}).meta({ id: 'AggregationsTermsAggregation' })
+export type AggregationsTermsAggregation = z.infer<typeof AggregationsTermsAggregation>
+
+export const AggregationsTimeSeriesAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  size: integer.describe('The maximum number of results to return.').optional(),
+  keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and returns the ranges as a hash rather than an array.').optional()
+}).meta({ id: 'AggregationsTimeSeriesAggregation' })
+export type AggregationsTimeSeriesAggregation = z.infer<typeof AggregationsTimeSeriesAggregation>
+
+export interface AggregationsTopHitsAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  docvalue_fields?: QueryDslFieldAndFormat[] | undefined
+  explain?: boolean | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
+  from?: integer | undefined
+  highlight?: SearchHighlightShape | undefined
+  script_fields?: Record<string, ScriptFieldShape> | undefined
+  size?: integer | undefined
+  sort?: SortShape | undefined
+  _source?: SearchSourceConfig | undefined
+  stored_fields?: Fields | undefined
+  track_scores?: boolean | undefined
+  version?: boolean | undefined
+  seq_no_primary_term?: boolean | undefined
+}
+export const AggregationsTopHitsAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
+  explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  from: integer.describe('Starting document offset.').optional(),
+  get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
+  get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
+  size: integer.describe('The maximum number of top matching hits to return per bucket.').optional(),
+  get sort () { return Sort.describe('Sort order of the top matching hits. By default, the hits are sorted by the score of the main query.').optional() },
+  _source: SearchSourceConfig.describe('Selects the fields of the source that are returned.').optional(),
+  stored_fields: Fields.describe('Returns values for the specified stored fields (fields that use the `store` mapping option).').optional(),
+  track_scores: z.boolean().describe('If `true`, calculates and returns document scores, even if the scores are not used for sorting.').optional(),
+  version: z.boolean().describe('If `true`, returns document version as part of a hit.').optional(),
+  seq_no_primary_term: z.boolean().describe('If `true`, returns sequence number and primary term of the last modification of each hit.').optional()
+}).meta({ id: 'AggregationsTopHitsAggregation' })
+export type AggregationsTopHitsAggregation = z.infer<typeof AggregationsTopHitsAggregation>
+
+export interface AggregationsTestPopulationShape {
+  field: Field
+  script?: ScriptShape | undefined
+  filter?: QueryDslQueryContainerShape | undefined
+}
+export const AggregationsTestPopulation = z.object({
+  field: Field.describe('The field to aggregate.'),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
+}).meta({ id: 'AggregationsTestPopulation' })
+export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
+
+export const AggregationsTTestType = z.enum(['paired', 'homoscedastic', 'heteroscedastic']).meta({ id: 'AggregationsTTestType' })
+export type AggregationsTTestType = z.infer<typeof AggregationsTTestType>
+
+export interface AggregationsTTestAggregationShape {
+  a?: AggregationsTestPopulationShape | undefined
+  b?: AggregationsTestPopulationShape | undefined
+  type?: AggregationsTTestType | undefined
+}
+export const AggregationsTTestAggregation = z.object({
+  get a () { return AggregationsTestPopulation.describe('Test population A.').optional() },
+  get b () { return AggregationsTestPopulation.describe('Test population B.').optional() },
+  type: AggregationsTTestType.describe('The type of test.').optional()
+}).meta({ id: 'AggregationsTTestAggregation' })
+export type AggregationsTTestAggregation = z.infer<typeof AggregationsTTestAggregation>
+
+export const AggregationsTopMetricsValue = z.object({
+  field: Field.describe('A field to return as a metric.')
+}).meta({ id: 'AggregationsTopMetricsValue' })
+export type AggregationsTopMetricsValue = z.infer<typeof AggregationsTopMetricsValue>
+
+export interface AggregationsTopMetricsAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  metrics?: AggregationsTopMetricsValue | AggregationsTopMetricsValue[] | undefined
+  size?: integer | undefined
+  sort?: SortShape | undefined
+}
+export const AggregationsTopMetricsAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
+  size: integer.describe('The number of top documents from which to return metrics.').optional(),
+  get sort () { return Sort.describe('The sort order of the documents.').optional() }
+}).meta({ id: 'AggregationsTopMetricsAggregation' })
+export type AggregationsTopMetricsAggregation = z.infer<typeof AggregationsTopMetricsAggregation>
+
+export interface AggregationsFormattableMetricAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  format?: string | undefined
+}
+export const AggregationsFormattableMetricAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  format: z.string().optional()
+}).meta({ id: 'AggregationsFormattableMetricAggregation' })
+export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
+
+export interface AggregationsValueCountAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  format?: string | undefined
+}
+export const AggregationsValueCountAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  format: z.string().optional()
+}).meta({ id: 'AggregationsValueCountAggregation' })
+export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
+
+export interface AggregationsWeightedAverageValueShape {
+  field?: Field | undefined
+  missing?: double | undefined
+  script?: ScriptShape | undefined
+}
+export const AggregationsWeightedAverageValue = z.object({
+  field: Field.describe('The field from which to extract the values or weights.').optional(),
+  missing: double.describe('A value or weight to use if the field is missing.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() }
+}).meta({ id: 'AggregationsWeightedAverageValue' })
+export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
+
+export interface AggregationsWeightedAverageAggregationShape {
+  format?: string | undefined
+  value?: AggregationsWeightedAverageValueShape | undefined
+  value_type?: AggregationsValueType | undefined
+  weight?: AggregationsWeightedAverageValueShape | undefined
+}
+export const AggregationsWeightedAverageAggregation = z.object({
+  format: z.string().describe('A numeric response formatter.').optional(),
+  get value () { return AggregationsWeightedAverageValue.describe('Configuration for the field that provides the values.').optional() },
+  value_type: AggregationsValueType.optional(),
+  get weight () { return AggregationsWeightedAverageValue.describe('Configuration for the field or script that provides the weights.').optional() }
+}).meta({ id: 'AggregationsWeightedAverageAggregation' })
+export type AggregationsWeightedAverageAggregation = z.infer<typeof AggregationsWeightedAverageAggregation>
+
+export interface AggregationsVariableWidthHistogramAggregationShape {
+  field?: Field | undefined
+  buckets?: integer | undefined
+  shard_size?: integer | undefined
+  initial_buffer?: integer | undefined
+  script?: ScriptShape | undefined
+}
+export const AggregationsVariableWidthHistogramAggregation = z.object({
+  field: Field.describe('The name of the field.').optional(),
+  buckets: integer.describe('The target number of buckets.').optional(),
+  shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
+  initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() }
+}).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
+export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
+
+const AggregationsAggregationContainerCommonProps = z.object({
+  aggregations: z.record(z.string(), z.lazy(() => AggregationsAggregationContainer)).describe('Sub-aggregations for this aggregation. Only applies to bucket aggregations.').optional(),
+  aggs: z.record(z.string(), z.lazy(() => AggregationsAggregationContainer)).describe('Sub-aggregations for this aggregation. Only applies to bucket aggregations.').optional(),
+  meta: Metadata.optional()
+})
+
+const AggregationsAggregationContainerExclusiveProps = z.union([z.object({ adjacency_matrix: z.lazy(() => AggregationsAdjacencyMatrixAggregation) }), z.object({ auto_date_histogram: z.lazy(() => AggregationsAutoDateHistogramAggregation) }), z.object({ avg: z.lazy(() => AggregationsAverageAggregation) }), z.object({ avg_bucket: AggregationsAverageBucketAggregation }), z.object({ boxplot: z.lazy(() => AggregationsBoxplotAggregation) }), z.object({ bucket_script: z.lazy(() => AggregationsBucketScriptAggregation) }), z.object({ bucket_selector: z.lazy(() => AggregationsBucketSelectorAggregation) }), z.object({ bucket_sort: z.lazy(() => AggregationsBucketSortAggregation) }), z.object({ bucket_count_ks_test: AggregationsBucketKsAggregation }), z.object({ bucket_correlation: AggregationsBucketCorrelationAggregation }), z.object({ cardinality: z.lazy(() => AggregationsCardinalityAggregation) }), z.object({ cartesian_bounds: z.lazy(() => AggregationsCartesianBoundsAggregation) }), z.object({ cartesian_centroid: z.lazy(() => AggregationsCartesianCentroidAggregation) }), z.object({ categorize_text: AggregationsCategorizeTextAggregation }), z.object({ change_point: AggregationsChangePointAggregation }), z.object({ children: AggregationsChildrenAggregation }), z.object({ composite: z.lazy(() => AggregationsCompositeAggregation) }), z.object({ cumulative_cardinality: AggregationsCumulativeCardinalityAggregation }), z.object({ cumulative_sum: AggregationsCumulativeSumAggregation }), z.object({ date_histogram: z.lazy(() => AggregationsDateHistogramAggregation) }), z.object({ date_range: AggregationsDateRangeAggregation }), z.object({ derivative: AggregationsDerivativeAggregation }), z.object({ diversified_sampler: z.lazy(() => AggregationsDiversifiedSamplerAggregation) }), z.object({ extended_stats: z.lazy(() => AggregationsExtendedStatsAggregation) }), z.object({ extended_stats_bucket: AggregationsExtendedStatsBucketAggregation }), z.object({ frequent_item_sets: z.lazy(() => AggregationsFrequentItemSetsAggregation) }), z.object({ filter: z.lazy(() => QueryDslQueryContainer) }), z.object({ filters: AggregationsFiltersAggregation }), z.object({ geo_bounds: z.lazy(() => AggregationsGeoBoundsAggregation) }), z.object({ geo_centroid: z.lazy(() => AggregationsGeoCentroidAggregation) }), z.object({ geo_distance: AggregationsGeoDistanceAggregation }), z.object({ geohash_grid: AggregationsGeoHashGridAggregation }), z.object({ geo_line: AggregationsGeoLineAggregation }), z.object({ geotile_grid: AggregationsGeoTileGridAggregation }), z.object({ geohex_grid: AggregationsGeohexGridAggregation }), z.object({ global: AggregationsGlobalAggregation }), z.object({ histogram: z.lazy(() => AggregationsHistogramAggregation) }), z.object({ ip_range: AggregationsIpRangeAggregation }), z.object({ ip_prefix: AggregationsIpPrefixAggregation }), z.object({ inference: AggregationsInferenceAggregation }), z.object({ line: AggregationsGeoLineAggregation }), z.object({ matrix_stats: AggregationsMatrixStatsAggregation }), z.object({ max: z.lazy(() => AggregationsMaxAggregation) }), z.object({ max_bucket: AggregationsMaxBucketAggregation }), z.object({ median_absolute_deviation: z.lazy(() => AggregationsMedianAbsoluteDeviationAggregation) }), z.object({ min: z.lazy(() => AggregationsMinAggregation) }), z.object({ min_bucket: AggregationsMinBucketAggregation }), z.object({ missing: AggregationsMissingAggregation }), z.object({ moving_avg: AggregationsMovingAverageAggregation }), z.object({ moving_percentiles: AggregationsMovingPercentilesAggregation }), z.object({ moving_fn: AggregationsMovingFunctionAggregation }), z.object({ multi_terms: z.lazy(() => AggregationsMultiTermsAggregation) }), z.object({ nested: AggregationsNestedAggregation }), z.object({ normalize: AggregationsNormalizeAggregation }), z.object({ parent: AggregationsParentAggregation }), z.object({ percentile_ranks: z.lazy(() => AggregationsPercentileRanksAggregation) }), z.object({ percentiles: z.lazy(() => AggregationsPercentilesAggregation) }), z.object({ percentiles_bucket: AggregationsPercentilesBucketAggregation }), z.object({ range: z.lazy(() => AggregationsRangeAggregation) }), z.object({ rare_terms: AggregationsRareTermsAggregation }), z.object({ rate: z.lazy(() => AggregationsRateAggregation) }), z.object({ reverse_nested: AggregationsReverseNestedAggregation }), z.object({ sampler: AggregationsSamplerAggregation }), z.object({ scripted_metric: z.lazy(() => AggregationsScriptedMetricAggregation) }), z.object({ serial_diff: AggregationsSerialDifferencingAggregation }), z.object({ significant_terms: z.lazy(() => AggregationsSignificantTermsAggregation) }), z.object({ significant_text: z.lazy(() => AggregationsSignificantTextAggregation) }), z.object({ stats: z.lazy(() => AggregationsStatsAggregation) }), z.object({ stats_bucket: AggregationsStatsBucketAggregation }), z.object({ string_stats: z.lazy(() => AggregationsStringStatsAggregation) }), z.object({ sum: z.lazy(() => AggregationsSumAggregation) }), z.object({ sum_bucket: AggregationsSumBucketAggregation }), z.object({ terms: z.lazy(() => AggregationsTermsAggregation) }), z.object({ time_series: AggregationsTimeSeriesAggregation }), z.object({ top_hits: z.lazy(() => AggregationsTopHitsAggregation) }), z.object({ t_test: z.lazy(() => AggregationsTTestAggregation) }), z.object({ top_metrics: z.lazy(() => AggregationsTopMetricsAggregation) }), z.object({ value_count: z.lazy(() => AggregationsValueCountAggregation) }), z.object({ weighted_avg: z.lazy(() => AggregationsWeightedAverageAggregation) }), z.object({ variable_width_histogram: z.lazy(() => AggregationsVariableWidthHistogramAggregation) })])
+
+export interface AggregationsAggregationContainerShape {
+  aggregations?: Record<string, AggregationsAggregationContainerShape> | undefined
+  meta?: Metadata | undefined
+  adjacency_matrix?: AggregationsAdjacencyMatrixAggregation | undefined
+  auto_date_histogram?: AggregationsAutoDateHistogramAggregation | undefined
+  avg?: AggregationsAverageAggregation | undefined
+  avg_bucket?: AggregationsAverageBucketAggregation | undefined
+  boxplot?: AggregationsBoxplotAggregation | undefined
+  bucket_script?: AggregationsBucketScriptAggregation | undefined
+  bucket_selector?: AggregationsBucketSelectorAggregation | undefined
+  bucket_sort?: AggregationsBucketSortAggregation | undefined
+  bucket_count_ks_test?: AggregationsBucketKsAggregation | undefined
+  bucket_correlation?: AggregationsBucketCorrelationAggregation | undefined
+  cardinality?: AggregationsCardinalityAggregation | undefined
+  cartesian_bounds?: AggregationsCartesianBoundsAggregation | undefined
+  cartesian_centroid?: AggregationsCartesianCentroidAggregation | undefined
+  categorize_text?: AggregationsCategorizeTextAggregation | undefined
+  change_point?: AggregationsChangePointAggregation | undefined
+  children?: AggregationsChildrenAggregation | undefined
+  composite?: AggregationsCompositeAggregation | undefined
+  cumulative_cardinality?: AggregationsCumulativeCardinalityAggregation | undefined
+  cumulative_sum?: AggregationsCumulativeSumAggregation | undefined
+  date_histogram?: AggregationsDateHistogramAggregation | undefined
+  date_range?: AggregationsDateRangeAggregation | undefined
+  derivative?: AggregationsDerivativeAggregation | undefined
+  diversified_sampler?: AggregationsDiversifiedSamplerAggregation | undefined
+  extended_stats?: AggregationsExtendedStatsAggregation | undefined
+  extended_stats_bucket?: AggregationsExtendedStatsBucketAggregation | undefined
+  frequent_item_sets?: AggregationsFrequentItemSetsAggregation | undefined
+  filter?: QueryDslQueryContainer | undefined
+  filters?: AggregationsFiltersAggregation | undefined
+  geo_bounds?: AggregationsGeoBoundsAggregation | undefined
+  geo_centroid?: AggregationsGeoCentroidAggregation | undefined
+  geo_distance?: AggregationsGeoDistanceAggregation | undefined
+  geohash_grid?: AggregationsGeoHashGridAggregation | undefined
+  geo_line?: AggregationsGeoLineAggregation | undefined
+  geotile_grid?: AggregationsGeoTileGridAggregation | undefined
+  geohex_grid?: AggregationsGeohexGridAggregation | undefined
+  global?: AggregationsGlobalAggregation | undefined
+  histogram?: AggregationsHistogramAggregation | undefined
+  ip_range?: AggregationsIpRangeAggregation | undefined
+  ip_prefix?: AggregationsIpPrefixAggregation | undefined
+  inference?: AggregationsInferenceAggregation | undefined
+  line?: AggregationsGeoLineAggregation | undefined
+  matrix_stats?: AggregationsMatrixStatsAggregation | undefined
+  max?: AggregationsMaxAggregation | undefined
+  max_bucket?: AggregationsMaxBucketAggregation | undefined
+  median_absolute_deviation?: AggregationsMedianAbsoluteDeviationAggregation | undefined
+  min?: AggregationsMinAggregation | undefined
+  min_bucket?: AggregationsMinBucketAggregation | undefined
+  missing?: AggregationsMissingAggregation | undefined
+  moving_avg?: AggregationsMovingAverageAggregation | undefined
+  moving_percentiles?: AggregationsMovingPercentilesAggregation | undefined
+  moving_fn?: AggregationsMovingFunctionAggregation | undefined
+  multi_terms?: AggregationsMultiTermsAggregation | undefined
+  nested?: AggregationsNestedAggregation | undefined
+  normalize?: AggregationsNormalizeAggregation | undefined
+  parent?: AggregationsParentAggregation | undefined
+  percentile_ranks?: AggregationsPercentileRanksAggregation | undefined
+  percentiles?: AggregationsPercentilesAggregation | undefined
+  percentiles_bucket?: AggregationsPercentilesBucketAggregation | undefined
+  range?: AggregationsRangeAggregation | undefined
+  rare_terms?: AggregationsRareTermsAggregation | undefined
+  rate?: AggregationsRateAggregation | undefined
+  reverse_nested?: AggregationsReverseNestedAggregation | undefined
+  sampler?: AggregationsSamplerAggregation | undefined
+  scripted_metric?: AggregationsScriptedMetricAggregation | undefined
+  serial_diff?: AggregationsSerialDifferencingAggregation | undefined
+  significant_terms?: AggregationsSignificantTermsAggregation | undefined
+  significant_text?: AggregationsSignificantTextAggregation | undefined
+  stats?: AggregationsStatsAggregation | undefined
+  stats_bucket?: AggregationsStatsBucketAggregation | undefined
+  string_stats?: AggregationsStringStatsAggregation | undefined
+  sum?: AggregationsSumAggregation | undefined
+  sum_bucket?: AggregationsSumBucketAggregation | undefined
+  terms?: AggregationsTermsAggregation | undefined
+  time_series?: AggregationsTimeSeriesAggregation | undefined
+  top_hits?: AggregationsTopHitsAggregation | undefined
+  t_test?: AggregationsTTestAggregation | undefined
+  top_metrics?: AggregationsTopMetricsAggregation | undefined
+  value_count?: AggregationsValueCountAggregation | undefined
+  weighted_avg?: AggregationsWeightedAverageAggregation | undefined
+  variable_width_histogram?: AggregationsVariableWidthHistogramAggregation | undefined
+}
+export const AggregationsAggregationContainer: z.ZodType<AggregationsAggregationContainerShape> = AggregationsAggregationContainerCommonProps.and(AggregationsAggregationContainerExclusiveProps).meta({ id: 'AggregationsAggregationContainer' })
+export type AggregationsAggregationContainer = z.infer<typeof AggregationsAggregationContainer>
+
+/**
+ * Number of hits matching the query to count accurately. If true, the exact
+ * number of hits is returned at the cost of some performance. If false, the
+ * response does not include the total number of hits matching the query.
+ * Defaults to 10,000 hits.
+ */
+export const SearchTrackHits = z.union([z.boolean(), integer]).meta({ id: 'SearchTrackHits' })
+export type SearchTrackHits = z.infer<typeof SearchTrackHits>
+
+export interface KnnSearchShape {
+  field: Field
+  query_vector?: QueryVector | undefined
+  query_vector_builder?: QueryVectorBuilder | undefined
+  k?: integer | undefined
+  num_candidates?: integer | undefined
+  visit_percentage?: float | undefined
+  boost?: float | undefined
+  filter?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+  similarity?: float | undefined
+  inner_hits?: SearchInnerHitsShape | undefined
+  rescore_vector?: RescoreVector | undefined
+  query_name?: string | undefined
+}
+export const KnnSearch = z.object({
+  field: Field.describe('The name of the vector field to search against'),
+  query_vector: QueryVector.describe('The query vector').optional(),
+  query_vector_builder: QueryVectorBuilder.describe('The query vector builder. You must provide a query_vector_builder or query_vector, but not both.').optional(),
+  k: integer.describe('The final number of nearest neighbors to return as top hits').optional(),
+  num_candidates: integer.describe('The number of nearest neighbor candidates to consider per shard').optional(),
+  visit_percentage: float.describe('The percentage of vectors to explore per shard while doing knn search with bbq_disk').optional(),
+  boost: float.describe('Boost value to apply to kNN scores').optional(),
+  get filter (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('Filters for the kNN search query').optional() },
+  similarity: float.describe('The minimum similarity for a vector to be considered a match').optional(),
+  get inner_hits () { return SearchInnerHits.describe('If defined, each search hit will contain inner hits.').optional() },
+  rescore_vector: RescoreVector.describe('Apply oversampling and rescoring to quantized vectors').optional(),
+  query_name: z.string().optional()
+}).meta({ id: 'KnnSearch' })
+export type KnnSearch = z.infer<typeof KnnSearch>
+
+export const SearchScoreMode = z.enum(['avg', 'max', 'min', 'multiply', 'total']).meta({ id: 'SearchScoreMode' })
+export type SearchScoreMode = z.infer<typeof SearchScoreMode>
+
+export interface SearchRescoreQueryShape {
+  Query: QueryDslQueryContainerShape
+  query_weight?: double | undefined
+  rescore_query_weight?: double | undefined
+  score_mode?: SearchScoreMode | undefined
+}
+export const SearchRescoreQuery = z.object({
+  get Query () { return QueryDslQueryContainer.describe('The query to use for rescoring. This query is only run on the Top-K results returned by the `query` and `post_filter` phases.') },
+  query_weight: double.describe('Relative importance of the original query versus the rescore query.').optional(),
+  rescore_query_weight: double.describe('Relative importance of the rescore query versus the original query.').optional(),
+  score_mode: SearchScoreMode.describe('Determines how scores are combined.').optional()
+}).meta({ id: 'SearchRescoreQuery' })
+export type SearchRescoreQuery = z.infer<typeof SearchRescoreQuery>
+
+export const SearchLearningToRank = z.object({
+  model_id: z.string().describe('The unique identifier of the trained model uploaded to Elasticsearch'),
+  params: z.record(z.string(), z.any()).describe('Named parameters to be passed to the query templates used for feature').optional()
+}).meta({ id: 'SearchLearningToRank' })
+export type SearchLearningToRank = z.infer<typeof SearchLearningToRank>
+
+export interface SearchScriptRescoreShape {
+  script: ScriptShape
+}
+export const SearchScriptRescore = z.object({
+  get script () { return z.union([Script, ScriptSource]) }
+}).meta({ id: 'SearchScriptRescore' })
+export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
+
+const SearchRescoreCommonProps = z.object({
+  window_size: integer.optional()
+})
+
+const SearchRescoreExclusiveProps = z.union([z.object({ query: z.lazy(() => SearchRescoreQuery) }), z.object({ learning_to_rank: SearchLearningToRank }), z.object({ script: z.lazy(() => SearchScriptRescore) })])
+
+export interface SearchRescoreShape {
+  window_size?: integer | undefined
+  query?: SearchRescoreQuery | undefined
+  learning_to_rank?: SearchLearningToRank | undefined
+  script?: SearchScriptRescore | undefined
+}
+export const SearchRescore: z.ZodType<SearchRescoreShape> = SearchRescoreCommonProps.and(SearchRescoreExclusiveProps).meta({ id: 'SearchRescore' })
+export type SearchRescore = z.infer<typeof SearchRescore>
+
+export interface RetrieverBaseShape {
+  filter?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+  min_score?: float | undefined
+  _name?: string | undefined
+}
+export const RetrieverBase = z.object({
+  get filter (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('Query to filter the documents that can match.').optional() },
+  min_score: float.describe('Minimum _score for matching documents. Documents with a lower _score are not included in the top documents.').optional(),
+  _name: z.string().describe('Retriever name.').optional()
+}).meta({ id: 'RetrieverBase' })
+export type RetrieverBase = z.infer<typeof RetrieverBase>
+
+export interface StandardRetrieverShape {
+  filter?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+  min_score?: float | undefined
+  _name?: string | undefined
+  query?: QueryDslQueryContainerShape | undefined
+  search_after?: SortResults | undefined
+  terminate_after?: integer | undefined
+  sort?: SortShape | undefined
+  collapse?: SearchFieldCollapseShape | undefined
+}
+export const StandardRetriever = z.object({
+  get filter (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('Query to filter the documents that can match.').optional() },
+  min_score: float.describe('Minimum _score for matching documents. Documents with a lower _score are not included in the top documents.').optional(),
+  _name: z.string().describe('Retriever name.').optional(),
+  get query () { return QueryDslQueryContainer.describe('Defines a query to retrieve a set of top documents.').optional() },
+  search_after: SortResults.describe('Defines a search after object parameter used for pagination.').optional(),
+  terminate_after: integer.describe('Maximum number of documents to collect for each shard.').optional(),
+  get sort () { return Sort.describe('A sort object that that specifies the order of matching documents.').optional() },
+  get collapse () { return SearchFieldCollapse.describe('Collapses the top documents by a specified key into a single top document per key.').optional() }
+}).meta({ id: 'StandardRetriever' })
+export type StandardRetriever = z.infer<typeof StandardRetriever>
+
+export interface KnnRetrieverShape {
+  filter?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+  min_score?: float | undefined
+  _name?: string | undefined
+  field: string
+  query_vector?: QueryVector | undefined
+  query_vector_builder?: QueryVectorBuilder | undefined
+  k: integer
+  num_candidates: integer
+  visit_percentage?: float | undefined
+  similarity?: float | undefined
+  rescore_vector?: RescoreVector | undefined
+}
+export const KnnRetriever = z.object({
+  get filter (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('Query to filter the documents that can match.').optional() },
+  min_score: float.describe('Minimum _score for matching documents. Documents with a lower _score are not included in the top documents.').optional(),
+  _name: z.string().describe('Retriever name.').optional(),
+  field: z.string().describe('The name of the vector field to search against.'),
+  query_vector: QueryVector.describe('Query vector. Must have the same number of dimensions as the vector field you are searching against. You must provide a query_vector_builder or query_vector, but not both.').optional(),
+  query_vector_builder: QueryVectorBuilder.describe('Defines a model to build a query vector.').optional(),
+  k: integer.describe('Number of nearest neighbors to return as top hits.'),
+  num_candidates: integer.describe('Number of nearest neighbor candidates to consider per shard.'),
+  visit_percentage: float.describe('The percentage of vectors to explore per shard while doing knn search with bbq_disk').optional(),
+  similarity: float.describe('The minimum similarity required for a document to be considered a match.').optional(),
+  rescore_vector: RescoreVector.describe('Apply oversampling and rescoring to quantized vectors').optional()
+}).meta({ id: 'KnnRetriever' })
+export type KnnRetriever = z.infer<typeof KnnRetriever>
+
+export interface RRFRetrieverComponentShape {
+  retriever: RetrieverContainerShape
+  weight?: float | undefined
+}
+/** Wraps a retriever with an optional weight for RRF scoring. */
+export const RRFRetrieverComponent = z.object({
+  get retriever () { return RetrieverContainer.describe('The nested retriever configuration.') },
+  weight: float.describe('Weight multiplier for this retriever\'s contribution to the RRF score. Higher values increase influence. Defaults to 1.0 if not specified. Must be non-negative.').optional()
+}).meta({ id: 'RRFRetrieverComponent' })
+export type RRFRetrieverComponent = z.infer<typeof RRFRetrieverComponent>
+
+export type RRFRetrieverEntryShape = RetrieverContainerShape | RRFRetrieverComponentShape
+/** Either a direct RetrieverContainer (backward compatible) or an RRFRetrieverComponent with weight. */
+export const RRFRetrieverEntry: z.ZodType<RRFRetrieverEntryShape> = z.union([z.lazy(() => RetrieverContainer), z.lazy(() => RRFRetrieverComponent)]).meta({ id: 'RRFRetrieverEntry' })
+export type RRFRetrieverEntry = z.infer<typeof RRFRetrieverEntry>
+
+export interface RRFRetrieverShape {
+  filter?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+  min_score?: float | undefined
+  _name?: string | undefined
+  retrievers: RRFRetrieverEntryShape[]
+  rank_constant?: integer | undefined
+  rank_window_size?: integer | undefined
+  query?: string | undefined
+  fields?: string[] | undefined
+}
+export const RRFRetriever = z.object({
+  get filter (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('Query to filter the documents that can match.').optional() },
+  min_score: float.describe('Minimum _score for matching documents. Documents with a lower _score are not included in the top documents.').optional(),
+  _name: z.string().describe('Retriever name.').optional(),
+  get retrievers () { return RRFRetrieverEntry.array().describe('A list of child retrievers to specify which sets of returned top documents will have the RRF formula applied to them. Each retriever can optionally include a weight parameter.') },
+  rank_constant: integer.describe('This value determines how much influence documents in individual result sets per query have over the final ranked result set.').optional(),
+  rank_window_size: integer.describe('This value determines the size of the individual result sets per query.').optional(),
+  query: z.string().optional(),
+  fields: z.array(z.string()).optional()
+}).meta({ id: 'RRFRetriever' })
+export type RRFRetriever = z.infer<typeof RRFRetriever>
+
+export const MappingChunkRescorerChunkingSettings = z.object({
+  max_chunk_size: integer.describe('The maximum size of a chunk in words. This value cannot be lower than `20` (for `sentence` strategy) or `10` (for `word` strategy). This value should not exceed the window size for the associated model.'),
+  overlap: integer.describe('The number of overlapping words for chunks. It is applicable only to a `word` chunking strategy. This value cannot be higher than half the `max_chunk_size` value.').optional(),
+  sentence_overlap: integer.describe('The number of overlapping sentences for chunks. It is applicable only for a `sentence` chunking strategy. It can be either `1` or `0`.').optional(),
+  separator_group: z.string().describe('Only applicable to the `recursive` strategy and required when using it. Sets a predefined list of separators in the saved chunking settings based on the selected text type. Values can be `markdown` or `plaintext`. Using this parameter is an alternative to manually specifying a custom `separators` list.').optional(),
+  separators: z.array(z.string()).describe('Only applicable to the `recursive` strategy and required when using it. A list of strings used as possible split points when chunking text. Each string can be a plain string or a regular expression (regex) pattern. The system tries each separator in order to split the text, starting from the first item in the list. After splitting, it attempts to recombine smaller pieces into larger chunks that stay within the `max_chunk_size` limit, to reduce the total number of chunks generated.').optional(),
+  strategy: z.string().describe('The chunking strategy: `sentence`, `word`, `none` or `recursive`.  * If `strategy` is set to `recursive`, you must also specify: - `max_chunk_size` - either `separators` or`separator_group` Learn more about different chunking strategies in the linked documentation.').optional()
+}).meta({ id: 'MappingChunkRescorerChunkingSettings' })
+export type MappingChunkRescorerChunkingSettings = z.infer<typeof MappingChunkRescorerChunkingSettings>
+
+export const ChunkRescorer = z.object({
+  size: integer.describe('The number of chunks per document to evaluate for reranking.').optional(),
+  chunking_settings: MappingChunkRescorerChunkingSettings.describe('Chunking settings to apply').optional()
+}).meta({ id: 'ChunkRescorer' })
+export type ChunkRescorer = z.infer<typeof ChunkRescorer>
+
+export interface TextSimilarityRerankerShape {
+  filter?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+  min_score?: float | undefined
+  _name?: string | undefined
+  retriever: RetrieverContainerShape
+  rank_window_size?: integer | undefined
+  inference_id?: string | undefined
+  inference_text: string
+  field: string
+  chunk_rescorer?: ChunkRescorer | undefined
+}
+export const TextSimilarityReranker = z.object({
+  get filter (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('Query to filter the documents that can match.').optional() },
+  min_score: float.describe('Minimum _score for matching documents. Documents with a lower _score are not included in the top documents.').optional(),
+  _name: z.string().describe('Retriever name.').optional(),
+  get retriever () { return RetrieverContainer.describe('The nested retriever which will produce the first-level results, that will later be used for reranking.') },
+  rank_window_size: integer.describe('This value determines how many documents we will consider from the nested retriever.').optional(),
+  inference_id: z.string().describe('Unique identifier of the inference endpoint created using the inference API.').optional(),
+  inference_text: z.string().describe('The text snippet used as the basis for similarity comparison.'),
+  field: z.string().describe('The document field to be used for text similarity comparisons. This field should contain the text that will be evaluated against the inference_text.'),
+  chunk_rescorer: ChunkRescorer.describe('Whether to rescore on only the best matching chunks.').optional()
+}).meta({ id: 'TextSimilarityReranker' })
+export type TextSimilarityReranker = z.infer<typeof TextSimilarityReranker>
+
+export interface RuleRetrieverShape {
+  filter?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+  min_score?: float | undefined
+  _name?: string | undefined
+  ruleset_ids: Id | Id[]
+  match_criteria: unknown
+  retriever: RetrieverContainerShape
+  rank_window_size?: integer | undefined
+}
+export const RuleRetriever = z.object({
+  get filter (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('Query to filter the documents that can match.').optional() },
+  min_score: float.describe('Minimum _score for matching documents. Documents with a lower _score are not included in the top documents.').optional(),
+  _name: z.string().describe('Retriever name.').optional(),
+  ruleset_ids: z.union([Id, z.array(Id)]).describe('The ruleset IDs containing the rules this retriever is evaluating against.'),
+  match_criteria: z.any().describe('The match criteria that will determine if a rule in the provided rulesets should be applied.'),
+  get retriever () { return RetrieverContainer.describe('The retriever whose results rules should be applied to.') },
+  rank_window_size: integer.describe('This value determines the size of the individual result set.').optional()
+}).meta({ id: 'RuleRetriever' })
+export type RuleRetriever = z.infer<typeof RuleRetriever>
+
+export interface RescorerRetrieverShape {
+  filter?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+  min_score?: float | undefined
+  _name?: string | undefined
+  retriever: RetrieverContainerShape
+  rescore: SearchRescoreShape | SearchRescoreShape[]
+}
+export const RescorerRetriever = z.object({
+  get filter (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('Query to filter the documents that can match.').optional() },
+  min_score: float.describe('Minimum _score for matching documents. Documents with a lower _score are not included in the top documents.').optional(),
+  _name: z.string().describe('Retriever name.').optional(),
+  get retriever () { return RetrieverContainer.describe('Inner retriever.') },
+  get rescore (): z.ZodUnion<readonly [typeof SearchRescore, z.ZodArray<typeof SearchRescore>]> { return z.union([SearchRescore, SearchRescore.array()]) }
+}).meta({ id: 'RescorerRetriever' })
+export type RescorerRetriever = z.infer<typeof RescorerRetriever>
+
+export const ScoreNormalizer = z.enum(['none', 'minmax', 'l2_norm']).meta({ id: 'ScoreNormalizer' })
+export type ScoreNormalizer = z.infer<typeof ScoreNormalizer>
+
+export interface InnerRetrieverShape {
+  retriever: RetrieverContainerShape
+  weight: float
+  normalizer: ScoreNormalizer
+}
+export const InnerRetriever = z.object({
+  get retriever () { return RetrieverContainer },
+  weight: float,
+  normalizer: ScoreNormalizer
+}).meta({ id: 'InnerRetriever' })
+export type InnerRetriever = z.infer<typeof InnerRetriever>
+
+export interface LinearRetrieverShape {
+  filter?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+  min_score?: float | undefined
+  _name?: string | undefined
+  retrievers?: InnerRetrieverShape[] | undefined
+  rank_window_size?: integer | undefined
+  query?: string | undefined
+  fields?: string[] | undefined
+  normalizer?: ScoreNormalizer | undefined
+}
+export const LinearRetriever = z.object({
+  get filter (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('Query to filter the documents that can match.').optional() },
+  min_score: float.describe('Minimum _score for matching documents. Documents with a lower _score are not included in the top documents.').optional(),
+  _name: z.string().describe('Retriever name.').optional(),
+  get retrievers () { return InnerRetriever.array().describe('Inner retrievers.').optional() },
+  rank_window_size: integer.optional(),
+  query: z.string().optional(),
+  fields: z.array(z.string()).optional(),
+  normalizer: ScoreNormalizer.optional()
+}).meta({ id: 'LinearRetriever' })
+export type LinearRetriever = z.infer<typeof LinearRetriever>
+
+export const SpecifiedDocument = z.object({
+  index: IndexName.optional(),
+  id: Id
+}).meta({ id: 'SpecifiedDocument' })
+export type SpecifiedDocument = z.infer<typeof SpecifiedDocument>
+
+export interface PinnedRetrieverShape {
+  filter?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+  min_score?: float | undefined
+  _name?: string | undefined
+  retriever: RetrieverContainerShape
+  ids?: string[] | undefined
+  docs?: SpecifiedDocument[] | undefined
+  rank_window_size?: integer | undefined
+}
+export const PinnedRetriever = z.object({
+  get filter (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('Query to filter the documents that can match.').optional() },
+  min_score: float.describe('Minimum _score for matching documents. Documents with a lower _score are not included in the top documents.').optional(),
+  _name: z.string().describe('Retriever name.').optional(),
+  get retriever () { return RetrieverContainer.describe('Inner retriever.') },
+  ids: z.array(z.string()).optional(),
+  docs: z.array(SpecifiedDocument).optional(),
+  rank_window_size: integer.optional()
+}).meta({ id: 'PinnedRetriever' })
+export type PinnedRetriever = z.infer<typeof PinnedRetriever>
+
+export const DiversifyRetrieverTypes = z.enum(['mmr']).meta({ id: 'DiversifyRetrieverTypes' })
+export type DiversifyRetrieverTypes = z.infer<typeof DiversifyRetrieverTypes>
+
+export interface DiversifyRetrieverShape {
+  filter?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+  min_score?: float | undefined
+  _name?: string | undefined
+  type: DiversifyRetrieverTypes
+  field: string
+  retriever: RetrieverContainerShape
+  size?: integer | undefined
+  rank_window_size?: integer | undefined
+  query_vector?: QueryVector | undefined
+  query_vector_builder?: QueryVectorBuilder | undefined
+  lambda?: float | undefined
+}
+export const DiversifyRetriever = z.object({
+  get filter (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('Query to filter the documents that can match.').optional() },
+  min_score: float.describe('Minimum _score for matching documents. Documents with a lower _score are not included in the top documents.').optional(),
+  _name: z.string().describe('Retriever name.').optional(),
+  type: DiversifyRetrieverTypes.describe('The diversification strategy to apply.'),
+  field: z.string().describe('The document field on which to diversify results on.'),
+  get retriever () { return RetrieverContainer.describe('The nested retriever whose results will be diversified.') },
+  size: integer.describe('The number of top documents to return after diversification.').optional(),
+  rank_window_size: integer.describe('The number of top documents from the nested retriever to consider for diversification.').optional(),
+  query_vector: QueryVector.describe('The query vector used for diversification.').optional(),
+  query_vector_builder: QueryVectorBuilder.describe('a dense vector query vector builder to use instead of a static query_vector').optional(),
+  lambda: float.describe('Controls the trade-off between relevance and diversity for MMR. A value of 0.0 focuses solely on diversity, while a value of 1.0 focuses solely on relevance. Required for MMR').optional()
+}).meta({ id: 'DiversifyRetriever' })
+export type DiversifyRetriever = z.infer<typeof DiversifyRetriever>
+
+const RetrieverContainerExclusiveProps = z.union([z.object({ standard: z.lazy(() => StandardRetriever) }), z.object({ knn: z.lazy(() => KnnRetriever) }), z.object({ rrf: z.lazy(() => RRFRetriever) }), z.object({ text_similarity_reranker: z.lazy(() => TextSimilarityReranker) }), z.object({ rule: z.lazy(() => RuleRetriever) }), z.object({ rescorer: z.lazy(() => RescorerRetriever) }), z.object({ linear: z.lazy(() => LinearRetriever) }), z.object({ pinned: z.lazy(() => PinnedRetriever) }), z.object({ diversify: z.lazy(() => DiversifyRetriever) })])
+
+export interface RetrieverContainerShape {
+  standard?: StandardRetriever | undefined
+  knn?: KnnRetriever | undefined
+  rrf?: RRFRetriever | undefined
+  text_similarity_reranker?: TextSimilarityReranker | undefined
+  rule?: RuleRetriever | undefined
+  rescorer?: RescorerRetriever | undefined
+  linear?: LinearRetriever | undefined
+  pinned?: PinnedRetriever | undefined
+  diversify?: DiversifyRetriever | undefined
+}
+export const RetrieverContainer: z.ZodType<RetrieverContainerShape> = RetrieverContainerExclusiveProps.meta({ id: 'RetrieverContainer' })
+export type RetrieverContainer = z.infer<typeof RetrieverContainer>
+
+export const SlicedScroll = z.object({
+  field: Field.optional(),
+  id: Id,
+  max: integer
+}).meta({ id: 'SlicedScroll' })
+export type SlicedScroll = z.infer<typeof SlicedScroll>
+
+export const SearchSuggester = z.object({
+  text: z.string().describe('Global suggest text, to avoid repetition when the same text is used in several suggesters').optional()
+}).catchall(z.any()).meta({ id: 'SearchSuggester' })
+export type SearchSuggester = z.infer<typeof SearchSuggester>
+
+export const SearchPointInTimeReference = z.object({
+  id: Id,
+  keep_alive: Duration.optional()
+}).meta({ id: 'SearchPointInTimeReference' })
+export type SearchPointInTimeReference = z.infer<typeof SearchPointInTimeReference>
+
+export const MappingRuntimeFieldType = z.enum(['boolean', 'composite', 'date', 'double', 'geo_point', 'geo_shape', 'ip', 'keyword', 'long', 'lookup']).meta({ id: 'MappingRuntimeFieldType' })
+export type MappingRuntimeFieldType = z.infer<typeof MappingRuntimeFieldType>
+
+export const MappingCompositeSubField = z.object({
+  type: MappingRuntimeFieldType
+}).meta({ id: 'MappingCompositeSubField' })
+export type MappingCompositeSubField = z.infer<typeof MappingCompositeSubField>
+
+export const MappingRuntimeFieldFetchFields = z.object({
+  field: Field,
+  format: z.string().optional()
+}).meta({ id: 'MappingRuntimeFieldFetchFields' })
+export type MappingRuntimeFieldFetchFields = z.infer<typeof MappingRuntimeFieldFetchFields>
+
+export interface MappingRuntimeFieldShape {
+  fields?: Record<string, MappingCompositeSubField> | undefined
+  fetch_fields?: MappingRuntimeFieldFetchFields[] | undefined
+  format?: string | undefined
+  input_field?: Field | undefined
+  target_field?: Field | undefined
+  target_index?: IndexName | undefined
+  script?: ScriptShape | undefined
+  type: MappingRuntimeFieldType
+}
+export const MappingRuntimeField = z.object({
+  fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
+  format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
+  input_field: Field.describe('For type `lookup`').optional(),
+  target_field: Field.describe('For type `lookup`').optional(),
+  target_index: IndexName.describe('For type `lookup`').optional(),
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
+  type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
+}).meta({ id: 'MappingRuntimeField' })
+export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
+
+export type MappingRuntimeFieldsShape = Record<Field, MappingRuntimeFieldShape>
+export const MappingRuntimeFields: z.ZodType<MappingRuntimeFieldsShape> = z.record(Field, z.lazy(() => MappingRuntimeField)).meta({ id: 'MappingRuntimeFields' })
+export type MappingRuntimeFields = z.infer<typeof MappingRuntimeFields>
+
+export interface SearchSearchRequestBodyShape {
+  aggregations?: Record<string, AggregationsAggregationContainerShape> | undefined
+  collapse?: SearchFieldCollapseShape | undefined
+  explain?: boolean | undefined
+  ext?: Record<string, unknown> | undefined
+  from?: integer | undefined
+  highlight?: SearchHighlightShape | undefined
+  track_total_hits?: SearchTrackHits | undefined
+  indices_boost?: Array<Record<IndexName, double>> | undefined
+  docvalue_fields?: QueryDslFieldAndFormat[] | undefined
+  knn?: KnnSearchShape | KnnSearchShape[] | undefined
+  min_score?: double | undefined
+  post_filter?: QueryDslQueryContainerShape | undefined
+  profile?: boolean | undefined
+  query?: QueryDslQueryContainerShape | undefined
+  rescore?: SearchRescoreShape | SearchRescoreShape[] | undefined
+  retriever?: RetrieverContainerShape | undefined
+  script_fields?: Record<string, ScriptFieldShape> | undefined
+  search_after?: SortResults | undefined
+  size?: integer | undefined
+  slice?: SlicedScroll | undefined
+  sort?: SortShape | undefined
+  _source?: SearchSourceConfig | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
+  suggest?: SearchSuggester | undefined
+  terminate_after?: long | undefined
+  timeout?: string | undefined
+  track_scores?: boolean | undefined
+  version?: boolean | undefined
+  seq_no_primary_term?: boolean | undefined
+  stored_fields?: Fields | undefined
+  pit?: SearchPointInTimeReference | undefined
+  runtime_mappings?: MappingRuntimeFieldsShape | undefined
+  stats?: string[] | undefined
+}
+export const SearchSearchRequestBody = z.object({
+  get aggregations (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof AggregationsAggregationContainer>> { return z.record(z.string(), AggregationsAggregationContainer).describe('Defines the aggregations that are run as part of the search request.').optional() },
+  get collapse () { return SearchFieldCollapse.describe('Collapses search results the values of the specified field.').optional() },
+  explain: z.boolean().describe('If `true`, the request returns detailed information about score computation as part of a hit.').optional(),
+  ext: z.record(z.string(), z.any()).describe('Configuration of search extensions defined by Elasticsearch plugins.').optional(),
+  from: integer.describe('The starting document offset, which must be non-negative. By default, you cannot page through more than 10,000 hits using the `from` and `size` parameters. To page through more hits, use the `search_after` parameter.').optional(),
+  get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
+  track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
+  indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
+  min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
+  get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
+  profile: z.boolean().describe('Set to `true` to return detailed timing information about the execution of individual components in a search request. NOTE: This is a debugging tool and adds significant overhead to search execution.').optional(),
+  get query () { return QueryDslQueryContainer.describe('The search definition using the Query DSL.').optional() },
+  get rescore (): z.ZodOptional<z.ZodUnion<readonly [typeof SearchRescore, z.ZodArray<typeof SearchRescore>]>> { return z.union([SearchRescore, SearchRescore.array()]).describe('Can be used to improve precision by reordering just the top (for example 100 - 500) documents returned by the `query` and `post_filter` phases.').optional() },
+  get retriever () { return RetrieverContainer.describe('A retriever is a specification to describe top documents returned from a search. A retriever replaces other elements of the search API that also return top documents such as `query` and `knn`.').optional() },
+  get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Retrieve a script evaluation (based on different fields) for each hit.').optional() },
+  search_after: SortResults.describe('Used to retrieve the next page of hits using a set of sort values from the previous page.').optional(),
+  size: integer.describe('The number of hits to return, which must not be negative. By default, you cannot page through more than 10,000 hits using the `from` and `size` parameters. To page through more hits, use the `search_after` property.').optional(),
+  slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
+  get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
+  _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
+  terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
+  timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
+  track_scores: z.boolean().describe('If `true`, calculate and return document scores, even if the scores are not used for sorting.').optional(),
+  version: z.boolean().describe('If `true`, the request returns the document version as part of a hit.').optional(),
+  seq_no_primary_term: z.boolean().describe('If `true`, the request returns sequence number and primary term of the last modification of each hit.').optional(),
+  stored_fields: Fields.describe('A comma-separated list of stored fields to return as part of a hit. If no fields are specified, no stored fields are included in the response. If this field is specified, the `_source` property defaults to `false`. You can pass `_source: true` to return both source fields and stored fields in the search response.').optional(),
+  pit: SearchPointInTimeReference.describe('Limit the search to a point in time (PIT). If you provide a PIT, you cannot specify an `<index>` in the request path.').optional(),
+  get runtime_mappings () { return MappingRuntimeFields.describe('One or more runtime fields in the search request. These fields take precedence over mapped fields with the same name.').optional() },
+  stats: z.array(z.string()).describe('The stats groups to associate with the search. Each group maintains a statistics aggregation for its associated searches. You can retrieve these stats using the indices stats API.').optional()
+}).meta({ id: 'SearchSearchRequestBody' })
+export type SearchSearchRequestBody = z.infer<typeof SearchSearchRequestBody>
+
+/**
+ * Coordinator snapshot of the original search request, serialized under `profile.request` when profiling is enabled.
+ * Introduced in Elasticsearch 9.5; omitted when the cluster contains mixed-version nodes that do not serialize this metadata.
+ */
+export const SearchSearchRequestCoordinatorMetadata = z.object({
+  source: z.lazy(() => SearchSearchRequestBody).describe('Original query source from the search request (`SearchSourceBuilder` as JSON).').optional(),
+  indices: z.array(IndexName).describe('Target index expressions from the request (before index resolution).').optional()
+}).meta({ id: 'SearchSearchRequestCoordinatorMetadata' })
+export type SearchSearchRequestCoordinatorMetadata = z.infer<typeof SearchSearchRequestCoordinatorMetadata>
+
 export const SearchProfile = z.object({
-  shards: z.array(SearchShardProfile)
+  shards: z.array(SearchShardProfile),
+  request: SearchSearchRequestCoordinatorMetadata.describe('When profiling is enabled, the original query source and target indices from the coordinating request.').optional()
 }).meta({ id: 'SearchProfile' })
 export type SearchProfile = z.infer<typeof SearchProfile>
 
@@ -621,30 +4567,6 @@ export const SearchSuggestBase = z.object({
   text: z.string()
 }).meta({ id: 'SearchSuggestBase' })
 export type SearchSuggestBase = z.infer<typeof SearchSuggestBase>
-
-export const LatLonGeoLocation = z.object({
-  lat: double.describe('Latitude'),
-  lon: double.describe('Longitude')
-}).meta({ id: 'LatLonGeoLocation' })
-export type LatLonGeoLocation = z.infer<typeof LatLonGeoLocation>
-
-export const GeoHash = z.string().meta({ id: 'GeoHash' })
-export type GeoHash = z.infer<typeof GeoHash>
-
-export const GeoHashLocation = z.object({
-  geohash: GeoHash
-}).meta({ id: 'GeoHashLocation' })
-export type GeoHashLocation = z.infer<typeof GeoHashLocation>
-
-/**
- * A latitude/longitude as a 2 dimensional point. It can be represented in various ways:
- * - as a `{lat, long}` object
- * - as a geo hash value
- * - as a `[lon, lat]` array
- * - as a string in `"<lat>, <lon>"` or WKT point formats
- */
-export const GeoLocation = z.union([LatLonGeoLocation, GeoHashLocation, z.array(double), z.string()]).meta({ id: 'GeoLocation' })
-export type GeoLocation = z.infer<typeof GeoLocation>
 
 /** Text or location that we want similar documents for or a lookup to a document's field for the text. */
 export const SearchContext = z.union([z.string(), GeoLocation]).meta({ id: 'SearchContext' })

--- a/packages/es-schemas/src/search.ts
+++ b/packages/es-schemas/src/search.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -487,7 +488,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -553,7 +554,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -592,7 +593,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), Fields, SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface SearchInnerHitsShape {
@@ -606,7 +607,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -618,13 +620,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -650,6 +653,36 @@ export type SearchFieldCollapse = z.infer<typeof SearchFieldCollapse>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -664,7 +697,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -731,7 +764,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -1090,12 +1123,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -1148,7 +1181,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -1162,7 +1195,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -1203,7 +1236,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -1387,7 +1420,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -1910,7 +1943,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -1926,7 +1959,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -2089,7 +2122,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -2165,7 +2198,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -2206,7 +2239,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -2303,7 +2336,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -2314,11 +2347,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -2334,7 +2367,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -2347,7 +2380,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -2361,7 +2394,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -2407,7 +2440,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -2423,7 +2456,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -2437,7 +2470,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -2512,7 +2545,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -2527,7 +2560,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -2539,7 +2572,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -2605,7 +2638,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -2623,7 +2656,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -2642,7 +2675,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -2673,7 +2706,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -2754,7 +2787,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -2837,7 +2870,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -2889,7 +2922,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -2905,7 +2938,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -2977,7 +3010,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -2992,7 +3025,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -3098,7 +3131,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -3177,7 +3210,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -3198,7 +3231,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -3214,7 +3247,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -3329,7 +3362,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -3406,7 +3439,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -3428,7 +3461,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -3455,7 +3488,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -3487,7 +3520,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -3519,12 +3552,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -3562,7 +3595,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -3659,7 +3692,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -3678,7 +3711,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -3692,7 +3725,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -3733,7 +3766,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -3770,10 +3803,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -3794,7 +3827,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -3830,7 +3863,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -3846,7 +3879,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -3860,7 +3893,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -3873,7 +3906,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -3903,7 +3936,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -4065,7 +4098,7 @@ export const SearchRequest = z.object({
   highlight: z.lazy(() => SearchHighlight).describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional().meta({ found_in: 'body' }),
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional().meta({ found_in: 'body' }),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional().meta({ found_in: 'body' }),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional().meta({ found_in: 'body' }),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional().meta({ found_in: 'body' }),
   knn: z.union([z.lazy(() => KnnSearch), z.array(z.lazy(() => KnnSearch))]).describe('The approximate kNN search to run.').optional().meta({ found_in: 'body' }),
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results and results collected by aggregations.').optional().meta({ found_in: 'body' }),
   post_filter: z.lazy(() => QueryDslQueryContainer).describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional().meta({ found_in: 'body' }),
@@ -4079,7 +4112,7 @@ export const SearchRequest = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional().meta({ found_in: 'body' }),
   sort: z.lazy(() => Sort).describe('A comma-separated list of <field>:<direction> pairs.').optional().meta({ found_in: 'body' }),
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional().meta({ found_in: 'body' }),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional().meta({ found_in: 'body' }),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional().meta({ found_in: 'body' }),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional().meta({ found_in: 'body' }),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional().meta({ found_in: 'body' }),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional().meta({ found_in: 'body' }),
@@ -4591,8 +4624,19 @@ export const SearchShardProfile = z.object({
 }).meta({ id: 'SearchShardProfile' })
 export type SearchShardProfile = z.infer<typeof SearchShardProfile>
 
+/**
+ * Coordinator snapshot of the original search request, serialized under `profile.request` when profiling is enabled.
+ * Introduced in Elasticsearch 9.5; omitted when the cluster contains mixed-version nodes that do not serialize this metadata.
+ */
+export const SearchSearchRequestCoordinatorMetadata = z.object({
+  source: z.lazy(() => SearchSearchRequestBody).describe('Original query source from the search request (`SearchSourceBuilder` as JSON).').optional(),
+  indices: z.array(IndexName).describe('Target index expressions from the request (before index resolution).').optional()
+}).meta({ id: 'SearchSearchRequestCoordinatorMetadata' })
+export type SearchSearchRequestCoordinatorMetadata = z.infer<typeof SearchSearchRequestCoordinatorMetadata>
+
 export const SearchProfile = z.object({
-  shards: z.array(SearchShardProfile)
+  shards: z.array(SearchShardProfile),
+  request: SearchSearchRequestCoordinatorMetadata.describe('When profiling is enabled, the original query source and target indices from the coordinating request.').optional()
 }).meta({ id: 'SearchProfile' })
 export type SearchProfile = z.infer<typeof SearchProfile>
 

--- a/packages/es-schemas/src/search_application_delete.ts
+++ b/packages/es-schemas/src/search_application_delete.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/search_application_delete_behavioral_analytics.ts
+++ b/packages/es-schemas/src/search_application_delete_behavioral_analytics.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/search_application_get.ts
+++ b/packages/es-schemas/src/search_application_get.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -3962,7 +3995,7 @@ export const RequestBase = z.object({
 export type RequestBase = z.infer<typeof RequestBase>
 
 export const SearchApplicationSearchApplicationTemplate = z.object({
-  script: z.lazy(() => Script).describe('The associated mustache template.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('The associated mustache template.')
 }).meta({ id: 'SearchApplicationSearchApplicationTemplate' })
 export type SearchApplicationSearchApplicationTemplate = z.infer<typeof SearchApplicationSearchApplicationTemplate>
 

--- a/packages/es-schemas/src/search_application_get_behavioral_analytics.ts
+++ b/packages/es-schemas/src/search_application_get_behavioral_analytics.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/search_application_list.ts
+++ b/packages/es-schemas/src/search_application_list.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -3962,7 +3995,7 @@ export const RequestBase = z.object({
 export type RequestBase = z.infer<typeof RequestBase>
 
 export const SearchApplicationSearchApplicationTemplate = z.object({
-  script: z.lazy(() => Script).describe('The associated mustache template.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('The associated mustache template.')
 }).meta({ id: 'SearchApplicationSearchApplicationTemplate' })
 export type SearchApplicationSearchApplicationTemplate = z.infer<typeof SearchApplicationSearchApplicationTemplate>
 

--- a/packages/es-schemas/src/search_application_post_behavioral_analytics_event.ts
+++ b/packages/es-schemas/src/search_application_post_behavioral_analytics_event.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/search_application_put.ts
+++ b/packages/es-schemas/src/search_application_put.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -3965,7 +3998,7 @@ export const Result = z.enum(['created', 'updated', 'deleted', 'not_found', 'noo
 export type Result = z.infer<typeof Result>
 
 export const SearchApplicationSearchApplicationTemplate = z.object({
-  script: z.lazy(() => Script).describe('The associated mustache template.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('The associated mustache template.')
 }).meta({ id: 'SearchApplicationSearchApplicationTemplate' })
 export type SearchApplicationSearchApplicationTemplate = z.infer<typeof SearchApplicationSearchApplicationTemplate>
 

--- a/packages/es-schemas/src/search_application_put_behavioral_analytics.ts
+++ b/packages/es-schemas/src/search_application_put_behavioral_analytics.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/search_application_render_query.ts
+++ b/packages/es-schemas/src/search_application_render_query.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/search_application_search.ts
+++ b/packages/es-schemas/src/search_application_search.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -572,8 +573,3953 @@ export const SearchShardProfile = z.object({
 }).meta({ id: 'SearchShardProfile' })
 export type SearchShardProfile = z.infer<typeof SearchShardProfile>
 
+export const Metadata = z.record(z.string(), z.any()).meta({ id: 'Metadata' })
+export type Metadata = z.infer<typeof Metadata>
+
+export const AggregationsAggregation = z.object({
+}).meta({ id: 'AggregationsAggregation' })
+export type AggregationsAggregation = z.infer<typeof AggregationsAggregation>
+
+/** Base type for bucket aggregations. These aggregations also accept sub-aggregations. */
+export const AggregationsBucketAggregationBase = z.object({
+}).meta({ id: 'AggregationsBucketAggregationBase' })
+export type AggregationsBucketAggregationBase = z.infer<typeof AggregationsBucketAggregationBase>
+
+export const QueryDslQueryBase = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional()
+}).meta({ id: 'QueryDslQueryBase' })
+export type QueryDslQueryBase = z.infer<typeof QueryDslQueryBase>
+
+/** The minimum number of terms that should match as integer, percentage or range */
+export const MinimumShouldMatch = z.union([integer, z.string()]).meta({ id: 'MinimumShouldMatch' })
+export type MinimumShouldMatch = z.infer<typeof MinimumShouldMatch>
+
+export interface QueryDslBoolQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  filter?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+  minimum_should_match?: MinimumShouldMatch | undefined
+  must?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+  must_not?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+  should?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+}
+export const QueryDslBoolQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  get filter (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('The clause (query) must appear in matching documents. However, unlike `must`, the score of the query will be ignored.').optional() },
+  minimum_should_match: MinimumShouldMatch.describe('Specifies the number or percentage of `should` clauses returned documents must match.').optional(),
+  get must (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('The clause (query) must appear in matching documents and will contribute to the score.').optional() },
+  get must_not (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('The clause (query) must not appear in the matching documents. Because scoring is ignored, a score of `0` is returned for all documents.').optional() },
+  get should (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('The clause (query) should appear in the matching document.').optional() }
+}).meta({ id: 'QueryDslBoolQuery' })
+export type QueryDslBoolQuery = z.infer<typeof QueryDslBoolQuery>
+
+export interface QueryDslBoostingQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  negative_boost: double
+  negative: QueryDslQueryContainerShape
+  positive: QueryDslQueryContainerShape
+}
+export const QueryDslBoostingQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  negative_boost: double.describe('Floating point number between 0 and 1.0 used to decrease the relevance scores of documents matching the `negative` query.'),
+  get negative () { return QueryDslQueryContainer.describe('Query used to decrease the relevance score of matching documents.') },
+  get positive () { return QueryDslQueryContainer.describe('Any returned documents must match this query.') }
+}).meta({ id: 'QueryDslBoostingQuery' })
+export type QueryDslBoostingQuery = z.infer<typeof QueryDslBoostingQuery>
+
+export const QueryDslOperator = z.enum(['and', 'AND', 'or', 'OR']).meta({ id: 'QueryDslOperator' })
+export type QueryDslOperator = z.infer<typeof QueryDslOperator>
+
+export const QueryDslCommonTermsQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  analyzer: z.string().optional(),
+  cutoff_frequency: double.optional(),
+  high_freq_operator: QueryDslOperator.optional(),
+  low_freq_operator: QueryDslOperator.optional(),
+  minimum_should_match: MinimumShouldMatch.optional(),
+  query: z.string()
+}).meta({ id: 'QueryDslCommonTermsQuery' })
+export type QueryDslCommonTermsQuery = z.infer<typeof QueryDslCommonTermsQuery>
+
+export const QueryDslCombinedFieldsOperator = z.enum(['or', 'and']).meta({ id: 'QueryDslCombinedFieldsOperator' })
+export type QueryDslCombinedFieldsOperator = z.infer<typeof QueryDslCombinedFieldsOperator>
+
+export const QueryDslCombinedFieldsZeroTerms = z.enum(['none', 'all']).meta({ id: 'QueryDslCombinedFieldsZeroTerms' })
+export type QueryDslCombinedFieldsZeroTerms = z.infer<typeof QueryDslCombinedFieldsZeroTerms>
+
+export const QueryDslCombinedFieldsQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  fields: z.array(Field).describe('List of fields to search. Field wildcard patterns are allowed. Only `text` fields are supported, and they must all have the same search `analyzer`.'),
+  query: z.string().describe('Text to search for in the provided `fields`. The `combined_fields` query analyzes the provided text before performing a search.'),
+  auto_generate_synonyms_phrase_query: z.boolean().describe('If true, match phrase queries are automatically created for multi-term synonyms.').optional(),
+  operator: QueryDslCombinedFieldsOperator.describe('Boolean logic used to interpret text in the query value.').optional(),
+  minimum_should_match: MinimumShouldMatch.describe('Minimum number of clauses that must match for a document to be returned.').optional(),
+  zero_terms_query: QueryDslCombinedFieldsZeroTerms.describe('Indicates whether no documents are returned if the analyzer removes all tokens, such as when using a `stop` filter.').optional()
+}).meta({ id: 'QueryDslCombinedFieldsQuery' })
+export type QueryDslCombinedFieldsQuery = z.infer<typeof QueryDslCombinedFieldsQuery>
+
+export interface QueryDslConstantScoreQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  filter: QueryDslQueryContainerShape
+}
+export const QueryDslConstantScoreQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  get filter () { return QueryDslQueryContainer.describe('Filter query you wish to run. Any returned documents must match this query. Filter queries do not calculate relevance scores. To speed up performance, Elasticsearch automatically caches frequently used filter queries.') }
+}).meta({ id: 'QueryDslConstantScoreQuery' })
+export type QueryDslConstantScoreQuery = z.infer<typeof QueryDslConstantScoreQuery>
+
+export interface QueryDslDisMaxQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  queries: QueryDslQueryContainerShape[]
+  tie_breaker?: double | undefined
+}
+export const QueryDslDisMaxQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  get queries () { return QueryDslQueryContainer.array().describe('One or more query clauses. Returned documents must match one or more of these queries. If a document matches multiple queries, Elasticsearch uses the highest relevance score.') },
+  tie_breaker: double.describe('Floating point number between 0 and 1.0 used to increase the relevance scores of documents matching multiple query clauses.').optional()
+}).meta({ id: 'QueryDslDisMaxQuery' })
+export type QueryDslDisMaxQuery = z.infer<typeof QueryDslDisMaxQuery>
+
+export const QueryDslDistanceFeatureQueryBase = z.object({
+  ...QueryDslQueryBase.shape,
+  origin: z.any().describe('Date or point of origin used to calculate distances. If the `field` value is a `date` or `date_nanos` field, the `origin` value must be a date. Date Math, such as `now-1h`, is supported. If the field value is a `geo_point` field, the `origin` value must be a geopoint.'),
+  pivot: z.any().describe('Distance from the `origin` at which relevance scores receive half of the `boost` value. If the `field` value is a `date` or `date_nanos` field, the `pivot` value must be a time unit, such as `1h` or `10d`. If the `field` value is a `geo_point` field, the `pivot` value must be a distance unit, such as `1km` or `12m`.'),
+  field: Field.describe('Name of the field used to calculate distances. This field must meet the following criteria: be a `date`, `date_nanos` or `geo_point` field; have an `index` mapping parameter value of `true`, which is the default; have an `doc_values` mapping parameter value of `true`, which is the default.')
+}).meta({ id: 'QueryDslDistanceFeatureQueryBase' })
+export type QueryDslDistanceFeatureQueryBase = z.infer<typeof QueryDslDistanceFeatureQueryBase>
+
+export const QueryDslUntypedDistanceFeatureQuery = z.object({
+  ...QueryDslDistanceFeatureQueryBase.shape
+}).meta({ id: 'QueryDslUntypedDistanceFeatureQuery' })
+export type QueryDslUntypedDistanceFeatureQuery = z.infer<typeof QueryDslUntypedDistanceFeatureQuery>
+
+export const QueryDslGeoDistanceFeatureQuery = z.object({
+  ...QueryDslDistanceFeatureQueryBase.shape
+}).meta({ id: 'QueryDslGeoDistanceFeatureQuery' })
+export type QueryDslGeoDistanceFeatureQuery = z.infer<typeof QueryDslGeoDistanceFeatureQuery>
+
+export const QueryDslDateDistanceFeatureQuery = z.object({
+  ...QueryDslDistanceFeatureQueryBase.shape
+}).meta({ id: 'QueryDslDateDistanceFeatureQuery' })
+export type QueryDslDateDistanceFeatureQuery = z.infer<typeof QueryDslDateDistanceFeatureQuery>
+
+export const QueryDslDistanceFeatureQuery = z.union([QueryDslUntypedDistanceFeatureQuery, QueryDslGeoDistanceFeatureQuery, QueryDslDateDistanceFeatureQuery]).meta({ id: 'QueryDslDistanceFeatureQuery' })
+export type QueryDslDistanceFeatureQuery = z.infer<typeof QueryDslDistanceFeatureQuery>
+
+export const QueryDslExistsQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  field: Field.describe('Name of the field you wish to search.')
+}).meta({ id: 'QueryDslExistsQuery' })
+export type QueryDslExistsQuery = z.infer<typeof QueryDslExistsQuery>
+
+export const QueryDslFunctionBoostMode = z.enum(['multiply', 'replace', 'sum', 'avg', 'max', 'min']).meta({ id: 'QueryDslFunctionBoostMode' })
+export type QueryDslFunctionBoostMode = z.infer<typeof QueryDslFunctionBoostMode>
+
+export const QueryDslMultiValueMode = z.enum(['min', 'max', 'avg', 'sum']).meta({ id: 'QueryDslMultiValueMode' })
+export type QueryDslMultiValueMode = z.infer<typeof QueryDslMultiValueMode>
+
+export const QueryDslDecayFunctionBase = z.object({
+  multi_value_mode: QueryDslMultiValueMode.describe('Determines how the distance is calculated when a field used for computing the decay contains multiple values.').optional()
+}).meta({ id: 'QueryDslDecayFunctionBase' })
+export type QueryDslDecayFunctionBase = z.infer<typeof QueryDslDecayFunctionBase>
+
+export const QueryDslUntypedDecayFunction = z.object({
+  multi_value_mode: QueryDslMultiValueMode.describe('Determines how the distance is calculated when a field used for computing the decay contains multiple values.').optional()
+}).catchall(z.any()).meta({ id: 'QueryDslUntypedDecayFunction' })
+export type QueryDslUntypedDecayFunction = z.infer<typeof QueryDslUntypedDecayFunction>
+
+export const QueryDslDateDecayFunction = z.object({
+  multi_value_mode: QueryDslMultiValueMode.describe('Determines how the distance is calculated when a field used for computing the decay contains multiple values.').optional()
+}).catchall(z.any()).meta({ id: 'QueryDslDateDecayFunction' })
+export type QueryDslDateDecayFunction = z.infer<typeof QueryDslDateDecayFunction>
+
+export const QueryDslNumericDecayFunction = z.object({
+  multi_value_mode: QueryDslMultiValueMode.describe('Determines how the distance is calculated when a field used for computing the decay contains multiple values.').optional()
+}).catchall(z.any()).meta({ id: 'QueryDslNumericDecayFunction' })
+export type QueryDslNumericDecayFunction = z.infer<typeof QueryDslNumericDecayFunction>
+
+export const QueryDslGeoDecayFunction = z.object({
+  multi_value_mode: QueryDslMultiValueMode.describe('Determines how the distance is calculated when a field used for computing the decay contains multiple values.').optional()
+}).catchall(z.any()).meta({ id: 'QueryDslGeoDecayFunction' })
+export type QueryDslGeoDecayFunction = z.infer<typeof QueryDslGeoDecayFunction>
+
+export const QueryDslDecayFunction = z.union([QueryDslUntypedDecayFunction, QueryDslDateDecayFunction, QueryDslNumericDecayFunction, QueryDslGeoDecayFunction]).meta({ id: 'QueryDslDecayFunction' })
+export type QueryDslDecayFunction = z.infer<typeof QueryDslDecayFunction>
+
+export const QueryDslFieldValueFactorModifier = z.enum(['none', 'log', 'log1p', 'log2p', 'ln', 'ln1p', 'ln2p', 'square', 'sqrt', 'reciprocal']).meta({ id: 'QueryDslFieldValueFactorModifier' })
+export type QueryDslFieldValueFactorModifier = z.infer<typeof QueryDslFieldValueFactorModifier>
+
+export const QueryDslFieldValueFactorScoreFunction = z.object({
+  field: Field.describe('Field to be extracted from the document.'),
+  factor: double.describe('Optional factor to multiply the field value with.').optional(),
+  missing: double.describe('Value used if the document doesn’t have that field. The modifier and factor are still applied to it as though it were read from the document.').optional(),
+  modifier: QueryDslFieldValueFactorModifier.describe('Modifier to apply to the field value.').optional()
+}).meta({ id: 'QueryDslFieldValueFactorScoreFunction' })
+export type QueryDslFieldValueFactorScoreFunction = z.infer<typeof QueryDslFieldValueFactorScoreFunction>
+
+export const QueryDslRandomScoreFunction = z.object({
+  field: Field.optional(),
+  seed: z.union([long, z.string()]).optional()
+}).meta({ id: 'QueryDslRandomScoreFunction' })
+export type QueryDslRandomScoreFunction = z.infer<typeof QueryDslRandomScoreFunction>
+
+export type ScriptSourceShape = string | SearchSearchRequestBodyShape
+export const ScriptSource: z.ZodType<ScriptSourceShape> = z.union([z.string(), z.lazy(() => SearchSearchRequestBody)]).meta({ id: 'ScriptSource' })
+export type ScriptSource = z.infer<typeof ScriptSource>
+
+export const ScriptLanguage = z.union([z.enum(['painless', 'expression', 'mustache', 'java']), z.string()]).meta({ id: 'ScriptLanguage' })
+export type ScriptLanguage = z.infer<typeof ScriptLanguage>
+
+export interface ScriptShape {
+  source?: ScriptSourceShape | undefined
+  id?: Id | undefined
+  params?: Record<string, unknown> | undefined
+  lang?: ScriptLanguage | undefined
+  options?: Record<string, string> | undefined
+}
+export const Script = z.object({
+  get source () { return ScriptSource.describe('The script source.').optional() },
+  id: Id.describe('The `id` for a stored script.').optional(),
+  params: z.record(z.string(), z.any()).describe('Specifies any named parameters that are passed into the script as variables. Use parameters instead of hard-coded values to decrease compile time.').optional(),
+  lang: ScriptLanguage.describe('Specifies the language the script is written in.').optional(),
+  options: z.record(z.string(), z.string()).optional()
+}).meta({ id: 'Script' })
+export type Script = z.infer<typeof Script>
+
+export interface QueryDslScriptScoreFunctionShape {
+  script: ScriptShape
+}
+export const QueryDslScriptScoreFunction = z.object({
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
+}).meta({ id: 'QueryDslScriptScoreFunction' })
+export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
+
+const QueryDslFunctionScoreContainerCommonProps = z.object({
+  filter: z.lazy(() => QueryDslQueryContainer).optional(),
+  weight: double.optional()
+})
+
+const QueryDslFunctionScoreContainerExclusiveProps = z.union([z.object({ exp: QueryDslDecayFunction }), z.object({ gauss: QueryDslDecayFunction }), z.object({ linear: QueryDslDecayFunction }), z.object({ field_value_factor: QueryDslFieldValueFactorScoreFunction }), z.object({ random_score: QueryDslRandomScoreFunction }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreFunction) })])
+
+export interface QueryDslFunctionScoreContainerShape {
+  filter?: QueryDslQueryContainerShape | undefined
+  weight?: double | undefined
+  exp?: QueryDslDecayFunction | undefined
+  gauss?: QueryDslDecayFunction | undefined
+  linear?: QueryDslDecayFunction | undefined
+  field_value_factor?: QueryDslFieldValueFactorScoreFunction | undefined
+  random_score?: QueryDslRandomScoreFunction | undefined
+  script_score?: QueryDslScriptScoreFunction | undefined
+}
+export const QueryDslFunctionScoreContainer: z.ZodType<QueryDslFunctionScoreContainerShape> = QueryDslFunctionScoreContainerCommonProps.and(QueryDslFunctionScoreContainerExclusiveProps).meta({ id: 'QueryDslFunctionScoreContainer' })
+export type QueryDslFunctionScoreContainer = z.infer<typeof QueryDslFunctionScoreContainer>
+
+export const QueryDslFunctionScoreMode = z.enum(['multiply', 'sum', 'avg', 'first', 'max', 'min']).meta({ id: 'QueryDslFunctionScoreMode' })
+export type QueryDslFunctionScoreMode = z.infer<typeof QueryDslFunctionScoreMode>
+
+export interface QueryDslFunctionScoreQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  boost_mode?: QueryDslFunctionBoostMode | undefined
+  functions?: QueryDslFunctionScoreContainerShape[] | undefined
+  max_boost?: double | undefined
+  min_score?: double | undefined
+  query?: QueryDslQueryContainerShape | undefined
+  score_mode?: QueryDslFunctionScoreMode | undefined
+}
+export const QueryDslFunctionScoreQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  boost_mode: QueryDslFunctionBoostMode.describe('Defines how he newly computed score is combined with the score of the query').optional(),
+  get functions () { return QueryDslFunctionScoreContainer.array().describe('One or more functions that compute a new score for each document returned by the query.').optional() },
+  max_boost: double.describe('Restricts the new score to not exceed the provided limit.').optional(),
+  min_score: double.describe('Excludes documents that do not meet the provided score threshold.').optional(),
+  get query () { return QueryDslQueryContainer.describe('A query that determines the documents for which a new score is computed.').optional() },
+  score_mode: QueryDslFunctionScoreMode.describe('Specifies how the computed scores are combined').optional()
+}).meta({ id: 'QueryDslFunctionScoreQuery' })
+export type QueryDslFunctionScoreQuery = z.infer<typeof QueryDslFunctionScoreQuery>
+
+export const MultiTermQueryRewrite = z.string().meta({ id: 'MultiTermQueryRewrite' })
+export type MultiTermQueryRewrite = z.infer<typeof MultiTermQueryRewrite>
+
+export const Fuzziness = z.union([z.string(), integer]).meta({ id: 'Fuzziness' })
+export type Fuzziness = z.infer<typeof Fuzziness>
+
+export const QueryDslFuzzyQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  max_expansions: integer.describe('Maximum number of variations created.').optional(),
+  prefix_length: integer.describe('Number of beginning characters left unchanged when creating expansions.').optional(),
+  rewrite: MultiTermQueryRewrite.describe('Number of beginning characters left unchanged when creating expansions.').optional(),
+  transpositions: z.boolean().describe('Indicates whether edits include transpositions of two adjacent characters (for example `ab` to `ba`).').optional(),
+  fuzziness: Fuzziness.describe('Maximum edit distance allowed for matching.').optional(),
+  value: z.union([z.string(), double, z.boolean()]).describe('Term you wish to find in the provided field.')
+}).meta({ id: 'QueryDslFuzzyQuery' })
+export type QueryDslFuzzyQuery = z.infer<typeof QueryDslFuzzyQuery>
+
+export const QueryDslGeoExecution = z.enum(['memory', 'indexed']).meta({ id: 'QueryDslGeoExecution' })
+export type QueryDslGeoExecution = z.infer<typeof QueryDslGeoExecution>
+
+export const QueryDslGeoValidationMethod = z.enum(['coerce', 'ignore_malformed', 'strict']).meta({ id: 'QueryDslGeoValidationMethod' })
+export type QueryDslGeoValidationMethod = z.infer<typeof QueryDslGeoValidationMethod>
+
+export const QueryDslGeoBoundingBoxQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  type: QueryDslGeoExecution.optional(),
+  validation_method: QueryDslGeoValidationMethod.describe('Set to `IGNORE_MALFORMED` to accept geo points with invalid latitude or longitude. Set to `COERCE` to also try to infer correct latitude or longitude.').optional(),
+  ignore_unmapped: z.boolean().describe('Set to `true` to ignore an unmapped field and not match any documents for this query. Set to `false` to throw an exception if the field is not mapped.').optional()
+}).catchall(z.any()).meta({ id: 'QueryDslGeoBoundingBoxQuery' })
+export type QueryDslGeoBoundingBoxQuery = z.infer<typeof QueryDslGeoBoundingBoxQuery>
+
+export const Distance = z.string().meta({ id: 'Distance' })
+export type Distance = z.infer<typeof Distance>
+
+export const GeoDistanceType = z.enum(['arc', 'plane']).meta({ id: 'GeoDistanceType' })
+export type GeoDistanceType = z.infer<typeof GeoDistanceType>
+
+export const QueryDslGeoDistanceQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  distance: Distance.describe('The radius of the circle centred on the specified location. Points which fall into this circle are considered to be matches.'),
+  distance_type: GeoDistanceType.describe('How to compute the distance. Set to `plane` for a faster calculation that\'s inaccurate on long distances and close to the poles.').optional(),
+  validation_method: QueryDslGeoValidationMethod.describe('Set to `IGNORE_MALFORMED` to accept geo points with invalid latitude or longitude. Set to `COERCE` to also try to infer correct latitude or longitude.').optional(),
+  ignore_unmapped: z.boolean().describe('Set to `true` to ignore an unmapped field and not match any documents for this query. Set to `false` to throw an exception if the field is not mapped.').optional()
+}).catchall(z.any()).meta({ id: 'QueryDslGeoDistanceQuery' })
+export type QueryDslGeoDistanceQuery = z.infer<typeof QueryDslGeoDistanceQuery>
+
+/** A map tile reference, represented as `{zoom}/{x}/{y}` */
+export const GeoTile = z.string().meta({ id: 'GeoTile' })
+export type GeoTile = z.infer<typeof GeoTile>
+
+export const GeoHash = z.string().meta({ id: 'GeoHash' })
+export type GeoHash = z.infer<typeof GeoHash>
+
+/** A map hex cell (H3) reference */
+export const GeoHexCell = z.string().meta({ id: 'GeoHexCell' })
+export type GeoHexCell = z.infer<typeof GeoHexCell>
+
+const QueryDslGeoGridQueryExclusiveProps = z.union([z.object({ geotile: GeoTile }), z.object({ geohash: GeoHash }), z.object({ geohex: GeoHexCell })])
+
+export const QueryDslGeoGridQuery = QueryDslGeoGridQueryExclusiveProps.meta({ id: 'QueryDslGeoGridQuery' })
+export type QueryDslGeoGridQuery = z.infer<typeof QueryDslGeoGridQuery>
+
+export const QueryDslGeoPolygonQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  validation_method: QueryDslGeoValidationMethod.optional(),
+  ignore_unmapped: z.boolean().optional()
+}).catchall(z.any()).meta({ id: 'QueryDslGeoPolygonQuery' })
+export type QueryDslGeoPolygonQuery = z.infer<typeof QueryDslGeoPolygonQuery>
+
+export const QueryDslGeoShapeQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  ignore_unmapped: z.boolean().describe('Set to `true` to ignore an unmapped field and not match any documents for this query. Set to `false` to throw an exception if the field is not mapped.').optional()
+}).catchall(z.any()).meta({ id: 'QueryDslGeoShapeQuery' })
+export type QueryDslGeoShapeQuery = z.infer<typeof QueryDslGeoShapeQuery>
+
+export const Name = z.string().meta({ id: 'Name' })
+export type Name = z.infer<typeof Name>
+
+export interface SearchFieldCollapseShape {
+  field: Field
+  inner_hits?: SearchInnerHitsShape | SearchInnerHitsShape[] | undefined
+  max_concurrent_group_searches?: integer | undefined
+  collapse?: SearchFieldCollapseShape | undefined
+}
+export const SearchFieldCollapse = z.object({
+  field: Field.describe('The field to collapse the result set on'),
+  get inner_hits (): z.ZodOptional<z.ZodUnion<readonly [typeof SearchInnerHits, z.ZodArray<typeof SearchInnerHits>]>> { return z.union([SearchInnerHits, SearchInnerHits.array()]).describe('The number of inner hits and their sort order').optional() },
+  max_concurrent_group_searches: integer.describe('The number of concurrent requests allowed to retrieve the inner_hits per group').optional(),
+  get collapse () { return SearchFieldCollapse.optional() }
+}).meta({ id: 'SearchFieldCollapse' })
+export type SearchFieldCollapse = z.infer<typeof SearchFieldCollapse>
+
+/** A reference to a field with formatting instructions on how to return the value */
+export const QueryDslFieldAndFormat = z.object({
+  field: Field.describe('A wildcard pattern. The request returns values for field names matching this pattern.'),
+  format: z.string().describe('The format in which the values are returned.').optional(),
+  include_unmapped: z.boolean().optional()
+}).meta({ id: 'QueryDslFieldAndFormat' })
+export type QueryDslFieldAndFormat = z.infer<typeof QueryDslFieldAndFormat>
+
+export const SearchHighlighterType = z.union([z.enum(['plain', 'fvh', 'unified']), z.string()]).meta({ id: 'SearchHighlighterType' })
+export type SearchHighlighterType = z.infer<typeof SearchHighlighterType>
+
+export const SearchBoundaryScanner = z.enum(['chars', 'sentence', 'word']).meta({ id: 'SearchBoundaryScanner' })
+export type SearchBoundaryScanner = z.infer<typeof SearchBoundaryScanner>
+
+export const SearchHighlighterFragmenter = z.enum(['simple', 'span']).meta({ id: 'SearchHighlighterFragmenter' })
+export type SearchHighlighterFragmenter = z.infer<typeof SearchHighlighterFragmenter>
+
+export const SearchHighlighterOrder = z.enum(['score']).meta({ id: 'SearchHighlighterOrder' })
+export type SearchHighlighterOrder = z.infer<typeof SearchHighlighterOrder>
+
+export const SearchHighlighterTagsSchema = z.enum(['styled']).meta({ id: 'SearchHighlighterTagsSchema' })
+export type SearchHighlighterTagsSchema = z.infer<typeof SearchHighlighterTagsSchema>
+
+export interface SearchHighlightBaseShape {
+  type?: SearchHighlighterType | undefined
+  boundary_chars?: string | undefined
+  boundary_max_scan?: integer | undefined
+  boundary_scanner?: SearchBoundaryScanner | undefined
+  boundary_scanner_locale?: string | undefined
+  force_source?: boolean | undefined
+  fragmenter?: SearchHighlighterFragmenter | undefined
+  fragment_size?: integer | undefined
+  highlight_filter?: boolean | undefined
+  highlight_query?: QueryDslQueryContainerShape | undefined
+  max_fragment_length?: integer | undefined
+  max_analyzed_offset?: integer | undefined
+  no_match_size?: integer | undefined
+  number_of_fragments?: integer | undefined
+  options?: Record<string, unknown> | undefined
+  order?: SearchHighlighterOrder | undefined
+  phrase_limit?: integer | undefined
+  post_tags?: string[] | undefined
+  pre_tags?: string[] | undefined
+  require_field_match?: boolean | undefined
+  tags_schema?: SearchHighlighterTagsSchema | undefined
+}
+export const SearchHighlightBase = z.object({
+  type: SearchHighlighterType.optional(),
+  boundary_chars: z.string().describe('A string that contains each boundary character.').optional(),
+  boundary_max_scan: integer.describe('How far to scan for boundary characters.').optional(),
+  boundary_scanner: SearchBoundaryScanner.describe('Specifies how to break the highlighted fragments: chars, sentence, or word. Only valid for the unified and fvh highlighters. Defaults to `sentence` for the `unified` highlighter. Defaults to `chars` for the `fvh` highlighter.').optional(),
+  boundary_scanner_locale: z.string().describe('Controls which locale is used to search for sentence and word boundaries. This parameter takes a form of a language tag, for example: `"en-US"`, `"fr-FR"`, `"ja-JP"`.').optional(),
+  force_source: z.boolean().optional(),
+  fragmenter: SearchHighlighterFragmenter.describe('Specifies how text should be broken up in highlight snippets: `simple` or `span`. Only valid for the `plain` highlighter.').optional(),
+  fragment_size: integer.describe('The size of the highlighted fragment in characters.').optional(),
+  highlight_filter: z.boolean().optional(),
+  get highlight_query () { return QueryDslQueryContainer.describe('Highlight matches for a query other than the search query. This is especially useful if you use a rescore query because those are not taken into account by highlighting by default.').optional() },
+  max_fragment_length: integer.optional(),
+  max_analyzed_offset: integer.describe('If set to a non-negative value, highlighting stops at this defined maximum limit. The rest of the text is not processed, thus not highlighted and no error is returned The `max_analyzed_offset` query setting does not override the `index.highlight.max_analyzed_offset` setting, which prevails when it’s set to lower value than the query setting.').optional(),
+  no_match_size: integer.describe('The amount of text you want to return from the beginning of the field if there are no matching fragments to highlight.').optional(),
+  number_of_fragments: integer.describe('The maximum number of fragments to return. If the number of fragments is set to `0`, no fragments are returned. Instead, the entire field contents are highlighted and returned. This can be handy when you need to highlight short texts such as a title or address, but fragmentation is not required. If `number_of_fragments` is `0`, `fragment_size` is ignored.').optional(),
+  options: z.record(z.string(), z.any()).optional(),
+  order: SearchHighlighterOrder.describe('Sorts highlighted fragments by score when set to `score`. By default, fragments will be output in the order they appear in the field (order: `none`). Setting this option to `score` will output the most relevant fragments first. Each highlighter applies its own logic to compute relevancy scores.').optional(),
+  phrase_limit: integer.describe('Controls the number of matching phrases in a document that are considered. Prevents the `fvh` highlighter from analyzing too many phrases and consuming too much memory. When using `matched_fields`, `phrase_limit` phrases per matched field are considered. Raising the limit increases query time and consumes more memory. Only supported by the `fvh` highlighter.').optional(),
+  post_tags: z.array(z.string()).describe('Use in conjunction with `pre_tags` to define the HTML tags to use for the highlighted text. By default, highlighted text is wrapped in `<em>` and `</em>` tags.').optional(),
+  pre_tags: z.array(z.string()).describe('Use in conjunction with `post_tags` to define the HTML tags to use for the highlighted text. By default, highlighted text is wrapped in `<em>` and `</em>` tags.').optional(),
+  require_field_match: z.boolean().describe('By default, only fields that contains a query match are highlighted. Set to `false` to highlight all fields.').optional(),
+  tags_schema: SearchHighlighterTagsSchema.describe('Set to `styled` to use the built-in tag schema.').optional()
+}).meta({ id: 'SearchHighlightBase' })
+export type SearchHighlightBase = z.infer<typeof SearchHighlightBase>
+
+export const SearchHighlighterEncoder = z.enum(['default', 'html']).meta({ id: 'SearchHighlighterEncoder' })
+export type SearchHighlighterEncoder = z.infer<typeof SearchHighlighterEncoder>
+
+export const Fields = z.union([Field, z.array(Field)]).meta({ id: 'Fields' })
+export type Fields = z.infer<typeof Fields>
+
+export interface SearchHighlightFieldShape {
+  type?: SearchHighlighterType | undefined
+  boundary_chars?: string | undefined
+  boundary_max_scan?: integer | undefined
+  boundary_scanner?: SearchBoundaryScanner | undefined
+  boundary_scanner_locale?: string | undefined
+  force_source?: boolean | undefined
+  fragmenter?: SearchHighlighterFragmenter | undefined
+  fragment_size?: integer | undefined
+  highlight_filter?: boolean | undefined
+  highlight_query?: QueryDslQueryContainerShape | undefined
+  max_fragment_length?: integer | undefined
+  max_analyzed_offset?: integer | undefined
+  no_match_size?: integer | undefined
+  number_of_fragments?: integer | undefined
+  options?: Record<string, unknown> | undefined
+  order?: SearchHighlighterOrder | undefined
+  phrase_limit?: integer | undefined
+  post_tags?: string[] | undefined
+  pre_tags?: string[] | undefined
+  require_field_match?: boolean | undefined
+  tags_schema?: SearchHighlighterTagsSchema | undefined
+  fragment_offset?: integer | undefined
+  matched_fields?: Fields | undefined
+}
+export const SearchHighlightField = z.object({
+  type: SearchHighlighterType.optional(),
+  boundary_chars: z.string().describe('A string that contains each boundary character.').optional(),
+  boundary_max_scan: integer.describe('How far to scan for boundary characters.').optional(),
+  boundary_scanner: SearchBoundaryScanner.describe('Specifies how to break the highlighted fragments: chars, sentence, or word. Only valid for the unified and fvh highlighters. Defaults to `sentence` for the `unified` highlighter. Defaults to `chars` for the `fvh` highlighter.').optional(),
+  boundary_scanner_locale: z.string().describe('Controls which locale is used to search for sentence and word boundaries. This parameter takes a form of a language tag, for example: `"en-US"`, `"fr-FR"`, `"ja-JP"`.').optional(),
+  force_source: z.boolean().optional(),
+  fragmenter: SearchHighlighterFragmenter.describe('Specifies how text should be broken up in highlight snippets: `simple` or `span`. Only valid for the `plain` highlighter.').optional(),
+  fragment_size: integer.describe('The size of the highlighted fragment in characters.').optional(),
+  highlight_filter: z.boolean().optional(),
+  get highlight_query () { return QueryDslQueryContainer.describe('Highlight matches for a query other than the search query. This is especially useful if you use a rescore query because those are not taken into account by highlighting by default.').optional() },
+  max_fragment_length: integer.optional(),
+  max_analyzed_offset: integer.describe('If set to a non-negative value, highlighting stops at this defined maximum limit. The rest of the text is not processed, thus not highlighted and no error is returned The `max_analyzed_offset` query setting does not override the `index.highlight.max_analyzed_offset` setting, which prevails when it’s set to lower value than the query setting.').optional(),
+  no_match_size: integer.describe('The amount of text you want to return from the beginning of the field if there are no matching fragments to highlight.').optional(),
+  number_of_fragments: integer.describe('The maximum number of fragments to return. If the number of fragments is set to `0`, no fragments are returned. Instead, the entire field contents are highlighted and returned. This can be handy when you need to highlight short texts such as a title or address, but fragmentation is not required. If `number_of_fragments` is `0`, `fragment_size` is ignored.').optional(),
+  options: z.record(z.string(), z.any()).optional(),
+  order: SearchHighlighterOrder.describe('Sorts highlighted fragments by score when set to `score`. By default, fragments will be output in the order they appear in the field (order: `none`). Setting this option to `score` will output the most relevant fragments first. Each highlighter applies its own logic to compute relevancy scores.').optional(),
+  phrase_limit: integer.describe('Controls the number of matching phrases in a document that are considered. Prevents the `fvh` highlighter from analyzing too many phrases and consuming too much memory. When using `matched_fields`, `phrase_limit` phrases per matched field are considered. Raising the limit increases query time and consumes more memory. Only supported by the `fvh` highlighter.').optional(),
+  post_tags: z.array(z.string()).describe('Use in conjunction with `pre_tags` to define the HTML tags to use for the highlighted text. By default, highlighted text is wrapped in `<em>` and `</em>` tags.').optional(),
+  pre_tags: z.array(z.string()).describe('Use in conjunction with `post_tags` to define the HTML tags to use for the highlighted text. By default, highlighted text is wrapped in `<em>` and `</em>` tags.').optional(),
+  require_field_match: z.boolean().describe('By default, only fields that contains a query match are highlighted. Set to `false` to highlight all fields.').optional(),
+  tags_schema: SearchHighlighterTagsSchema.describe('Set to `styled` to use the built-in tag schema.').optional(),
+  fragment_offset: integer.optional(),
+  matched_fields: Fields.optional()
+}).meta({ id: 'SearchHighlightField' })
+export type SearchHighlightField = z.infer<typeof SearchHighlightField>
+
+export interface SearchHighlightShape {
+  type?: SearchHighlighterType | undefined
+  boundary_chars?: string | undefined
+  boundary_max_scan?: integer | undefined
+  boundary_scanner?: SearchBoundaryScanner | undefined
+  boundary_scanner_locale?: string | undefined
+  force_source?: boolean | undefined
+  fragmenter?: SearchHighlighterFragmenter | undefined
+  fragment_size?: integer | undefined
+  highlight_filter?: boolean | undefined
+  highlight_query?: QueryDslQueryContainerShape | undefined
+  max_fragment_length?: integer | undefined
+  max_analyzed_offset?: integer | undefined
+  no_match_size?: integer | undefined
+  number_of_fragments?: integer | undefined
+  options?: Record<string, unknown> | undefined
+  order?: SearchHighlighterOrder | undefined
+  phrase_limit?: integer | undefined
+  post_tags?: string[] | undefined
+  pre_tags?: string[] | undefined
+  require_field_match?: boolean | undefined
+  tags_schema?: SearchHighlighterTagsSchema | undefined
+  encoder?: SearchHighlighterEncoder | undefined
+  fields: Record<Field, SearchHighlightFieldShape> | Array<Record<Field, SearchHighlightFieldShape>>
+}
+export const SearchHighlight = z.object({
+  type: SearchHighlighterType.optional(),
+  boundary_chars: z.string().describe('A string that contains each boundary character.').optional(),
+  boundary_max_scan: integer.describe('How far to scan for boundary characters.').optional(),
+  boundary_scanner: SearchBoundaryScanner.describe('Specifies how to break the highlighted fragments: chars, sentence, or word. Only valid for the unified and fvh highlighters. Defaults to `sentence` for the `unified` highlighter. Defaults to `chars` for the `fvh` highlighter.').optional(),
+  boundary_scanner_locale: z.string().describe('Controls which locale is used to search for sentence and word boundaries. This parameter takes a form of a language tag, for example: `"en-US"`, `"fr-FR"`, `"ja-JP"`.').optional(),
+  force_source: z.boolean().optional(),
+  fragmenter: SearchHighlighterFragmenter.describe('Specifies how text should be broken up in highlight snippets: `simple` or `span`. Only valid for the `plain` highlighter.').optional(),
+  fragment_size: integer.describe('The size of the highlighted fragment in characters.').optional(),
+  highlight_filter: z.boolean().optional(),
+  get highlight_query () { return QueryDslQueryContainer.describe('Highlight matches for a query other than the search query. This is especially useful if you use a rescore query because those are not taken into account by highlighting by default.').optional() },
+  max_fragment_length: integer.optional(),
+  max_analyzed_offset: integer.describe('If set to a non-negative value, highlighting stops at this defined maximum limit. The rest of the text is not processed, thus not highlighted and no error is returned The `max_analyzed_offset` query setting does not override the `index.highlight.max_analyzed_offset` setting, which prevails when it’s set to lower value than the query setting.').optional(),
+  no_match_size: integer.describe('The amount of text you want to return from the beginning of the field if there are no matching fragments to highlight.').optional(),
+  number_of_fragments: integer.describe('The maximum number of fragments to return. If the number of fragments is set to `0`, no fragments are returned. Instead, the entire field contents are highlighted and returned. This can be handy when you need to highlight short texts such as a title or address, but fragmentation is not required. If `number_of_fragments` is `0`, `fragment_size` is ignored.').optional(),
+  options: z.record(z.string(), z.any()).optional(),
+  order: SearchHighlighterOrder.describe('Sorts highlighted fragments by score when set to `score`. By default, fragments will be output in the order they appear in the field (order: `none`). Setting this option to `score` will output the most relevant fragments first. Each highlighter applies its own logic to compute relevancy scores.').optional(),
+  phrase_limit: integer.describe('Controls the number of matching phrases in a document that are considered. Prevents the `fvh` highlighter from analyzing too many phrases and consuming too much memory. When using `matched_fields`, `phrase_limit` phrases per matched field are considered. Raising the limit increases query time and consumes more memory. Only supported by the `fvh` highlighter.').optional(),
+  post_tags: z.array(z.string()).describe('Use in conjunction with `pre_tags` to define the HTML tags to use for the highlighted text. By default, highlighted text is wrapped in `<em>` and `</em>` tags.').optional(),
+  pre_tags: z.array(z.string()).describe('Use in conjunction with `post_tags` to define the HTML tags to use for the highlighted text. By default, highlighted text is wrapped in `<em>` and `</em>` tags.').optional(),
+  require_field_match: z.boolean().describe('By default, only fields that contains a query match are highlighted. Set to `false` to highlight all fields.').optional(),
+  tags_schema: SearchHighlighterTagsSchema.describe('Set to `styled` to use the built-in tag schema.').optional(),
+  encoder: SearchHighlighterEncoder.optional(),
+  get fields (): z.ZodUnion<readonly [z.ZodRecord<typeof Field, typeof SearchHighlightField>, z.ZodArray<z.ZodRecord<typeof Field, typeof SearchHighlightField>>]> { return z.union([z.record(Field, SearchHighlightField), z.array(z.record(Field, SearchHighlightField))]) }
+}).meta({ id: 'SearchHighlight' })
+export type SearchHighlight = z.infer<typeof SearchHighlight>
+
+export interface ScriptFieldShape {
+  script: ScriptShape
+  ignore_failure?: boolean | undefined
+}
+export const ScriptField = z.object({
+  get script () { return z.union([Script, ScriptSource]) },
+  ignore_failure: z.boolean().optional()
+}).meta({ id: 'ScriptField' })
+export type ScriptField = z.infer<typeof ScriptField>
+
+export const SortOrder = z.enum(['asc', 'desc']).meta({ id: 'SortOrder' })
+export type SortOrder = z.infer<typeof SortOrder>
+
+export const ScoreSort = z.object({
+  order: SortOrder.optional()
+}).meta({ id: 'ScoreSort' })
+export type ScoreSort = z.infer<typeof ScoreSort>
+
+export const SortMode = z.enum(['min', 'max', 'sum', 'avg', 'median']).meta({ id: 'SortMode' })
+export type SortMode = z.infer<typeof SortMode>
+
+export const DistanceUnit = z.enum(['in', 'ft', 'yd', 'mi', 'nmi', 'km', 'm', 'cm', 'mm']).meta({ id: 'DistanceUnit' })
+export type DistanceUnit = z.infer<typeof DistanceUnit>
+
+export interface NestedSortValueShape {
+  filter?: QueryDslQueryContainerShape | undefined
+  max_children?: integer | undefined
+  nested?: NestedSortValueShape | undefined
+  path: Field
+}
+export const NestedSortValue = z.object({
+  get filter () { return QueryDslQueryContainer.optional() },
+  max_children: integer.optional(),
+  get nested () { return NestedSortValue.optional() },
+  path: Field
+}).meta({ id: 'NestedSortValue' })
+export type NestedSortValue = z.infer<typeof NestedSortValue>
+
+export interface GeoDistanceSortShape {
+  mode?: SortMode | undefined
+  distance_type?: GeoDistanceType | undefined
+  ignore_unmapped?: boolean | undefined
+  order?: SortOrder | undefined
+  unit?: DistanceUnit | undefined
+  nested?: NestedSortValueShape | undefined
+}
+export const GeoDistanceSort = z.looseObject({
+  mode: SortMode.optional(),
+  distance_type: GeoDistanceType.optional(),
+  ignore_unmapped: z.boolean().optional(),
+  order: SortOrder.optional(),
+  unit: DistanceUnit.optional(),
+  get nested () { return NestedSortValue.optional() }
+}).meta({ id: 'GeoDistanceSort' })
+export type GeoDistanceSort = z.infer<typeof GeoDistanceSort>
+
+export const ScriptSortType = z.enum(['string', 'number', 'version']).meta({ id: 'ScriptSortType' })
+export type ScriptSortType = z.infer<typeof ScriptSortType>
+
+export interface ScriptSortShape {
+  order?: SortOrder | undefined
+  script: ScriptShape
+  type?: ScriptSortType | undefined
+  mode?: SortMode | undefined
+  nested?: NestedSortValueShape | undefined
+}
+export const ScriptSort = z.object({
+  order: SortOrder.optional(),
+  get script () { return z.union([Script, ScriptSource]) },
+  type: ScriptSortType.optional(),
+  mode: SortMode.optional(),
+  get nested () { return NestedSortValue.optional() }
+}).meta({ id: 'ScriptSort' })
+export type ScriptSort = z.infer<typeof ScriptSort>
+
+export interface SortOptionsShape {
+  _score?: ScoreSort | undefined
+  _doc?: ScoreSort | undefined
+  _geo_distance?: GeoDistanceSortShape | undefined
+  _script?: ScriptSortShape | undefined
+}
+export const SortOptions = z.looseObject({
+  _score: ScoreSort.optional(),
+  _doc: ScoreSort.optional(),
+  get _geo_distance () { return GeoDistanceSort.optional() },
+  get _script () { return ScriptSort.optional() }
+}).meta({ id: 'SortOptions' })
+export type SortOptions = z.infer<typeof SortOptions>
+
+export type SortCombinationsShape = Field | SortOptionsShape
+export const SortCombinations: z.ZodType<SortCombinationsShape> = z.union([Field, z.lazy(() => SortOptions)]).meta({ id: 'SortCombinations' })
+export type SortCombinations = z.infer<typeof SortCombinations>
+
+export type SortShape = SortCombinationsShape | SortCombinationsShape[]
+export const Sort: z.ZodType<SortShape> = z.union([z.lazy(() => SortCombinations), z.array(z.lazy(() => SortCombinations))]).meta({ id: 'Sort' })
+export type Sort = z.infer<typeof Sort>
+
+export const SearchSourceFilter = z.object({
+  exclude_vectors: z.boolean().describe('If `true`, vector fields are excluded from the returned source. This option takes precedence over `includes`: any vector field will remain excluded even if it matches an `includes` rule.').optional(),
+  excludes: Fields.describe('A list of fields to exclude from the returned source.').optional(),
+  exclude: Fields.describe('A list of fields to exclude from the returned source.').optional(),
+  includes: Fields.describe('A list of fields to include in the returned source.').optional(),
+  include: Fields.describe('A list of fields to include in the returned source.').optional()
+}).meta({ id: 'SearchSourceFilter' })
+export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
+
+/** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
+export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
+
+export interface SearchInnerHitsShape {
+  name?: Name | undefined
+  size?: integer | undefined
+  from?: integer | undefined
+  collapse?: SearchFieldCollapseShape | undefined
+  docvalue_fields?: QueryDslFieldAndFormat[] | undefined
+  explain?: boolean | undefined
+  highlight?: SearchHighlightShape | undefined
+  ignore_unmapped?: boolean | undefined
+  script_fields?: Record<Field, ScriptFieldShape> | undefined
+  seq_no_primary_term?: boolean | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
+  sort?: SortShape | undefined
+  _source?: SearchSourceConfig | undefined
+  stored_fields?: Fields | undefined
+  track_scores?: boolean | undefined
+  version?: boolean | undefined
+}
+export const SearchInnerHits = z.object({
+  name: Name.describe('The name for the particular inner hit definition in the response. Useful when a search request contains multiple inner hits.').optional(),
+  size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
+  from: integer.describe('Inner hit starting document offset.').optional(),
+  get collapse () { return SearchFieldCollapse.optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
+  explain: z.boolean().optional(),
+  get highlight () { return SearchHighlight.optional() },
+  ignore_unmapped: z.boolean().optional(),
+  get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
+  seq_no_primary_term: z.boolean().optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
+  get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
+  _source: SearchSourceConfig.optional(),
+  stored_fields: Fields.optional(),
+  track_scores: z.boolean().optional(),
+  version: z.boolean().optional()
+}).meta({ id: 'SearchInnerHits' })
+export type SearchInnerHits = z.infer<typeof SearchInnerHits>
+
+export const QueryDslChildScoreMode = z.enum(['none', 'avg', 'sum', 'max', 'min']).meta({ id: 'QueryDslChildScoreMode' })
+export type QueryDslChildScoreMode = z.infer<typeof QueryDslChildScoreMode>
+
+export const RelationName = z.string().meta({ id: 'RelationName' })
+export type RelationName = z.infer<typeof RelationName>
+
+export interface QueryDslHasChildQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  ignore_unmapped?: boolean | undefined
+  inner_hits?: SearchInnerHitsShape | undefined
+  max_children?: integer | undefined
+  min_children?: integer | undefined
+  query: QueryDslQueryContainerShape
+  score_mode?: QueryDslChildScoreMode | undefined
+  type: RelationName
+}
+export const QueryDslHasChildQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  ignore_unmapped: z.boolean().describe('Indicates whether to ignore an unmapped `type` and not return any documents instead of an error.').optional(),
+  get inner_hits () { return SearchInnerHits.describe('If defined, each search hit will contain inner hits.').optional() },
+  max_children: integer.describe('Maximum number of child documents that match the query allowed for a returned parent document. If the parent document exceeds this limit, it is excluded from the search results.').optional(),
+  min_children: integer.describe('Minimum number of child documents that match the query required to match the query for a returned parent document. If the parent document does not meet this limit, it is excluded from the search results.').optional(),
+  get query () { return QueryDslQueryContainer.describe('Query you wish to run on child documents of the `type` field. If a child document matches the search, the query returns the parent document.') },
+  score_mode: QueryDslChildScoreMode.describe('Indicates how scores for matching child documents affect the root parent document’s relevance score.').optional(),
+  type: RelationName.describe('Name of the child relationship mapped for the `join` field.')
+}).meta({ id: 'QueryDslHasChildQuery' })
+export type QueryDslHasChildQuery = z.infer<typeof QueryDslHasChildQuery>
+
+export interface QueryDslHasParentQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  ignore_unmapped?: boolean | undefined
+  inner_hits?: SearchInnerHitsShape | undefined
+  parent_type: RelationName
+  query: QueryDslQueryContainerShape
+  score?: boolean | undefined
+}
+export const QueryDslHasParentQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  ignore_unmapped: z.boolean().describe('Indicates whether to ignore an unmapped `parent_type` and not return any documents instead of an error. You can use this parameter to query multiple indices that may not contain the `parent_type`.').optional(),
+  get inner_hits () { return SearchInnerHits.describe('If defined, each search hit will contain inner hits.').optional() },
+  parent_type: RelationName.describe('Name of the parent relationship mapped for the `join` field.'),
+  get query () { return QueryDslQueryContainer.describe('Query you wish to run on parent documents of the `parent_type` field. If a parent document matches the search, the query returns its child documents.') },
+  score: z.boolean().describe('Indicates whether the relevance score of a matching parent document is aggregated into its child documents.').optional()
+}).meta({ id: 'QueryDslHasParentQuery' })
+export type QueryDslHasParentQuery = z.infer<typeof QueryDslHasParentQuery>
+
+export const Ids = z.union([Id, z.array(Id)]).meta({ id: 'Ids' })
+export type Ids = z.infer<typeof Ids>
+
+export const QueryDslIdsQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  values: Ids.describe('An array of document IDs.').optional()
+}).meta({ id: 'QueryDslIdsQuery' })
+export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
+
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
+
+export interface QueryDslIntervalsFilterShape {
+  after?: QueryDslIntervalsContainer | undefined
+  before?: QueryDslIntervalsContainer | undefined
+  contained_by?: QueryDslIntervalsContainer | undefined
+  containing?: QueryDslIntervalsContainer | undefined
+  not_contained_by?: QueryDslIntervalsContainer | undefined
+  not_containing?: QueryDslIntervalsContainer | undefined
+  not_overlapping?: QueryDslIntervalsContainer | undefined
+  overlapping?: QueryDslIntervalsContainer | undefined
+  script?: Script | undefined
+}
+export const QueryDslIntervalsFilter: z.ZodType<QueryDslIntervalsFilterShape> = QueryDslIntervalsFilterExclusiveProps.meta({ id: 'QueryDslIntervalsFilter' })
+export type QueryDslIntervalsFilter = z.infer<typeof QueryDslIntervalsFilter>
+
+export interface QueryDslIntervalsAnyOfShape {
+  intervals: QueryDslIntervalsContainerShape[]
+  filter?: QueryDslIntervalsFilterShape | undefined
+}
+export const QueryDslIntervalsAnyOf = z.object({
+  get intervals () { return QueryDslIntervalsContainer.array().describe('An array of rules to match.') },
+  get filter () { return QueryDslIntervalsFilter.describe('Rule used to filter returned intervals.').optional() }
+}).meta({ id: 'QueryDslIntervalsAnyOf' })
+export type QueryDslIntervalsAnyOf = z.infer<typeof QueryDslIntervalsAnyOf>
+
+export const QueryDslIntervalsFuzzy = z.object({
+  analyzer: z.string().describe('Analyzer used to normalize the term.').optional(),
+  fuzziness: Fuzziness.describe('Maximum edit distance allowed for matching.').optional(),
+  prefix_length: integer.describe('Number of beginning characters left unchanged when creating expansions.').optional(),
+  term: z.string().describe('The term to match.'),
+  transpositions: z.boolean().describe('Indicates whether edits include transpositions of two adjacent characters (for example, `ab` to `ba`).').optional(),
+  use_field: Field.describe('If specified, match intervals from this field rather than the top-level field. The `term` is normalized using the search analyzer from this field, unless `analyzer` is specified separately.').optional()
+}).meta({ id: 'QueryDslIntervalsFuzzy' })
+export type QueryDslIntervalsFuzzy = z.infer<typeof QueryDslIntervalsFuzzy>
+
+export interface QueryDslIntervalsMatchShape {
+  analyzer?: string | undefined
+  max_gaps?: integer | undefined
+  ordered?: boolean | undefined
+  query: string
+  use_field?: Field | undefined
+  filter?: QueryDslIntervalsFilterShape | undefined
+}
+export const QueryDslIntervalsMatch = z.object({
+  analyzer: z.string().describe('Analyzer used to analyze terms in the query.').optional(),
+  max_gaps: integer.describe('Maximum number of positions between the matching terms. Terms further apart than this are not considered matches.').optional(),
+  ordered: z.boolean().describe('If `true`, matching terms must appear in their specified order.').optional(),
+  query: z.string().describe('Text you wish to find in the provided field.'),
+  use_field: Field.describe('If specified, match intervals from this field rather than the top-level field. The `term` is normalized using the search analyzer from this field, unless `analyzer` is specified separately.').optional(),
+  get filter () { return QueryDslIntervalsFilter.describe('An optional interval filter.').optional() }
+}).meta({ id: 'QueryDslIntervalsMatch' })
+export type QueryDslIntervalsMatch = z.infer<typeof QueryDslIntervalsMatch>
+
+export const QueryDslIntervalsPrefix = z.object({
+  analyzer: z.string().describe('Analyzer used to analyze the `prefix`.').optional(),
+  prefix: z.string().describe('Beginning characters of terms you wish to find in the top-level field.'),
+  use_field: Field.describe('If specified, match intervals from this field rather than the top-level field. The `prefix` is normalized using the search analyzer from this field, unless `analyzer` is specified separately.').optional()
+}).meta({ id: 'QueryDslIntervalsPrefix' })
+export type QueryDslIntervalsPrefix = z.infer<typeof QueryDslIntervalsPrefix>
+
+export const QueryDslIntervalsRange = z.object({
+  analyzer: z.string().describe('Analyzer used to analyze the `prefix`.').optional(),
+  gte: z.string().describe('Lower term, either gte or gt must be provided.').optional(),
+  gt: z.string().describe('Lower term, either gte or gt must be provided.').optional(),
+  lte: z.string().describe('Upper term, either lte or lt must be provided.').optional(),
+  lt: z.string().describe('Upper term, either lte or lt must be provided.').optional(),
+  use_field: Field.describe('If specified, match intervals from this field rather than the top-level field. The `prefix` is normalized using the search analyzer from this field, unless `analyzer` is specified separately.').optional()
+}).meta({ id: 'QueryDslIntervalsRange' })
+export type QueryDslIntervalsRange = z.infer<typeof QueryDslIntervalsRange>
+
+export const QueryDslIntervalsRegexp = z.object({
+  analyzer: z.string().describe('Analyzer used to analyze the `prefix`.').optional(),
+  pattern: z.string().describe('Regex pattern.'),
+  use_field: Field.describe('If specified, match intervals from this field rather than the top-level field. The `prefix` is normalized using the search analyzer from this field, unless `analyzer` is specified separately.').optional()
+}).meta({ id: 'QueryDslIntervalsRegexp' })
+export type QueryDslIntervalsRegexp = z.infer<typeof QueryDslIntervalsRegexp>
+
+export const QueryDslIntervalsWildcard = z.object({
+  analyzer: z.string().describe('Analyzer used to analyze the `pattern`. Defaults to the top-level field\'s analyzer.').optional(),
+  pattern: z.string().describe('Wildcard pattern used to find matching terms.'),
+  use_field: Field.describe('If specified, match intervals from this field rather than the top-level field. The `pattern` is normalized using the search analyzer from this field, unless `analyzer` is specified separately.').optional()
+}).meta({ id: 'QueryDslIntervalsWildcard' })
+export type QueryDslIntervalsWildcard = z.infer<typeof QueryDslIntervalsWildcard>
+
+const QueryDslIntervalsContainerExclusiveProps = z.union([z.object({ all_of: z.lazy(() => QueryDslIntervalsAllOf) }), z.object({ any_of: z.lazy(() => QueryDslIntervalsAnyOf) }), z.object({ fuzzy: QueryDslIntervalsFuzzy }), z.object({ match: z.lazy(() => QueryDslIntervalsMatch) }), z.object({ prefix: QueryDslIntervalsPrefix }), z.object({ range: QueryDslIntervalsRange }), z.object({ regexp: QueryDslIntervalsRegexp }), z.object({ wildcard: QueryDslIntervalsWildcard })])
+
+export interface QueryDslIntervalsContainerShape {
+  all_of?: QueryDslIntervalsAllOf | undefined
+  any_of?: QueryDslIntervalsAnyOf | undefined
+  fuzzy?: QueryDslIntervalsFuzzy | undefined
+  match?: QueryDslIntervalsMatch | undefined
+  prefix?: QueryDslIntervalsPrefix | undefined
+  range?: QueryDslIntervalsRange | undefined
+  regexp?: QueryDslIntervalsRegexp | undefined
+  wildcard?: QueryDslIntervalsWildcard | undefined
+}
+export const QueryDslIntervalsContainer: z.ZodType<QueryDslIntervalsContainerShape> = QueryDslIntervalsContainerExclusiveProps.meta({ id: 'QueryDslIntervalsContainer' })
+export type QueryDslIntervalsContainer = z.infer<typeof QueryDslIntervalsContainer>
+
+export interface QueryDslIntervalsAllOfShape {
+  intervals: QueryDslIntervalsContainerShape[]
+  max_gaps?: integer | undefined
+  ordered?: boolean | undefined
+  filter?: QueryDslIntervalsFilterShape | undefined
+}
+export const QueryDslIntervalsAllOf = z.object({
+  get intervals () { return QueryDslIntervalsContainer.array().describe('An array of rules to combine. All rules must produce a match in a document for the overall source to match.') },
+  max_gaps: integer.describe('Maximum number of positions between the matching terms. Intervals produced by the rules further apart than this are not considered matches.').optional(),
+  ordered: z.boolean().describe('If `true`, intervals produced by the rules should appear in the order in which they are specified.').optional(),
+  get filter () { return QueryDslIntervalsFilter.describe('Rule used to filter returned intervals.').optional() }
+}).meta({ id: 'QueryDslIntervalsAllOf' })
+export type QueryDslIntervalsAllOf = z.infer<typeof QueryDslIntervalsAllOf>
+
+const QueryDslIntervalsQueryExclusiveProps = z.union([z.object({ all_of: z.lazy(() => QueryDslIntervalsAllOf) }), z.object({ any_of: z.lazy(() => QueryDslIntervalsAnyOf) }), z.object({ fuzzy: QueryDslIntervalsFuzzy }), z.object({ match: z.lazy(() => QueryDslIntervalsMatch) }), z.object({ prefix: QueryDslIntervalsPrefix }), z.object({ range: QueryDslIntervalsRange }), z.object({ regexp: QueryDslIntervalsRegexp }), z.object({ wildcard: QueryDslIntervalsWildcard })])
+
+export interface QueryDslIntervalsQueryShape {
+  all_of?: QueryDslIntervalsAllOf | undefined
+  any_of?: QueryDslIntervalsAnyOf | undefined
+  fuzzy?: QueryDslIntervalsFuzzy | undefined
+  match?: QueryDslIntervalsMatch | undefined
+  prefix?: QueryDslIntervalsPrefix | undefined
+  range?: QueryDslIntervalsRange | undefined
+  regexp?: QueryDslIntervalsRegexp | undefined
+  wildcard?: QueryDslIntervalsWildcard | undefined
+}
+export const QueryDslIntervalsQuery: z.ZodType<QueryDslIntervalsQueryShape> = QueryDslIntervalsQueryExclusiveProps.meta({ id: 'QueryDslIntervalsQuery' })
+export type QueryDslIntervalsQuery = z.infer<typeof QueryDslIntervalsQuery>
+
+export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
+export type QueryVector = z.infer<typeof QueryVector>
+
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
+export const TextEmbedding = z.object({
+  model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
+  model_text: z.string().describe('The text to be converted into a vector by the specified model')
+}).meta({ id: 'TextEmbedding' })
+export type TextEmbedding = z.infer<typeof TextEmbedding>
+
+export const LookupQueryVectorBuilder = z.object({
+  id: z.string().describe('The ID of the document to fetch the vector from'),
+  index: z.string().describe('The name of the index to fetch the document from'),
+  path: z.string().describe('The name of the field containing the vector'),
+  routing: z.string().describe('The routing value to use when fetching the document').optional()
+}).meta({ id: 'LookupQueryVectorBuilder' })
+export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
+
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+
+export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
+export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
+
+export const RescoreVector = z.object({
+  oversample: float.describe('Applies the specified oversample factor to k on the approximate kNN search')
+}).meta({ id: 'RescoreVector' })
+export type RescoreVector = z.infer<typeof RescoreVector>
+
+export interface KnnQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  field: Field
+  query_vector?: QueryVector | undefined
+  query_vector_builder?: QueryVectorBuilder | undefined
+  num_candidates?: integer | undefined
+  visit_percentage?: float | undefined
+  k?: integer | undefined
+  filter?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+  similarity?: float | undefined
+  rescore_vector?: RescoreVector | undefined
+}
+export const KnnQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  field: Field.describe('The name of the vector field to search against'),
+  query_vector: QueryVector.describe('The query vector').optional(),
+  query_vector_builder: QueryVectorBuilder.describe('The query vector builder. You must provide a query_vector_builder or query_vector, but not both.').optional(),
+  num_candidates: integer.describe('The number of nearest neighbor candidates to consider per shard').optional(),
+  visit_percentage: float.describe('The percentage of vectors to explore per shard while doing knn search with bbq_disk').optional(),
+  k: integer.describe('The final number of nearest neighbors to return as top hits').optional(),
+  get filter (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('Filters for the kNN search query').optional() },
+  similarity: float.describe('The minimum similarity for a vector to be considered a match').optional(),
+  rescore_vector: RescoreVector.describe('Apply oversampling and rescoring to quantized vectors').optional()
+}).meta({ id: 'KnnQuery' })
+export type KnnQuery = z.infer<typeof KnnQuery>
+
+export const QueryDslZeroTermsQuery = z.enum(['all', 'none']).meta({ id: 'QueryDslZeroTermsQuery' })
+export type QueryDslZeroTermsQuery = z.infer<typeof QueryDslZeroTermsQuery>
+
+export const QueryDslMatchQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  analyzer: z.string().describe('Analyzer used to convert the text in the query value into tokens.').optional(),
+  auto_generate_synonyms_phrase_query: z.boolean().describe('If `true`, match phrase queries are automatically created for multi-term synonyms.').optional(),
+  cutoff_frequency: double.optional(),
+  fuzziness: Fuzziness.describe('Maximum edit distance allowed for matching.').optional(),
+  fuzzy_rewrite: MultiTermQueryRewrite.describe('Method used to rewrite the query.').optional(),
+  fuzzy_transpositions: z.boolean().describe('If `true`, edits for fuzzy matching include transpositions of two adjacent characters (for example, `ab` to `ba`).').optional(),
+  lenient: z.boolean().describe('If `true`, format-based errors, such as providing a text query value for a numeric field, are ignored.').optional(),
+  max_expansions: integer.describe('Maximum number of terms to which the query will expand.').optional(),
+  minimum_should_match: MinimumShouldMatch.describe('Minimum number of clauses that must match for a document to be returned.').optional(),
+  operator: QueryDslOperator.describe('Boolean logic used to interpret text in the query value.').optional(),
+  prefix_length: integer.describe('Number of beginning characters left unchanged for fuzzy matching.').optional(),
+  query: z.union([z.string(), float, z.boolean()]).describe('Text, number, boolean value or date you wish to find in the provided field.'),
+  zero_terms_query: QueryDslZeroTermsQuery.describe('Indicates whether no documents are returned if the `analyzer` removes all tokens, such as when using a `stop` filter.').optional()
+}).meta({ id: 'QueryDslMatchQuery' })
+export type QueryDslMatchQuery = z.infer<typeof QueryDslMatchQuery>
+
+export const QueryDslMatchAllQuery = z.object({
+  ...QueryDslQueryBase.shape
+}).meta({ id: 'QueryDslMatchAllQuery' })
+export type QueryDslMatchAllQuery = z.infer<typeof QueryDslMatchAllQuery>
+
+export const QueryDslMatchBoolPrefixQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  analyzer: z.string().describe('Analyzer used to convert the text in the query value into tokens.').optional(),
+  fuzziness: Fuzziness.describe('Maximum edit distance allowed for matching. Can be applied to the term subqueries constructed for all terms but the final term.').optional(),
+  fuzzy_rewrite: MultiTermQueryRewrite.describe('Method used to rewrite the query. Can be applied to the term subqueries constructed for all terms but the final term.').optional(),
+  fuzzy_transpositions: z.boolean().describe('If `true`, edits for fuzzy matching include transpositions of two adjacent characters (for example, `ab` to `ba`). Can be applied to the term subqueries constructed for all terms but the final term.').optional(),
+  max_expansions: integer.describe('Maximum number of terms to which the query will expand. Can be applied to the term subqueries constructed for all terms but the final term.').optional(),
+  minimum_should_match: MinimumShouldMatch.describe('Minimum number of clauses that must match for a document to be returned. Applied to the constructed bool query.').optional(),
+  operator: QueryDslOperator.describe('Boolean logic used to interpret text in the query value. Applied to the constructed bool query.').optional(),
+  prefix_length: integer.describe('Number of beginning characters left unchanged for fuzzy matching. Can be applied to the term subqueries constructed for all terms but the final term.').optional(),
+  query: z.string().describe('Terms you wish to find in the provided field. The last term is used in a prefix query.')
+}).meta({ id: 'QueryDslMatchBoolPrefixQuery' })
+export type QueryDslMatchBoolPrefixQuery = z.infer<typeof QueryDslMatchBoolPrefixQuery>
+
+export const QueryDslMatchNoneQuery = z.object({
+  ...QueryDslQueryBase.shape
+}).meta({ id: 'QueryDslMatchNoneQuery' })
+export type QueryDslMatchNoneQuery = z.infer<typeof QueryDslMatchNoneQuery>
+
+export const QueryDslMatchPhraseQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  analyzer: z.string().describe('Analyzer used to convert the text in the query value into tokens.').optional(),
+  query: z.string().describe('Query terms that are analyzed and turned into a phrase query.'),
+  slop: integer.describe('Maximum number of positions allowed between matching tokens.').optional(),
+  zero_terms_query: QueryDslZeroTermsQuery.describe('Indicates whether no documents are returned if the `analyzer` removes all tokens, such as when using a `stop` filter.').optional()
+}).meta({ id: 'QueryDslMatchPhraseQuery' })
+export type QueryDslMatchPhraseQuery = z.infer<typeof QueryDslMatchPhraseQuery>
+
+export const QueryDslMatchPhrasePrefixQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  analyzer: z.string().describe('Analyzer used to convert text in the query value into tokens.').optional(),
+  max_expansions: integer.describe('Maximum number of terms to which the last provided term of the query value will expand.').optional(),
+  query: z.string().describe('Text you wish to find in the provided field.'),
+  slop: integer.describe('Maximum number of positions allowed between matching tokens.').optional(),
+  zero_terms_query: QueryDslZeroTermsQuery.describe('Indicates whether no documents are returned if the analyzer removes all tokens, such as when using a `stop` filter.').optional()
+}).meta({ id: 'QueryDslMatchPhrasePrefixQuery' })
+export type QueryDslMatchPhrasePrefixQuery = z.infer<typeof QueryDslMatchPhrasePrefixQuery>
+
+/** Only to be used in query and path parameters, as the array form is actually a csv */
+export const Routing = z.union([z.string(), z.array(z.string())]).meta({ id: 'Routing' })
+export type Routing = z.infer<typeof Routing>
+
+export const VersionType = z.enum(['internal', 'external', 'external_gte']).meta({ id: 'VersionType' })
+export type VersionType = z.infer<typeof VersionType>
+
+export const QueryDslLikeDocument = z.object({
+  doc: z.any().describe('A document not present in the index.').optional(),
+  fields: z.array(Field).optional(),
+  _id: Id.describe('ID of a document.').optional(),
+  _index: IndexName.describe('Index of a document.').optional(),
+  per_field_analyzer: z.record(Field, z.string()).describe('Overrides the default analyzer.').optional(),
+  routing: Routing.optional(),
+  version: VersionNumber.optional(),
+  version_type: VersionType.optional()
+}).meta({ id: 'QueryDslLikeDocument' })
+export type QueryDslLikeDocument = z.infer<typeof QueryDslLikeDocument>
+
+/** Text that we want similar documents for or a lookup to a document's field for the text. */
+export const QueryDslLike = z.union([z.string(), QueryDslLikeDocument]).meta({ id: 'QueryDslLike' })
+export type QueryDslLike = z.infer<typeof QueryDslLike>
+
+export const AnalysisStopWordLanguage = z.enum(['_arabic_', '_armenian_', '_basque_', '_bengali_', '_brazilian_', '_bulgarian_', '_catalan_', '_cjk_', '_czech_', '_danish_', '_dutch_', '_english_', '_estonian_', '_finnish_', '_french_', '_galician_', '_german_', '_greek_', '_hindi_', '_hungarian_', '_indonesian_', '_irish_', '_italian_', '_latvian_', '_lithuanian_', '_norwegian_', '_persian_', '_portuguese_', '_romanian_', '_russian_', '_serbian_', '_sorani_', '_spanish_', '_swedish_', '_thai_', '_turkish_', '_none_']).meta({ id: 'AnalysisStopWordLanguage' })
+export type AnalysisStopWordLanguage = z.infer<typeof AnalysisStopWordLanguage>
+
+/**
+ * Language value, such as _arabic_ or _thai_. Defaults to _english_.
+ * Each language value corresponds to a predefined list of stop words in Lucene. See Stop words by language for supported language values and their stop words.
+ * Also accepts an array of stop words.
+ */
+export const AnalysisStopWords = z.union([AnalysisStopWordLanguage, z.array(z.string())]).meta({ id: 'AnalysisStopWords' })
+export type AnalysisStopWords = z.infer<typeof AnalysisStopWords>
+
+export const QueryDslMoreLikeThisQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  analyzer: z.string().describe('The analyzer that is used to analyze the free form text. Defaults to the analyzer associated with the first field in fields.').optional(),
+  boost_terms: double.describe('Each term in the formed query could be further boosted by their tf-idf score. This sets the boost factor to use when using this feature. Defaults to deactivated (0).').optional(),
+  fail_on_unsupported_field: z.boolean().describe('Controls whether the query should fail (throw an exception) if any of the specified fields are not of the supported types (`text` or `keyword`).').optional(),
+  fields: z.array(Field).describe('A list of fields to fetch and analyze the text from. Defaults to the `index.query.default_field` index setting, which has a default value of `*`.').optional(),
+  include: z.boolean().describe('Specifies whether the input documents should also be included in the search results returned.').optional(),
+  like: z.union([QueryDslLike, z.array(QueryDslLike)]).describe('Specifies free form text and/or a single or multiple documents for which you want to find similar documents.'),
+  max_doc_freq: integer.describe('The maximum document frequency above which the terms are ignored from the input document.').optional(),
+  max_query_terms: integer.describe('The maximum number of query terms that can be selected.').optional(),
+  max_word_length: integer.describe('The maximum word length above which the terms are ignored. Defaults to unbounded (`0`).').optional(),
+  min_doc_freq: integer.describe('The minimum document frequency below which the terms are ignored from the input document.').optional(),
+  minimum_should_match: MinimumShouldMatch.describe('After the disjunctive query has been formed, this parameter controls the number of terms that must match.').optional(),
+  min_term_freq: integer.describe('The minimum term frequency below which the terms are ignored from the input document.').optional(),
+  min_word_length: integer.describe('The minimum word length below which the terms are ignored.').optional(),
+  routing: z.string().optional(),
+  stop_words: AnalysisStopWords.describe('An array of stop words. Any word in this set is ignored.').optional(),
+  unlike: z.union([QueryDslLike, z.array(QueryDslLike)]).describe('Used in combination with `like` to exclude documents that match a set of terms.').optional(),
+  version: VersionNumber.optional(),
+  version_type: VersionType.optional()
+}).meta({ id: 'QueryDslMoreLikeThisQuery' })
+export type QueryDslMoreLikeThisQuery = z.infer<typeof QueryDslMoreLikeThisQuery>
+
+export const QueryDslTextQueryType = z.enum(['best_fields', 'most_fields', 'cross_fields', 'phrase', 'phrase_prefix', 'bool_prefix']).meta({ id: 'QueryDslTextQueryType' })
+export type QueryDslTextQueryType = z.infer<typeof QueryDslTextQueryType>
+
+export const QueryDslMultiMatchQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  analyzer: z.string().describe('Analyzer used to convert the text in the query value into tokens.').optional(),
+  auto_generate_synonyms_phrase_query: z.boolean().describe('If `true`, match phrase queries are automatically created for multi-term synonyms.').optional(),
+  cutoff_frequency: double.optional(),
+  fields: Fields.describe('The fields to be queried. Defaults to the `index.query.default_field` index settings, which in turn defaults to `*`.').optional(),
+  fuzziness: Fuzziness.describe('Maximum edit distance allowed for matching.').optional(),
+  fuzzy_rewrite: MultiTermQueryRewrite.describe('Method used to rewrite the query.').optional(),
+  fuzzy_transpositions: z.boolean().describe('If `true`, edits for fuzzy matching include transpositions of two adjacent characters (for example, `ab` to `ba`). Can be applied to the term subqueries constructed for all terms but the final term.').optional(),
+  lenient: z.boolean().describe('If `true`, format-based errors, such as providing a text query value for a numeric field, are ignored.').optional(),
+  max_expansions: integer.describe('Maximum number of terms to which the query will expand.').optional(),
+  minimum_should_match: MinimumShouldMatch.describe('Minimum number of clauses that must match for a document to be returned.').optional(),
+  operator: QueryDslOperator.describe('Boolean logic used to interpret text in the query value.').optional(),
+  prefix_length: integer.describe('Number of beginning characters left unchanged for fuzzy matching.').optional(),
+  query: z.string().describe('Text, number, boolean value or date you wish to find in the provided field.'),
+  slop: integer.describe('Maximum number of positions allowed between matching tokens.').optional(),
+  tie_breaker: double.describe('Determines how scores for each per-term blended query and scores across groups are combined.').optional(),
+  type: QueryDslTextQueryType.describe('How `the` multi_match query is executed internally.').optional(),
+  zero_terms_query: QueryDslZeroTermsQuery.describe('Indicates whether no documents are returned if the `analyzer` removes all tokens, such as when using a `stop` filter.').optional()
+}).meta({ id: 'QueryDslMultiMatchQuery' })
+export type QueryDslMultiMatchQuery = z.infer<typeof QueryDslMultiMatchQuery>
+
+export interface QueryDslNestedQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  ignore_unmapped?: boolean | undefined
+  inner_hits?: SearchInnerHitsShape | undefined
+  path: Field
+  query: QueryDslQueryContainerShape
+  score_mode?: QueryDslChildScoreMode | undefined
+}
+export const QueryDslNestedQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  ignore_unmapped: z.boolean().describe('Indicates whether to ignore an unmapped path and not return any documents instead of an error.').optional(),
+  get inner_hits () { return SearchInnerHits.describe('If defined, each search hit will contain inner hits.').optional() },
+  path: Field.describe('Path to the nested object you wish to search.'),
+  get query () { return QueryDslQueryContainer.describe('Query you wish to run on nested objects in the path.') },
+  score_mode: QueryDslChildScoreMode.describe('How scores for matching child objects affect the root parent document’s relevance score.').optional()
+}).meta({ id: 'QueryDslNestedQuery' })
+export type QueryDslNestedQuery = z.infer<typeof QueryDslNestedQuery>
+
+export const QueryDslParentIdQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  id: Id.describe('ID of the parent document.').optional(),
+  ignore_unmapped: z.boolean().describe('Indicates whether to ignore an unmapped `type` and not return any documents instead of an error.').optional(),
+  type: RelationName.describe('Name of the child relationship mapped for the `join` field.').optional()
+}).meta({ id: 'QueryDslParentIdQuery' })
+export type QueryDslParentIdQuery = z.infer<typeof QueryDslParentIdQuery>
+
+export const QueryDslPercolateQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  document: z.any().describe('The source of the document being percolated.').optional(),
+  documents: z.array(z.any()).describe('An array of sources of the documents being percolated.').optional(),
+  field: Field.describe('Field that holds the indexed queries. The field must use the `percolator` mapping type.'),
+  id: Id.describe('The ID of a stored document to percolate.').optional(),
+  index: IndexName.describe('The index of a stored document to percolate.').optional(),
+  name: z.string().describe('The suffix used for the `_percolator_document_slot` field when multiple `percolate` queries are specified.').optional(),
+  preference: z.string().describe('Preference used to fetch document to percolate.').optional(),
+  routing: z.string().describe('Routing used to fetch document to percolate.').optional(),
+  version: VersionNumber.describe('The expected version of a stored document to percolate.').optional()
+}).meta({ id: 'QueryDslPercolateQuery' })
+export type QueryDslPercolateQuery = z.infer<typeof QueryDslPercolateQuery>
+
+export const QueryDslPinnedDoc = z.object({
+  _id: Id.describe('The unique document ID.'),
+  _index: IndexName.describe('The index that contains the document.').optional()
+}).meta({ id: 'QueryDslPinnedDoc' })
+export type QueryDslPinnedDoc = z.infer<typeof QueryDslPinnedDoc>
+
+const QueryDslPinnedQueryCommonProps = z.object({
+  organic: z.lazy(() => QueryDslQueryContainer).describe('Any choice of query used to rank documents which will be ranked below the "pinned" documents.')
+})
+
+const QueryDslPinnedQueryExclusiveProps = z.union([z.object({ ids: z.array(Id) }), z.object({ docs: z.array(QueryDslPinnedDoc) })])
+
+export interface QueryDslPinnedQueryShape {
+  organic: QueryDslQueryContainerShape
+  ids?: Id[] | undefined
+  docs?: QueryDslPinnedDoc[] | undefined
+}
+export const QueryDslPinnedQuery: z.ZodType<QueryDslPinnedQueryShape> = QueryDslPinnedQueryCommonProps.and(QueryDslPinnedQueryExclusiveProps).meta({ id: 'QueryDslPinnedQuery' })
+export type QueryDslPinnedQuery = z.infer<typeof QueryDslPinnedQuery>
+
+export const QueryDslPrefixQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  rewrite: MultiTermQueryRewrite.describe('Method used to rewrite the query.').optional(),
+  value: z.string().describe('Beginning characters of terms you wish to find in the provided field.'),
+  case_insensitive: z.boolean().describe('Allows ASCII case insensitive matching of the value with the indexed field values when set to `true`. Default is `false` which means the case sensitivity of matching depends on the underlying field’s mapping.').optional()
+}).meta({ id: 'QueryDslPrefixQuery' })
+export type QueryDslPrefixQuery = z.infer<typeof QueryDslPrefixQuery>
+
+export const TimeZone = z.string().meta({ id: 'TimeZone' })
+export type TimeZone = z.infer<typeof TimeZone>
+
+export const QueryDslQueryStringQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  allow_leading_wildcard: z.boolean().describe('If `true`, the wildcard characters `*` and `?` are allowed as the first character of the query string.').optional(),
+  analyzer: z.string().describe('Analyzer used to convert text in the query string into tokens.').optional(),
+  analyze_wildcard: z.boolean().describe('If `true`, the query attempts to analyze wildcard terms in the query string.').optional(),
+  auto_generate_synonyms_phrase_query: z.boolean().describe('If `true`, match phrase queries are automatically created for multi-term synonyms.').optional(),
+  default_field: Field.describe('Default field to search if no field is provided in the query string. Supports wildcards (`*`). Defaults to the `index.query.default_field` index setting, which has a default value of `*`.').optional(),
+  default_operator: QueryDslOperator.describe('Default boolean logic used to interpret text in the query string if no operators are specified.').optional(),
+  enable_position_increments: z.boolean().describe('If `true`, enable position increments in queries constructed from a `query_string` search.').optional(),
+  escape: z.boolean().optional(),
+  fields: z.array(Field).describe('Array of fields to search. Supports wildcards (`*`).').optional(),
+  fuzziness: Fuzziness.describe('Maximum edit distance allowed for fuzzy matching.').optional(),
+  fuzzy_max_expansions: integer.describe('Maximum number of terms to which the query expands for fuzzy matching.').optional(),
+  fuzzy_prefix_length: integer.describe('Number of beginning characters left unchanged for fuzzy matching.').optional(),
+  fuzzy_rewrite: MultiTermQueryRewrite.describe('Method used to rewrite the query.').optional(),
+  fuzzy_transpositions: z.boolean().describe('If `true`, edits for fuzzy matching include transpositions of two adjacent characters (for example, `ab` to `ba`).').optional(),
+  lenient: z.boolean().describe('If `true`, format-based errors, such as providing a text value for a numeric field, are ignored.').optional(),
+  max_determinized_states: integer.describe('Maximum number of automaton states required for the query.').optional(),
+  minimum_should_match: MinimumShouldMatch.describe('Minimum number of clauses that must match for a document to be returned.').optional(),
+  phrase_slop: double.describe('Maximum number of positions allowed between matching tokens for phrases.').optional(),
+  query: z.string().describe('Query string you wish to parse and use for search.'),
+  quote_analyzer: z.string().describe('Analyzer used to convert quoted text in the query string into tokens. For quoted text, this parameter overrides the analyzer specified in the `analyzer` parameter.').optional(),
+  quote_field_suffix: z.string().describe('Suffix appended to quoted text in the query string. You can use this suffix to use a different analysis method for exact matches.').optional(),
+  rewrite: MultiTermQueryRewrite.describe('Method used to rewrite the query.').optional(),
+  tie_breaker: double.describe('How to combine the queries generated from the individual search terms in the resulting `dis_max` query.').optional(),
+  time_zone: TimeZone.describe('Coordinated Universal Time (UTC) offset or IANA time zone used to convert date values in the query string to UTC.').optional(),
+  type: QueryDslTextQueryType.describe('Determines how the query matches and scores documents.').optional()
+}).meta({ id: 'QueryDslQueryStringQuery' })
+export type QueryDslQueryStringQuery = z.infer<typeof QueryDslQueryStringQuery>
+
+export const QueryDslRangeRelation = z.enum(['within', 'contains', 'intersects']).meta({ id: 'QueryDslRangeRelation' })
+export type QueryDslRangeRelation = z.infer<typeof QueryDslRangeRelation>
+
+export const QueryDslRangeQueryBase = z.object({
+  ...QueryDslQueryBase.shape,
+  relation: QueryDslRangeRelation.describe('Indicates how the range query matches values for `range` fields.').optional(),
+  gt: z.any().describe('Greater than.').optional(),
+  gte: z.any().describe('Greater than or equal to.').optional(),
+  lt: z.any().describe('Less than.').optional(),
+  lte: z.any().describe('Less than or equal to.').optional()
+}).meta({ id: 'QueryDslRangeQueryBase' })
+export type QueryDslRangeQueryBase = z.infer<typeof QueryDslRangeQueryBase>
+
+export const DateFormat = z.string().meta({ id: 'DateFormat' })
+export type DateFormat = z.infer<typeof DateFormat>
+
+export const QueryDslUntypedRangeQuery = z.object({
+  ...QueryDslRangeQueryBase.shape,
+  format: DateFormat.describe('Date format used to convert `date` values in the query.').optional(),
+  time_zone: TimeZone.describe('Coordinated Universal Time (UTC) offset or IANA time zone used to convert `date` values in the query to UTC.').optional()
+}).meta({ id: 'QueryDslUntypedRangeQuery' })
+export type QueryDslUntypedRangeQuery = z.infer<typeof QueryDslUntypedRangeQuery>
+
+export const QueryDslDateRangeQuery = z.object({
+  ...QueryDslRangeQueryBase.shape,
+  format: DateFormat.describe('Date format used to convert `date` values in the query.').optional(),
+  time_zone: TimeZone.describe('Coordinated Universal Time (UTC) offset or IANA time zone used to convert `date` values in the query to UTC.').optional()
+}).meta({ id: 'QueryDslDateRangeQuery' })
+export type QueryDslDateRangeQuery = z.infer<typeof QueryDslDateRangeQuery>
+
+export const QueryDslNumberRangeQuery = z.object({
+  ...QueryDslRangeQueryBase.shape
+}).meta({ id: 'QueryDslNumberRangeQuery' })
+export type QueryDslNumberRangeQuery = z.infer<typeof QueryDslNumberRangeQuery>
+
+export const QueryDslLongNumberRangeQuery = z.object({
+  ...QueryDslRangeQueryBase.shape
+}).meta({ id: 'QueryDslLongNumberRangeQuery' })
+export type QueryDslLongNumberRangeQuery = z.infer<typeof QueryDslLongNumberRangeQuery>
+
+export const QueryDslTermRangeQuery = z.object({
+  ...QueryDslRangeQueryBase.shape
+}).meta({ id: 'QueryDslTermRangeQuery' })
+export type QueryDslTermRangeQuery = z.infer<typeof QueryDslTermRangeQuery>
+
+export const QueryDslRangeQuery = z.union([QueryDslUntypedRangeQuery, QueryDslDateRangeQuery, QueryDslNumberRangeQuery, QueryDslLongNumberRangeQuery, QueryDslTermRangeQuery]).meta({ id: 'QueryDslRangeQuery' })
+export type QueryDslRangeQuery = z.infer<typeof QueryDslRangeQuery>
+
+export const QueryDslRankFeatureFunction = z.object({
+}).meta({ id: 'QueryDslRankFeatureFunction' })
+export type QueryDslRankFeatureFunction = z.infer<typeof QueryDslRankFeatureFunction>
+
+export const QueryDslRankFeatureFunctionSaturation = z.object({
+  pivot: float.describe('Configurable pivot value so that the result will be less than 0.5.').optional()
+}).meta({ id: 'QueryDslRankFeatureFunctionSaturation' })
+export type QueryDslRankFeatureFunctionSaturation = z.infer<typeof QueryDslRankFeatureFunctionSaturation>
+
+export const QueryDslRankFeatureFunctionLogarithm = z.object({
+  scaling_factor: float.describe('Configurable scaling factor.')
+}).meta({ id: 'QueryDslRankFeatureFunctionLogarithm' })
+export type QueryDslRankFeatureFunctionLogarithm = z.infer<typeof QueryDslRankFeatureFunctionLogarithm>
+
+export const QueryDslRankFeatureFunctionLinear = z.object({
+}).meta({ id: 'QueryDslRankFeatureFunctionLinear' })
+export type QueryDslRankFeatureFunctionLinear = z.infer<typeof QueryDslRankFeatureFunctionLinear>
+
+export const QueryDslRankFeatureFunctionSigmoid = z.object({
+  pivot: float.describe('Configurable pivot value so that the result will be less than 0.5.'),
+  exponent: float.describe('Configurable Exponent.')
+}).meta({ id: 'QueryDslRankFeatureFunctionSigmoid' })
+export type QueryDslRankFeatureFunctionSigmoid = z.infer<typeof QueryDslRankFeatureFunctionSigmoid>
+
+export const QueryDslRankFeatureQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  field: Field.describe('`rank_feature` or `rank_features` field used to boost relevance scores.'),
+  saturation: QueryDslRankFeatureFunctionSaturation.describe('Saturation function used to boost relevance scores based on the value of the rank feature `field`.').optional(),
+  log: QueryDslRankFeatureFunctionLogarithm.describe('Logarithmic function used to boost relevance scores based on the value of the rank feature `field`.').optional(),
+  linear: QueryDslRankFeatureFunctionLinear.describe('Linear function used to boost relevance scores based on the value of the rank feature `field`.').optional(),
+  sigmoid: QueryDslRankFeatureFunctionSigmoid.describe('Sigmoid function used to boost relevance scores based on the value of the rank feature `field`.').optional()
+}).meta({ id: 'QueryDslRankFeatureQuery' })
+export type QueryDslRankFeatureQuery = z.infer<typeof QueryDslRankFeatureQuery>
+
+export const QueryDslRegexpQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  case_insensitive: z.boolean().describe('Allows case insensitive matching of the regular expression value with the indexed field values when set to `true`. When `false`, case sensitivity of matching depends on the underlying field’s mapping.').optional(),
+  flags: z.string().describe('Enables optional operators for the regular expression.').optional(),
+  max_determinized_states: integer.describe('Maximum number of automaton states required for the query.').optional(),
+  rewrite: MultiTermQueryRewrite.describe('Method used to rewrite the query.').optional(),
+  value: z.string().describe('Regular expression for terms you wish to find in the provided field.')
+}).meta({ id: 'QueryDslRegexpQuery' })
+export type QueryDslRegexpQuery = z.infer<typeof QueryDslRegexpQuery>
+
+export interface QueryDslRuleQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  organic: QueryDslQueryContainerShape
+  ruleset_ids?: Id | Id[] | undefined
+  ruleset_id?: string | undefined
+  match_criteria: unknown
+}
+export const QueryDslRuleQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  get organic () { return QueryDslQueryContainer },
+  ruleset_ids: z.union([Id, z.array(Id)]).optional(),
+  ruleset_id: z.string().optional(),
+  match_criteria: z.any()
+}).meta({ id: 'QueryDslRuleQuery' })
+export type QueryDslRuleQuery = z.infer<typeof QueryDslRuleQuery>
+
+export interface QueryDslScriptQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  script: ScriptShape
+}
+export const QueryDslScriptQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+}).meta({ id: 'QueryDslScriptQuery' })
+export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
+
+export interface QueryDslScriptScoreQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  min_score?: float | undefined
+  query: QueryDslQueryContainerShape
+  script: ScriptShape
+}
+export const QueryDslScriptScoreQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
+  get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+}).meta({ id: 'QueryDslScriptScoreQuery' })
+export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
+
+export const QueryDslSemanticQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  field: z.string().describe('The field to query, which must be a semantic_text field type'),
+  query: z.string().describe('The query text')
+}).meta({ id: 'QueryDslSemanticQuery' })
+export type QueryDslSemanticQuery = z.infer<typeof QueryDslSemanticQuery>
+
+export const QueryDslShapeQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  ignore_unmapped: z.boolean().describe('When set to `true` the query ignores an unmapped field and will not match any documents.').optional()
+}).catchall(z.any()).meta({ id: 'QueryDslShapeQuery' })
+export type QueryDslShapeQuery = z.infer<typeof QueryDslShapeQuery>
+
+/**
+ * A set of flags that can be represented as a single enum value or a set of values that are encoded
+ * as a pipe-separated string
+ *
+ * Depending on the target language, code generators can use this hint to generate language specific
+ * flags enum constructs and the corresponding (de-)serialization code.
+ */
+export const SpecUtilsPipeSeparatedFlags = z.union([z.any(), z.string()]).meta({ id: 'SpecUtilsPipeSeparatedFlags' })
+export type SpecUtilsPipeSeparatedFlags = z.infer<typeof SpecUtilsPipeSeparatedFlags>
+
+/** Query flags can be either a single flag or a combination of flags, e.g. `OR|AND|PREFIX` */
+export const QueryDslSimpleQueryStringFlags = SpecUtilsPipeSeparatedFlags.meta({ id: 'QueryDslSimpleQueryStringFlags' })
+export type QueryDslSimpleQueryStringFlags = z.infer<typeof QueryDslSimpleQueryStringFlags>
+
+export const QueryDslSimpleQueryStringQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  analyzer: z.string().describe('Analyzer used to convert text in the query string into tokens.').optional(),
+  analyze_wildcard: z.boolean().describe('If `true`, the query attempts to analyze wildcard terms in the query string.').optional(),
+  auto_generate_synonyms_phrase_query: z.boolean().describe('If `true`, the parser creates a match_phrase query for each multi-position token.').optional(),
+  default_operator: QueryDslOperator.describe('Default boolean logic used to interpret text in the query string if no operators are specified.').optional(),
+  fields: z.array(Field).describe('Array of fields you wish to search. Accepts wildcard expressions. You also can boost relevance scores for matches to particular fields using a caret (`^`) notation. Defaults to the `index.query.default_field index` setting, which has a default value of `*`.').optional(),
+  flags: QueryDslSimpleQueryStringFlags.describe('List of enabled operators for the simple query string syntax.').optional(),
+  fuzzy_max_expansions: integer.describe('Maximum number of terms to which the query expands for fuzzy matching.').optional(),
+  fuzzy_prefix_length: integer.describe('Number of beginning characters left unchanged for fuzzy matching.').optional(),
+  fuzzy_transpositions: z.boolean().describe('If `true`, edits for fuzzy matching include transpositions of two adjacent characters (for example, `ab` to `ba`).').optional(),
+  lenient: z.boolean().describe('If `true`, format-based errors, such as providing a text value for a numeric field, are ignored.').optional(),
+  minimum_should_match: MinimumShouldMatch.describe('Minimum number of clauses that must match for a document to be returned.').optional(),
+  query: z.string().describe('Query string in the simple query string syntax you wish to parse and use for search.'),
+  quote_field_suffix: z.string().describe('Suffix appended to quoted text in the query string.').optional()
+}).meta({ id: 'QueryDslSimpleQueryStringQuery' })
+export type QueryDslSimpleQueryStringQuery = z.infer<typeof QueryDslSimpleQueryStringQuery>
+
+export interface QueryDslSpanFieldMaskingQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  field: Field
+  query: QueryDslSpanQueryShape
+}
+export const QueryDslSpanFieldMaskingQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  field: Field,
+  get query () { return QueryDslSpanQuery }
+}).meta({ id: 'QueryDslSpanFieldMaskingQuery' })
+export type QueryDslSpanFieldMaskingQuery = z.infer<typeof QueryDslSpanFieldMaskingQuery>
+
+export interface QueryDslSpanFirstQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  end: integer
+  match: QueryDslSpanQueryShape
+}
+export const QueryDslSpanFirstQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  end: integer.describe('Controls the maximum end position permitted in a match.'),
+  get match () { return QueryDslSpanQuery.describe('Can be any other span type query.') }
+}).meta({ id: 'QueryDslSpanFirstQuery' })
+export type QueryDslSpanFirstQuery = z.infer<typeof QueryDslSpanFirstQuery>
+
+/** Can only be used as a clause in a span_near query. */
+export const QueryDslSpanGapQuery = z.record(Field, integer).meta({ id: 'QueryDslSpanGapQuery' })
+export type QueryDslSpanGapQuery = z.infer<typeof QueryDslSpanGapQuery>
+
+export interface QueryDslSpanMultiTermQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  match: QueryDslQueryContainerShape
+}
+export const QueryDslSpanMultiTermQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  get match () { return QueryDslQueryContainer.describe('Should be a multi term query (one of `wildcard`, `fuzzy`, `prefix`, `range`, or `regexp` query).') }
+}).meta({ id: 'QueryDslSpanMultiTermQuery' })
+export type QueryDslSpanMultiTermQuery = z.infer<typeof QueryDslSpanMultiTermQuery>
+
+export interface QueryDslSpanNearQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  clauses: QueryDslSpanQueryShape[]
+  in_order?: boolean | undefined
+  slop?: integer | undefined
+}
+export const QueryDslSpanNearQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  get clauses () { return QueryDslSpanQuery.array().describe('Array of one or more other span type queries.') },
+  in_order: z.boolean().describe('Controls whether matches are required to be in-order.').optional(),
+  slop: integer.describe('Controls the maximum number of intervening unmatched positions permitted.').optional()
+}).meta({ id: 'QueryDslSpanNearQuery' })
+export type QueryDslSpanNearQuery = z.infer<typeof QueryDslSpanNearQuery>
+
+export interface QueryDslSpanNotQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  dist?: integer | undefined
+  exclude: QueryDslSpanQueryShape
+  include: QueryDslSpanQueryShape
+  post?: integer | undefined
+  pre?: integer | undefined
+}
+export const QueryDslSpanNotQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  dist: integer.describe('The number of tokens from within the include span that can’t have overlap with the exclude span. Equivalent to setting both `pre` and `post`.').optional(),
+  get exclude () { return QueryDslSpanQuery.describe('Span query whose matches must not overlap those returned.') },
+  get include () { return QueryDslSpanQuery.describe('Span query whose matches are filtered.') },
+  post: integer.describe('The number of tokens after the include span that can’t have overlap with the exclude span.').optional(),
+  pre: integer.describe('The number of tokens before the include span that can’t have overlap with the exclude span.').optional()
+}).meta({ id: 'QueryDslSpanNotQuery' })
+export type QueryDslSpanNotQuery = z.infer<typeof QueryDslSpanNotQuery>
+
+export interface QueryDslSpanOrQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  clauses: QueryDslSpanQueryShape[]
+}
+export const QueryDslSpanOrQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  get clauses () { return QueryDslSpanQuery.array().describe('Array of one or more other span type queries.') }
+}).meta({ id: 'QueryDslSpanOrQuery' })
+export type QueryDslSpanOrQuery = z.infer<typeof QueryDslSpanOrQuery>
+
+export const QueryDslSpanTermQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  value: FieldValue,
+  term: FieldValue
+}).meta({ id: 'QueryDslSpanTermQuery' })
+export type QueryDslSpanTermQuery = z.infer<typeof QueryDslSpanTermQuery>
+
+export interface QueryDslSpanWithinQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  big: QueryDslSpanQueryShape
+  little: QueryDslSpanQueryShape
+}
+export const QueryDslSpanWithinQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  get big () { return QueryDslSpanQuery.describe('Can be any span query. Matching spans from `little` that are enclosed within `big` are returned.') },
+  get little () { return QueryDslSpanQuery.describe('Can be any span query. Matching spans from `little` that are enclosed within `big` are returned.') }
+}).meta({ id: 'QueryDslSpanWithinQuery' })
+export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
+
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+
+export interface QueryDslSpanQueryShape {
+  span_containing?: QueryDslSpanContainingQuery | undefined
+  span_field_masking?: QueryDslSpanFieldMaskingQuery | undefined
+  span_first?: QueryDslSpanFirstQuery | undefined
+  span_gap?: QueryDslSpanGapQuery | undefined
+  span_multi?: QueryDslSpanMultiTermQuery | undefined
+  span_near?: QueryDslSpanNearQuery | undefined
+  span_not?: QueryDslSpanNotQuery | undefined
+  span_or?: QueryDslSpanOrQuery | undefined
+  span_term?: Record<Field, QueryDslSpanTermQuery> | undefined
+  span_within?: QueryDslSpanWithinQuery | undefined
+}
+export const QueryDslSpanQuery: z.ZodType<QueryDslSpanQueryShape> = QueryDslSpanQueryExclusiveProps.meta({ id: 'QueryDslSpanQuery' })
+export type QueryDslSpanQuery = z.infer<typeof QueryDslSpanQuery>
+
+export interface QueryDslSpanContainingQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  big: QueryDslSpanQueryShape
+  little: QueryDslSpanQueryShape
+}
+export const QueryDslSpanContainingQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  get big () { return QueryDslSpanQuery.describe('Can be any span query. Matching spans from `big` that contain matches from `little` are returned.') },
+  get little () { return QueryDslSpanQuery.describe('Can be any span query. Matching spans from `big` that contain matches from `little` are returned.') }
+}).meta({ id: 'QueryDslSpanContainingQuery' })
+export type QueryDslSpanContainingQuery = z.infer<typeof QueryDslSpanContainingQuery>
+
+export const TokenPruningConfig = z.object({
+  tokens_freq_ratio_threshold: integer.describe('Tokens whose frequency is more than this threshold times the average frequency of all tokens in the specified field are considered outliers and pruned.').optional(),
+  tokens_weight_threshold: float.describe('Tokens whose weight is less than this threshold are considered nonsignificant and pruned.').optional(),
+  only_score_pruned_tokens: z.boolean().describe('Whether to only score pruned tokens, vs only scoring kept tokens.').optional()
+}).meta({ id: 'TokenPruningConfig' })
+export type TokenPruningConfig = z.infer<typeof TokenPruningConfig>
+
+const QueryDslSparseVectorQueryCommonProps = z.object({
+  field: Field.describe('The name of the field that contains the token-weight pairs to be searched against. This field must be a mapped sparse_vector field.'),
+  query: z.string().describe('The query text you want to use for search. If inference_id is specified, query must also be specified.').optional(),
+  prune: z.boolean().describe('Whether to perform pruning, omitting the non-significant tokens from the query to improve query performance. If prune is true but the pruning_config is not specified, pruning will occur but default values will be used. Default: false').optional(),
+  pruning_config: TokenPruningConfig.describe('Optional pruning configuration. If enabled, this will omit non-significant tokens from the query in order to improve query performance. This is only used if prune is set to true. If prune is set to true but pruning_config is not specified, default values will be used.').optional()
+})
+
+const QueryDslSparseVectorQueryExclusiveProps = z.union([z.object({ query_vector: z.record(z.string(), float) }), z.object({ inference_id: Id })])
+
+export const QueryDslSparseVectorQuery = QueryDslSparseVectorQueryCommonProps.and(QueryDslSparseVectorQueryExclusiveProps).meta({ id: 'QueryDslSparseVectorQuery' })
+export type QueryDslSparseVectorQuery = z.infer<typeof QueryDslSparseVectorQuery>
+
+export const QueryDslTermQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  value: FieldValue.describe('Term you wish to find in the provided field.'),
+  case_insensitive: z.boolean().describe('Allows ASCII case insensitive matching of the value with the indexed field values when set to `true`. When `false`, the case sensitivity of matching depends on the underlying field’s mapping.').optional()
+}).meta({ id: 'QueryDslTermQuery' })
+export type QueryDslTermQuery = z.infer<typeof QueryDslTermQuery>
+
+export const QueryDslTermsQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional()
+}).catchall(z.any()).meta({ id: 'QueryDslTermsQuery' })
+export type QueryDslTermsQuery = z.infer<typeof QueryDslTermsQuery>
+
+export interface QueryDslTermsSetQueryShape {
+  boost?: float | undefined
+  query_name?: string | undefined
+  minimum_should_match?: MinimumShouldMatch | undefined
+  minimum_should_match_field?: Field | undefined
+  minimum_should_match_script?: ScriptShape | undefined
+  terms: FieldValue[]
+}
+export const QueryDslTermsSetQuery = z.object({
+  boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
+  query_name: z.string().optional(),
+  minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
+  minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
+}).meta({ id: 'QueryDslTermsSetQuery' })
+export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
+
+export const QueryDslTextExpansionQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  model_id: z.string().describe('The text expansion NLP model to use'),
+  model_text: z.string().describe('The query text'),
+  pruning_config: TokenPruningConfig.describe('Token pruning configurations').optional()
+}).meta({ id: 'QueryDslTextExpansionQuery' })
+export type QueryDslTextExpansionQuery = z.infer<typeof QueryDslTextExpansionQuery>
+
+export const QueryDslWeightedTokensQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  tokens: z.union([z.record(z.string(), float), z.array(z.record(z.string(), float))]).describe('The tokens representing this query'),
+  pruning_config: TokenPruningConfig.describe('Token pruning configurations').optional()
+}).meta({ id: 'QueryDslWeightedTokensQuery' })
+export type QueryDslWeightedTokensQuery = z.infer<typeof QueryDslWeightedTokensQuery>
+
+export const QueryDslWildcardQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  case_insensitive: z.boolean().describe('Allows case insensitive matching of the pattern with the indexed field values when set to true. Default is false which means the case sensitivity of matching depends on the underlying field’s mapping.').optional(),
+  rewrite: MultiTermQueryRewrite.describe('Method used to rewrite the query.').optional(),
+  value: z.string().describe('Wildcard pattern for terms you wish to find in the provided field. Required, when wildcard is not set.').optional(),
+  wildcard: z.string().describe('Wildcard pattern for terms you wish to find in the provided field. Required, when value is not set.').optional()
+}).meta({ id: 'QueryDslWildcardQuery' })
+export type QueryDslWildcardQuery = z.infer<typeof QueryDslWildcardQuery>
+
+export const QueryDslWrapperQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  query: z.string().describe('A base64 encoded query. The binary data format can be any of JSON, YAML, CBOR or SMILE encodings')
+}).meta({ id: 'QueryDslWrapperQuery' })
+export type QueryDslWrapperQuery = z.infer<typeof QueryDslWrapperQuery>
+
+export const QueryDslTypeQuery = z.object({
+  ...QueryDslQueryBase.shape,
+  value: z.string()
+}).meta({ id: 'QueryDslTypeQuery' })
+export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
+
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+
+export interface QueryDslQueryContainerShape {
+  bool?: QueryDslBoolQuery | undefined
+  boosting?: QueryDslBoostingQuery | undefined
+  common?: Record<Field, QueryDslCommonTermsQuery> | undefined
+  combined_fields?: QueryDslCombinedFieldsQuery | undefined
+  constant_score?: QueryDslConstantScoreQuery | undefined
+  dis_max?: QueryDslDisMaxQuery | undefined
+  distance_feature?: QueryDslDistanceFeatureQuery | undefined
+  exists?: QueryDslExistsQuery | undefined
+  function_score?: QueryDslFunctionScoreQuery | undefined
+  fuzzy?: Record<Field, QueryDslFuzzyQuery> | undefined
+  geo_bounding_box?: QueryDslGeoBoundingBoxQuery | undefined
+  geo_distance?: QueryDslGeoDistanceQuery | undefined
+  geo_grid?: Record<Field, QueryDslGeoGridQuery> | undefined
+  geo_polygon?: QueryDslGeoPolygonQuery | undefined
+  geo_shape?: QueryDslGeoShapeQuery | undefined
+  has_child?: QueryDslHasChildQuery | undefined
+  has_parent?: QueryDslHasParentQuery | undefined
+  ids?: QueryDslIdsQuery | undefined
+  intervals?: Record<Field, QueryDslIntervalsQuery> | undefined
+  knn?: KnnQuery | undefined
+  match?: Record<Field, QueryDslMatchQuery> | undefined
+  match_all?: QueryDslMatchAllQuery | undefined
+  match_bool_prefix?: Record<Field, QueryDslMatchBoolPrefixQuery> | undefined
+  match_none?: QueryDslMatchNoneQuery | undefined
+  match_phrase?: Record<Field, QueryDslMatchPhraseQuery> | undefined
+  match_phrase_prefix?: Record<Field, QueryDslMatchPhrasePrefixQuery> | undefined
+  more_like_this?: QueryDslMoreLikeThisQuery | undefined
+  multi_match?: QueryDslMultiMatchQuery | undefined
+  nested?: QueryDslNestedQuery | undefined
+  parent_id?: QueryDslParentIdQuery | undefined
+  percolate?: QueryDslPercolateQuery | undefined
+  pinned?: QueryDslPinnedQuery | undefined
+  prefix?: Record<Field, QueryDslPrefixQuery> | undefined
+  query_string?: QueryDslQueryStringQuery | undefined
+  range?: Record<Field, QueryDslRangeQuery> | undefined
+  rank_feature?: QueryDslRankFeatureQuery | undefined
+  regexp?: Record<Field, QueryDslRegexpQuery> | undefined
+  rule?: QueryDslRuleQuery | undefined
+  script?: QueryDslScriptQuery | undefined
+  script_score?: QueryDslScriptScoreQuery | undefined
+  semantic?: QueryDslSemanticQuery | undefined
+  shape?: QueryDslShapeQuery | undefined
+  simple_query_string?: QueryDslSimpleQueryStringQuery | undefined
+  span_containing?: QueryDslSpanContainingQuery | undefined
+  span_field_masking?: QueryDslSpanFieldMaskingQuery | undefined
+  span_first?: QueryDslSpanFirstQuery | undefined
+  span_multi?: QueryDslSpanMultiTermQuery | undefined
+  span_near?: QueryDslSpanNearQuery | undefined
+  span_not?: QueryDslSpanNotQuery | undefined
+  span_or?: QueryDslSpanOrQuery | undefined
+  span_term?: Record<Field, QueryDslSpanTermQuery> | undefined
+  span_within?: QueryDslSpanWithinQuery | undefined
+  sparse_vector?: QueryDslSparseVectorQuery | undefined
+  term?: Record<Field, QueryDslTermQuery> | undefined
+  terms?: QueryDslTermsQuery | undefined
+  terms_set?: Record<Field, QueryDslTermsSetQuery> | undefined
+  text_expansion?: Record<Field, QueryDslTextExpansionQuery> | undefined
+  weighted_tokens?: Record<Field, QueryDslWeightedTokensQuery> | undefined
+  wildcard?: Record<Field, QueryDslWildcardQuery> | undefined
+  wrapper?: QueryDslWrapperQuery | undefined
+  type?: QueryDslTypeQuery | undefined
+}
+/** An Elasticsearch Query DSL (Domain Specific Language) object that defines a query. */
+export const QueryDslQueryContainer: z.ZodType<QueryDslQueryContainerShape> = QueryDslQueryContainerExclusiveProps.meta({ id: 'QueryDslQueryContainer' })
+export type QueryDslQueryContainer = z.infer<typeof QueryDslQueryContainer>
+
+export interface AggregationsAdjacencyMatrixAggregationShape {
+  filters?: Record<string, QueryDslQueryContainerShape> | undefined
+  separator?: string | undefined
+}
+export const AggregationsAdjacencyMatrixAggregation = z.object({
+  get filters (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof QueryDslQueryContainer>> { return z.record(z.string(), QueryDslQueryContainer).describe('Filters used to create buckets. At least one filter is required.').optional() },
+  separator: z.string().describe('Separator used to concatenate filter names. Defaults to &.').optional()
+}).meta({ id: 'AggregationsAdjacencyMatrixAggregation' })
+export type AggregationsAdjacencyMatrixAggregation = z.infer<typeof AggregationsAdjacencyMatrixAggregation>
+
+export const AggregationsMinimumInterval = z.enum(['second', 'minute', 'hour', 'day', 'month', 'year']).meta({ id: 'AggregationsMinimumInterval' })
+export type AggregationsMinimumInterval = z.infer<typeof AggregationsMinimumInterval>
+
+export const EpochTime = z.any().meta({ id: 'EpochTime' })
+export type EpochTime = z.infer<typeof EpochTime>
+
+/**
+ * A date and time, either as a string whose format can depend on the context (defaulting to ISO 8601), or a
+ * number of milliseconds since the Epoch. Elasticsearch accepts both as input, but will generally output a string
+ * representation.
+ */
+export const DateTime = z.union([z.string(), EpochTime]).meta({ id: 'DateTime' })
+export type DateTime = z.infer<typeof DateTime>
+
+export interface AggregationsAutoDateHistogramAggregationShape {
+  buckets?: integer | undefined
+  field?: Field | undefined
+  format?: string | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
+  missing?: DateTime | undefined
+  offset?: string | undefined
+  params?: Record<string, unknown> | undefined
+  script?: ScriptShape | undefined
+  time_zone?: TimeZone | undefined
+}
+export const AggregationsAutoDateHistogramAggregation = z.object({
+  buckets: integer.describe('The target number of buckets.').optional(),
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
+  params: z.record(z.string(), z.any()).optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  time_zone: TimeZone.describe('Time zone ID.').optional()
+}).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
+export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
+
+export const AggregationsMissing = z.union([z.string(), integer, double, z.boolean()]).meta({ id: 'AggregationsMissing' })
+export type AggregationsMissing = z.infer<typeof AggregationsMissing>
+
+export interface AggregationsMetricAggregationBaseShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+}
+export const AggregationsMetricAggregationBase = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() }
+}).meta({ id: 'AggregationsMetricAggregationBase' })
+export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
+
+export interface AggregationsFormatMetricAggregationBaseShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  format?: string | undefined
+}
+export const AggregationsFormatMetricAggregationBase = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  format: z.string().optional()
+}).meta({ id: 'AggregationsFormatMetricAggregationBase' })
+export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
+
+export interface AggregationsAverageAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  format?: string | undefined
+}
+export const AggregationsAverageAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  format: z.string().optional()
+}).meta({ id: 'AggregationsAverageAggregation' })
+export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
+
+/**
+ * Buckets path can be expressed in different ways, and an aggregation may accept some or all of these
+ * forms depending on its type. Please refer to each aggregation's documentation to know what buckets
+ * path forms they accept.
+ */
+export const AggregationsBucketsPath = z.union([z.string(), z.array(z.string()), z.record(z.string(), z.string())]).meta({ id: 'AggregationsBucketsPath' })
+export type AggregationsBucketsPath = z.infer<typeof AggregationsBucketsPath>
+
+export const AggregationsBucketPathAggregation = z.object({
+  buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional()
+}).meta({ id: 'AggregationsBucketPathAggregation' })
+export type AggregationsBucketPathAggregation = z.infer<typeof AggregationsBucketPathAggregation>
+
+export const AggregationsGapPolicy = z.enum(['skip', 'insert_zeros', 'keep_values']).meta({ id: 'AggregationsGapPolicy' })
+export type AggregationsGapPolicy = z.infer<typeof AggregationsGapPolicy>
+
+export const AggregationsPipelineAggregationBase = z.object({
+  ...AggregationsBucketPathAggregation.shape,
+  format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
+  gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional()
+}).meta({ id: 'AggregationsPipelineAggregationBase' })
+export type AggregationsPipelineAggregationBase = z.infer<typeof AggregationsPipelineAggregationBase>
+
+export const AggregationsAverageBucketAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape
+}).meta({ id: 'AggregationsAverageBucketAggregation' })
+export type AggregationsAverageBucketAggregation = z.infer<typeof AggregationsAverageBucketAggregation>
+
+export const AggregationsTDigestExecutionHint = z.enum(['default', 'high_accuracy']).meta({ id: 'AggregationsTDigestExecutionHint' })
+export type AggregationsTDigestExecutionHint = z.infer<typeof AggregationsTDigestExecutionHint>
+
+export interface AggregationsBoxplotAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  compression?: double | undefined
+  execution_hint?: AggregationsTDigestExecutionHint | undefined
+}
+export const AggregationsBoxplotAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
+  execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
+}).meta({ id: 'AggregationsBoxplotAggregation' })
+export type AggregationsBoxplotAggregation = z.infer<typeof AggregationsBoxplotAggregation>
+
+export interface AggregationsBucketScriptAggregationShape {
+  buckets_path?: AggregationsBucketsPath | undefined
+  format?: string | undefined
+  gap_policy?: AggregationsGapPolicy | undefined
+  script?: ScriptShape | undefined
+}
+export const AggregationsBucketScriptAggregation = z.object({
+  buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
+  format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
+  gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
+}).meta({ id: 'AggregationsBucketScriptAggregation' })
+export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
+
+export interface AggregationsBucketSelectorAggregationShape {
+  buckets_path?: AggregationsBucketsPath | undefined
+  format?: string | undefined
+  gap_policy?: AggregationsGapPolicy | undefined
+  script?: ScriptShape | undefined
+}
+export const AggregationsBucketSelectorAggregation = z.object({
+  buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
+  format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
+  gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
+}).meta({ id: 'AggregationsBucketSelectorAggregation' })
+export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
+
+export interface AggregationsBucketSortAggregationShape {
+  from?: integer | undefined
+  gap_policy?: AggregationsGapPolicy | undefined
+  size?: integer | undefined
+  sort?: SortShape | undefined
+}
+export const AggregationsBucketSortAggregation = z.object({
+  from: integer.describe('Buckets in positions prior to `from` will be truncated.').optional(),
+  gap_policy: AggregationsGapPolicy.describe('The policy to apply when gaps are found in the data.').optional(),
+  size: integer.describe('The number of buckets to return. Defaults to all buckets of the parent aggregation.').optional(),
+  get sort () { return Sort.describe('The list of fields to sort on.').optional() }
+}).meta({ id: 'AggregationsBucketSortAggregation' })
+export type AggregationsBucketSortAggregation = z.infer<typeof AggregationsBucketSortAggregation>
+
+/**
+ * A sibling pipeline aggregation which executes a two sample Kolmogorov–Smirnov test (referred
+ * to as a "K-S test" from now on) against a provided distribution, and the distribution implied
+ * by the documents counts in the configured sibling aggregation. Specifically, for some metric,
+ * assuming that the percentile intervals of the metric are known beforehand or have been computed
+ * by an aggregation, then one would use range aggregation for the sibling to compute the p-value
+ * of the distribution difference between the metric and the restriction of that metric to a subset
+ * of the documents. A natural use case is if the sibling aggregation range aggregation nested in a
+ * terms aggregation, in which case one compares the overall distribution of metric to its restriction
+ * to each term.
+ */
+export const AggregationsBucketKsAggregation = z.object({
+  ...AggregationsBucketPathAggregation.shape,
+  alternative: z.array(z.string()).describe('A list of string values indicating which K-S test alternative to calculate. The valid values are: "greater", "less", "two_sided". This parameter is key for determining the K-S statistic used when calculating the K-S test. Default value is all possible alternative hypotheses.').optional(),
+  fractions: z.array(double).describe('A list of doubles indicating the distribution of the samples with which to compare to the `buckets_path` results. In typical usage this is the overall proportion of documents in each bucket, which is compared with the actual document proportions in each bucket from the sibling aggregation counts. The default is to assume that overall documents are uniformly distributed on these buckets, which they would be if one used equal percentiles of a metric to define the bucket end points.').optional(),
+  sampling_method: z.string().describe('Indicates the sampling methodology when calculating the K-S test. Note, this is sampling of the returned values. This determines the cumulative distribution function (CDF) points used comparing the two samples. Default is `upper_tail`, which emphasizes the upper end of the CDF points. Valid options are: `upper_tail`, `uniform`, and `lower_tail`.').optional()
+}).meta({ id: 'AggregationsBucketKsAggregation' })
+export type AggregationsBucketKsAggregation = z.infer<typeof AggregationsBucketKsAggregation>
+
+export const AggregationsBucketCorrelationFunctionCountCorrelationIndicator = z.object({
+  doc_count: integer.describe('The total number of documents that initially created the expectations. It’s required to be greater than or equal to the sum of all values in the buckets_path as this is the originating superset of data to which the term values are correlated.'),
+  expectations: z.array(double).describe('An array of numbers with which to correlate the configured `bucket_path` values. The length of this value must always equal the number of buckets returned by the `bucket_path`.'),
+  fractions: z.array(double).describe('An array of fractions to use when averaging and calculating variance. This should be used if the pre-calculated data and the buckets_path have known gaps. The length of fractions, if provided, must equal expectations.').optional()
+}).meta({ id: 'AggregationsBucketCorrelationFunctionCountCorrelationIndicator' })
+export type AggregationsBucketCorrelationFunctionCountCorrelationIndicator = z.infer<typeof AggregationsBucketCorrelationFunctionCountCorrelationIndicator>
+
+export const AggregationsBucketCorrelationFunctionCountCorrelation = z.object({
+  indicator: AggregationsBucketCorrelationFunctionCountCorrelationIndicator.describe('The indicator with which to correlate the configured `bucket_path` values.')
+}).meta({ id: 'AggregationsBucketCorrelationFunctionCountCorrelation' })
+export type AggregationsBucketCorrelationFunctionCountCorrelation = z.infer<typeof AggregationsBucketCorrelationFunctionCountCorrelation>
+
+export const AggregationsBucketCorrelationFunction = z.object({
+  count_correlation: AggregationsBucketCorrelationFunctionCountCorrelation.describe('The configuration to calculate a count correlation. This function is designed for determining the correlation of a term value and a given metric.')
+}).meta({ id: 'AggregationsBucketCorrelationFunction' })
+export type AggregationsBucketCorrelationFunction = z.infer<typeof AggregationsBucketCorrelationFunction>
+
+/** A sibling pipeline aggregation which executes a correlation function on the configured sibling multi-bucket aggregation. */
+export const AggregationsBucketCorrelationAggregation = z.object({
+  ...AggregationsBucketPathAggregation.shape,
+  function: AggregationsBucketCorrelationFunction.describe('The correlation function to execute.')
+}).meta({ id: 'AggregationsBucketCorrelationAggregation' })
+export type AggregationsBucketCorrelationAggregation = z.infer<typeof AggregationsBucketCorrelationAggregation>
+
+export const AggregationsCardinalityExecutionMode = z.enum(['global_ordinals', 'segment_ordinals', 'direct', 'save_memory_heuristic', 'save_time_heuristic']).meta({ id: 'AggregationsCardinalityExecutionMode' })
+export type AggregationsCardinalityExecutionMode = z.infer<typeof AggregationsCardinalityExecutionMode>
+
+export interface AggregationsCardinalityAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  precision_threshold?: integer | undefined
+  rehash?: boolean | undefined
+  execution_hint?: AggregationsCardinalityExecutionMode | undefined
+}
+export const AggregationsCardinalityAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
+  rehash: z.boolean().optional(),
+  execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
+}).meta({ id: 'AggregationsCardinalityAggregation' })
+export type AggregationsCardinalityAggregation = z.infer<typeof AggregationsCardinalityAggregation>
+
+export interface AggregationsCartesianBoundsAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+}
+export const AggregationsCartesianBoundsAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() }
+}).meta({ id: 'AggregationsCartesianBoundsAggregation' })
+export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
+
+export interface AggregationsCartesianCentroidAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+}
+export const AggregationsCartesianCentroidAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() }
+}).meta({ id: 'AggregationsCartesianCentroidAggregation' })
+export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
+
+export const AggregationsCustomCategorizeTextAnalyzer = z.object({
+  char_filter: z.array(z.string()).optional(),
+  tokenizer: z.string().optional(),
+  filter: z.array(z.string()).optional()
+}).meta({ id: 'AggregationsCustomCategorizeTextAnalyzer' })
+export type AggregationsCustomCategorizeTextAnalyzer = z.infer<typeof AggregationsCustomCategorizeTextAnalyzer>
+
+export const AggregationsCategorizeTextAnalyzer = z.union([z.string(), AggregationsCustomCategorizeTextAnalyzer]).meta({ id: 'AggregationsCategorizeTextAnalyzer' })
+export type AggregationsCategorizeTextAnalyzer = z.infer<typeof AggregationsCategorizeTextAnalyzer>
+
+/**
+ * A multi-bucket aggregation that groups semi-structured text into buckets. Each text
+ * field is re-analyzed using a custom analyzer. The resulting tokens are then categorized
+ * creating buckets of similarly formatted text values. This aggregation works best with machine
+ * generated text like system logs. Only the first 100 analyzed tokens are used to categorize the text.
+ */
+export const AggregationsCategorizeTextAggregation = z.object({
+  field: Field.describe('The semi-structured text field to categorize.'),
+  max_unique_tokens: integer.describe('The maximum number of unique tokens at any position up to max_matched_tokens. Must be larger than 1. Smaller values use less memory and create fewer categories. Larger values will use more memory and create narrower categories. Max allowed value is 100.').optional(),
+  max_matched_tokens: integer.describe('The maximum number of token positions to match on before attempting to merge categories. Larger values will use more memory and create narrower categories. Max allowed value is 100.').optional(),
+  similarity_threshold: integer.describe('The minimum percentage of tokens that must match for text to be added to the category bucket. Must be between 1 and 100. The larger the value the narrower the categories. Larger values will increase memory usage and create narrower categories.').optional(),
+  categorization_filters: z.array(z.string()).describe('This property expects an array of regular expressions. The expressions are used to filter out matching sequences from the categorization field values. You can use this functionality to fine tune the categorization by excluding sequences from consideration when categories are defined. For example, you can exclude SQL statements that appear in your log files. This property cannot be used at the same time as categorization_analyzer. If you only want to define simple regular expression filters that are applied prior to tokenization, setting this property is the easiest method. If you also want to customize the tokenizer or post-tokenization filtering, use the categorization_analyzer property instead and include the filters as pattern_replace character filters.').optional(),
+  categorization_analyzer: AggregationsCategorizeTextAnalyzer.describe('The categorization analyzer specifies how the text is analyzed and tokenized before being categorized. The syntax is very similar to that used to define the analyzer in the analyze API. This property cannot be used at the same time as `categorization_filters`.').optional(),
+  shard_size: integer.describe('The number of categorization buckets to return from each shard before merging all the results.').optional(),
+  size: integer.describe('The number of buckets to return.').optional(),
+  min_doc_count: integer.describe('The minimum number of documents in a bucket to be returned to the results.').optional(),
+  shard_min_doc_count: integer.describe('The minimum number of documents in a bucket to be returned from the shard before merging.').optional()
+}).meta({ id: 'AggregationsCategorizeTextAggregation' })
+export type AggregationsCategorizeTextAggregation = z.infer<typeof AggregationsCategorizeTextAggregation>
+
+export const AggregationsChangePointAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape
+}).meta({ id: 'AggregationsChangePointAggregation' })
+export type AggregationsChangePointAggregation = z.infer<typeof AggregationsChangePointAggregation>
+
+export const AggregationsChildrenAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  type: RelationName.describe('The child type that should be selected.').optional()
+}).meta({ id: 'AggregationsChildrenAggregation' })
+export type AggregationsChildrenAggregation = z.infer<typeof AggregationsChildrenAggregation>
+
+export const AggregationsCompositeAggregateKey = z.record(Field, FieldValue).meta({ id: 'AggregationsCompositeAggregateKey' })
+export type AggregationsCompositeAggregateKey = z.infer<typeof AggregationsCompositeAggregateKey>
+
+export const AggregationsMissingOrder = z.enum(['first', 'last', 'default']).meta({ id: 'AggregationsMissingOrder' })
+export type AggregationsMissingOrder = z.infer<typeof AggregationsMissingOrder>
+
+export const AggregationsValueType = z.enum(['string', 'long', 'double', 'number', 'date', 'date_nanos', 'ip', 'numeric', 'geo_point', 'boolean']).meta({ id: 'AggregationsValueType' })
+export type AggregationsValueType = z.infer<typeof AggregationsValueType>
+
+export interface AggregationsCompositeAggregationBaseShape {
+  field?: Field | undefined
+  missing_bucket?: boolean | undefined
+  missing_order?: AggregationsMissingOrder | undefined
+  script?: ScriptShape | undefined
+  value_type?: AggregationsValueType | undefined
+  order?: SortOrder | undefined
+}
+export const AggregationsCompositeAggregationBase = z.object({
+  field: Field.describe('Either `field` or `script` must be present').optional(),
+  missing_bucket: z.boolean().optional(),
+  missing_order: AggregationsMissingOrder.optional(),
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
+  value_type: AggregationsValueType.optional(),
+  order: SortOrder.optional()
+}).meta({ id: 'AggregationsCompositeAggregationBase' })
+export type AggregationsCompositeAggregationBase = z.infer<typeof AggregationsCompositeAggregationBase>
+
+export interface AggregationsCompositeTermsAggregationShape {
+  field?: Field | undefined
+  missing_bucket?: boolean | undefined
+  missing_order?: AggregationsMissingOrder | undefined
+  script?: ScriptShape | undefined
+  value_type?: AggregationsValueType | undefined
+  order?: SortOrder | undefined
+}
+export const AggregationsCompositeTermsAggregation = z.object({
+  field: Field.describe('Either `field` or `script` must be present').optional(),
+  missing_bucket: z.boolean().optional(),
+  missing_order: AggregationsMissingOrder.optional(),
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
+  value_type: AggregationsValueType.optional(),
+  order: SortOrder.optional()
+}).meta({ id: 'AggregationsCompositeTermsAggregation' })
+export type AggregationsCompositeTermsAggregation = z.infer<typeof AggregationsCompositeTermsAggregation>
+
+export interface AggregationsCompositeHistogramAggregationShape {
+  field?: Field | undefined
+  missing_bucket?: boolean | undefined
+  missing_order?: AggregationsMissingOrder | undefined
+  script?: ScriptShape | undefined
+  value_type?: AggregationsValueType | undefined
+  order?: SortOrder | undefined
+  interval: double
+}
+export const AggregationsCompositeHistogramAggregation = z.object({
+  field: Field.describe('Either `field` or `script` must be present').optional(),
+  missing_bucket: z.boolean().optional(),
+  missing_order: AggregationsMissingOrder.optional(),
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
+  value_type: AggregationsValueType.optional(),
+  order: SortOrder.optional(),
+  interval: double
+}).meta({ id: 'AggregationsCompositeHistogramAggregation' })
+export type AggregationsCompositeHistogramAggregation = z.infer<typeof AggregationsCompositeHistogramAggregation>
+
+/**
+ * A date histogram interval. Similar to `Duration` with additional units: `w` (week), `M` (month), `q` (quarter) and
+ * `y` (year)
+ */
+export const DurationLarge = z.string().meta({ id: 'DurationLarge' })
+export type DurationLarge = z.infer<typeof DurationLarge>
+
+export interface AggregationsCompositeDateHistogramAggregationShape {
+  field?: Field | undefined
+  missing_bucket?: boolean | undefined
+  missing_order?: AggregationsMissingOrder | undefined
+  script?: ScriptShape | undefined
+  value_type?: AggregationsValueType | undefined
+  order?: SortOrder | undefined
+  format?: string | undefined
+  calendar_interval?: DurationLarge | undefined
+  fixed_interval?: DurationLarge | undefined
+  offset?: Duration | undefined
+  time_zone?: TimeZone | undefined
+}
+export const AggregationsCompositeDateHistogramAggregation = z.object({
+  field: Field.describe('Either `field` or `script` must be present').optional(),
+  missing_bucket: z.boolean().optional(),
+  missing_order: AggregationsMissingOrder.optional(),
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
+  value_type: AggregationsValueType.optional(),
+  order: SortOrder.optional(),
+  format: z.string().optional(),
+  calendar_interval: DurationLarge.describe('Either `calendar_interval` or `fixed_interval` must be present').optional(),
+  fixed_interval: DurationLarge.describe('Either `calendar_interval` or `fixed_interval` must be present').optional(),
+  offset: Duration.optional(),
+  time_zone: TimeZone.optional()
+}).meta({ id: 'AggregationsCompositeDateHistogramAggregation' })
+export type AggregationsCompositeDateHistogramAggregation = z.infer<typeof AggregationsCompositeDateHistogramAggregation>
+
+export const CoordsGeoBounds = z.object({
+  top: double,
+  bottom: double,
+  left: double,
+  right: double
+}).meta({ id: 'CoordsGeoBounds' })
+export type CoordsGeoBounds = z.infer<typeof CoordsGeoBounds>
+
+export const LatLonGeoLocation = z.object({
+  lat: double.describe('Latitude'),
+  lon: double.describe('Longitude')
+}).meta({ id: 'LatLonGeoLocation' })
+export type LatLonGeoLocation = z.infer<typeof LatLonGeoLocation>
+
+export const GeoHashLocation = z.object({
+  geohash: GeoHash
+}).meta({ id: 'GeoHashLocation' })
+export type GeoHashLocation = z.infer<typeof GeoHashLocation>
+
+/**
+ * A latitude/longitude as a 2 dimensional point. It can be represented in various ways:
+ * - as a `{lat, long}` object
+ * - as a geo hash value
+ * - as a `[lon, lat]` array
+ * - as a string in `"<lat>, <lon>"` or WKT point formats
+ */
+export const GeoLocation = z.union([LatLonGeoLocation, GeoHashLocation, z.array(double), z.string()]).meta({ id: 'GeoLocation' })
+export type GeoLocation = z.infer<typeof GeoLocation>
+
+export const TopLeftBottomRightGeoBounds = z.object({
+  top_left: GeoLocation,
+  bottom_right: GeoLocation
+}).meta({ id: 'TopLeftBottomRightGeoBounds' })
+export type TopLeftBottomRightGeoBounds = z.infer<typeof TopLeftBottomRightGeoBounds>
+
+export const TopRightBottomLeftGeoBounds = z.object({
+  top_right: GeoLocation,
+  bottom_left: GeoLocation
+}).meta({ id: 'TopRightBottomLeftGeoBounds' })
+export type TopRightBottomLeftGeoBounds = z.infer<typeof TopRightBottomLeftGeoBounds>
+
+export const WktGeoBounds = z.object({
+  wkt: z.string()
+}).meta({ id: 'WktGeoBounds' })
+export type WktGeoBounds = z.infer<typeof WktGeoBounds>
+
+/**
+ * A geo bounding box. It can be represented in various ways:
+ * - as 4 top/bottom/left/right coordinates
+ * - as 2 top_left / bottom_right points
+ * - as 2 top_right / bottom_left points
+ * - as a WKT bounding box
+ */
+export const GeoBounds = z.union([CoordsGeoBounds, TopLeftBottomRightGeoBounds, TopRightBottomLeftGeoBounds, WktGeoBounds]).meta({ id: 'GeoBounds' })
+export type GeoBounds = z.infer<typeof GeoBounds>
+
+export interface AggregationsCompositeGeoTileGridAggregationShape {
+  field?: Field | undefined
+  missing_bucket?: boolean | undefined
+  missing_order?: AggregationsMissingOrder | undefined
+  script?: ScriptShape | undefined
+  value_type?: AggregationsValueType | undefined
+  order?: SortOrder | undefined
+  precision?: integer | undefined
+  bounds?: GeoBounds | undefined
+}
+export const AggregationsCompositeGeoTileGridAggregation = z.object({
+  field: Field.describe('Either `field` or `script` must be present').optional(),
+  missing_bucket: z.boolean().optional(),
+  missing_order: AggregationsMissingOrder.optional(),
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
+  value_type: AggregationsValueType.optional(),
+  order: SortOrder.optional(),
+  precision: integer.optional(),
+  bounds: GeoBounds.optional()
+}).meta({ id: 'AggregationsCompositeGeoTileGridAggregation' })
+export type AggregationsCompositeGeoTileGridAggregation = z.infer<typeof AggregationsCompositeGeoTileGridAggregation>
+
+const AggregationsCompositeAggregationSourceExclusiveProps = z.union([z.object({ terms: z.lazy(() => AggregationsCompositeTermsAggregation) }), z.object({ histogram: z.lazy(() => AggregationsCompositeHistogramAggregation) }), z.object({ date_histogram: z.lazy(() => AggregationsCompositeDateHistogramAggregation) }), z.object({ geotile_grid: z.lazy(() => AggregationsCompositeGeoTileGridAggregation) })])
+
+export interface AggregationsCompositeAggregationSourceShape {
+  terms?: AggregationsCompositeTermsAggregation | undefined
+  histogram?: AggregationsCompositeHistogramAggregation | undefined
+  date_histogram?: AggregationsCompositeDateHistogramAggregation | undefined
+  geotile_grid?: AggregationsCompositeGeoTileGridAggregation | undefined
+}
+export const AggregationsCompositeAggregationSource: z.ZodType<AggregationsCompositeAggregationSourceShape> = AggregationsCompositeAggregationSourceExclusiveProps.meta({ id: 'AggregationsCompositeAggregationSource' })
+export type AggregationsCompositeAggregationSource = z.infer<typeof AggregationsCompositeAggregationSource>
+
+export interface AggregationsCompositeAggregationShape {
+  after?: AggregationsCompositeAggregateKey | undefined
+  size?: integer | undefined
+  sources?: Array<Record<string, AggregationsCompositeAggregationSourceShape>> | undefined
+}
+export const AggregationsCompositeAggregation = z.object({
+  after: AggregationsCompositeAggregateKey.describe('When paginating, use the `after_key` value returned in the previous response to retrieve the next page.').optional(),
+  size: integer.describe('The number of composite buckets that should be returned.').optional(),
+  get sources (): z.ZodOptional<z.ZodArray<z.ZodRecord<z.ZodString, typeof AggregationsCompositeAggregationSource>>> { return z.array(z.record(z.string(), AggregationsCompositeAggregationSource)).describe('The value sources used to build composite buckets. Keys are returned in the order of the `sources` definition.').optional() }
+}).meta({ id: 'AggregationsCompositeAggregation' })
+export type AggregationsCompositeAggregation = z.infer<typeof AggregationsCompositeAggregation>
+
+export const AggregationsCumulativeCardinalityAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape
+}).meta({ id: 'AggregationsCumulativeCardinalityAggregation' })
+export type AggregationsCumulativeCardinalityAggregation = z.infer<typeof AggregationsCumulativeCardinalityAggregation>
+
+export const AggregationsCumulativeSumAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape
+}).meta({ id: 'AggregationsCumulativeSumAggregation' })
+export type AggregationsCumulativeSumAggregation = z.infer<typeof AggregationsCumulativeSumAggregation>
+
+export const AggregationsCalendarInterval = z.enum(['second', '1s', 'minute', '1m', 'hour', '1h', 'day', '1d', 'week', '1w', 'month', '1M', 'quarter', '1q', 'year', '1y']).meta({ id: 'AggregationsCalendarInterval' })
+export type AggregationsCalendarInterval = z.infer<typeof AggregationsCalendarInterval>
+
+export const AggregationsExtendedBounds = z.object({
+  max: z.any().describe('Maximum value for the bound.').optional(),
+  min: z.any().describe('Minimum value for the bound.').optional()
+}).meta({ id: 'AggregationsExtendedBounds' })
+export type AggregationsExtendedBounds = z.infer<typeof AggregationsExtendedBounds>
+
+export const AggregationsAggregateOrder = z.union([z.record(Field, SortOrder), z.array(z.record(Field, SortOrder))]).meta({ id: 'AggregationsAggregateOrder' })
+export type AggregationsAggregateOrder = z.infer<typeof AggregationsAggregateOrder>
+
+export interface AggregationsDateHistogramAggregationShape {
+  calendar_interval?: AggregationsCalendarInterval | undefined
+  extended_bounds?: AggregationsExtendedBounds | undefined
+  hard_bounds?: AggregationsExtendedBounds | undefined
+  field?: Field | undefined
+  fixed_interval?: Duration | undefined
+  format?: string | undefined
+  interval?: Duration | undefined
+  min_doc_count?: integer | undefined
+  missing?: DateTime | undefined
+  offset?: Duration | undefined
+  order?: AggregationsAggregateOrder | undefined
+  params?: Record<string, unknown> | undefined
+  script?: ScriptShape | undefined
+  time_zone?: TimeZone | undefined
+  keyed?: boolean | undefined
+}
+export const AggregationsDateHistogramAggregation = z.object({
+  calendar_interval: AggregationsCalendarInterval.describe('Calendar-aware interval. Can be specified using the unit name, such as `month`, or as a single unit quantity, such as `1M`.').optional(),
+  extended_bounds: AggregationsExtendedBounds.describe('Enables extending the bounds of the histogram beyond the data itself.').optional(),
+  hard_bounds: AggregationsExtendedBounds.describe('Limits the histogram to specified bounds.').optional(),
+  field: Field.describe('The date field whose values are use to build a histogram.').optional(),
+  fixed_interval: Duration.describe('Fixed intervals: a fixed number of SI units and never deviate, regardless of where they fall on the calendar.').optional(),
+  format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
+  interval: Duration.optional(),
+  min_doc_count: integer.describe('Only returns buckets that have `min_doc_count` number of documents. By default, all buckets between the first bucket that matches documents and the last one are returned.').optional(),
+  missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
+  order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
+  params: z.record(z.string(), z.any()).optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
+  keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
+}).meta({ id: 'AggregationsDateHistogramAggregation' })
+export type AggregationsDateHistogramAggregation = z.infer<typeof AggregationsDateHistogramAggregation>
+
+export const DateMath = z.string().meta({ id: 'DateMath' })
+export type DateMath = z.infer<typeof DateMath>
+
+/**
+ * A date range limit, represented either as a DateMath expression or a number expressed
+ * according to the target field's precision.
+ */
+export const AggregationsFieldDateMath = z.union([DateMath, long]).meta({ id: 'AggregationsFieldDateMath' })
+export type AggregationsFieldDateMath = z.infer<typeof AggregationsFieldDateMath>
+
+export const AggregationsDateRangeExpression = z.object({
+  from: AggregationsFieldDateMath.describe('Start of the range (inclusive).').optional(),
+  key: z.string().describe('Custom key to return the range with.').optional(),
+  to: AggregationsFieldDateMath.describe('End of the range (exclusive).').optional()
+}).meta({ id: 'AggregationsDateRangeExpression' })
+export type AggregationsDateRangeExpression = z.infer<typeof AggregationsDateRangeExpression>
+
+export const AggregationsDateRangeAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  field: Field.describe('The date field whose values are use to build ranges.').optional(),
+  format: z.string().describe('The date format used to format `from` and `to` in the response.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  ranges: z.array(AggregationsDateRangeExpression).describe('Array of date ranges.').optional(),
+  time_zone: TimeZone.describe('Time zone used to convert dates from another time zone to UTC.').optional(),
+  keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and returns the ranges as a hash rather than an array.').optional()
+}).meta({ id: 'AggregationsDateRangeAggregation' })
+export type AggregationsDateRangeAggregation = z.infer<typeof AggregationsDateRangeAggregation>
+
+export const AggregationsDerivativeAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape
+}).meta({ id: 'AggregationsDerivativeAggregation' })
+export type AggregationsDerivativeAggregation = z.infer<typeof AggregationsDerivativeAggregation>
+
+export const AggregationsSamplerAggregationExecutionHint = z.enum(['map', 'global_ordinals', 'bytes_hash']).meta({ id: 'AggregationsSamplerAggregationExecutionHint' })
+export type AggregationsSamplerAggregationExecutionHint = z.infer<typeof AggregationsSamplerAggregationExecutionHint>
+
+export interface AggregationsDiversifiedSamplerAggregationShape {
+  execution_hint?: AggregationsSamplerAggregationExecutionHint | undefined
+  max_docs_per_value?: integer | undefined
+  script?: ScriptShape | undefined
+  shard_size?: integer | undefined
+  field?: Field | undefined
+}
+export const AggregationsDiversifiedSamplerAggregation = z.object({
+  execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
+  max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
+  field: Field.describe('The field used to provide values used for de-duplication.').optional()
+}).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
+export type AggregationsDiversifiedSamplerAggregation = z.infer<typeof AggregationsDiversifiedSamplerAggregation>
+
+export interface AggregationsExtendedStatsAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  format?: string | undefined
+  sigma?: double | undefined
+}
+export const AggregationsExtendedStatsAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  format: z.string().optional(),
+  sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
+}).meta({ id: 'AggregationsExtendedStatsAggregation' })
+export type AggregationsExtendedStatsAggregation = z.infer<typeof AggregationsExtendedStatsAggregation>
+
+export const AggregationsExtendedStatsBucketAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape,
+  sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
+}).meta({ id: 'AggregationsExtendedStatsBucketAggregation' })
+export type AggregationsExtendedStatsBucketAggregation = z.infer<typeof AggregationsExtendedStatsBucketAggregation>
+
+export const AggregationsTermsExclude = z.union([z.string(), z.array(z.string())]).meta({ id: 'AggregationsTermsExclude' })
+export type AggregationsTermsExclude = z.infer<typeof AggregationsTermsExclude>
+
+export const AggregationsTermsPartition = z.object({
+  num_partitions: long.describe('The number of partitions.'),
+  partition: long.describe('The partition number for this request.')
+}).meta({ id: 'AggregationsTermsPartition' })
+export type AggregationsTermsPartition = z.infer<typeof AggregationsTermsPartition>
+
+export const AggregationsTermsInclude = z.union([z.string(), z.array(z.string()), AggregationsTermsPartition]).meta({ id: 'AggregationsTermsInclude' })
+export type AggregationsTermsInclude = z.infer<typeof AggregationsTermsInclude>
+
+export const AggregationsFrequentItemSetsField = z.object({
+  field: Field,
+  exclude: AggregationsTermsExclude.describe('Values to exclude. Can be regular expression strings or arrays of strings of exact terms.').optional(),
+  include: AggregationsTermsInclude.describe('Values to include. Can be regular expression strings or arrays of strings of exact terms.').optional()
+}).meta({ id: 'AggregationsFrequentItemSetsField' })
+export type AggregationsFrequentItemSetsField = z.infer<typeof AggregationsFrequentItemSetsField>
+
+export interface AggregationsFrequentItemSetsAggregationShape {
+  fields: AggregationsFrequentItemSetsField[]
+  minimum_set_size?: integer | undefined
+  minimum_support?: double | undefined
+  size?: integer | undefined
+  filter?: QueryDslQueryContainerShape | undefined
+}
+export const AggregationsFrequentItemSetsAggregation = z.object({
+  fields: z.array(AggregationsFrequentItemSetsField).describe('Fields to analyze.'),
+  minimum_set_size: integer.describe('The minimum size of one item set.').optional(),
+  minimum_support: double.describe('The minimum support of one item set.').optional(),
+  size: integer.describe('The number of top item sets to return.').optional(),
+  get filter () { return QueryDslQueryContainer.describe('Query that filters documents from analysis.').optional() }
+}).meta({ id: 'AggregationsFrequentItemSetsAggregation' })
+export type AggregationsFrequentItemSetsAggregation = z.infer<typeof AggregationsFrequentItemSetsAggregation>
+
+/**
+ * Aggregation buckets. By default they are returned as an array, but if the aggregation has keys configured for
+ * the different buckets, the result is a dictionary.
+ */
+export const AggregationsBuckets = z.union([z.record(z.string(), z.any()), z.array(z.any())]).meta({ id: 'AggregationsBuckets' })
+export type AggregationsBuckets = z.infer<typeof AggregationsBuckets>
+
+export const AggregationsFiltersAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  filters: AggregationsBuckets.describe('Collection of queries from which to build buckets.').optional(),
+  other_bucket: z.boolean().describe('Set to `true` to add a bucket to the response which will contain all documents that do not match any of the given filters.').optional(),
+  other_bucket_key: z.string().describe('The key with which the other bucket is returned.').optional(),
+  keyed: z.boolean().describe('By default, the named filters aggregation returns the buckets as an object. Set to `false` to return the buckets as an array of objects.').optional()
+}).meta({ id: 'AggregationsFiltersAggregation' })
+export type AggregationsFiltersAggregation = z.infer<typeof AggregationsFiltersAggregation>
+
+export interface AggregationsGeoBoundsAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  wrap_longitude?: boolean | undefined
+}
+export const AggregationsGeoBoundsAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
+}).meta({ id: 'AggregationsGeoBoundsAggregation' })
+export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
+
+export interface AggregationsGeoCentroidAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  count?: long | undefined
+  location?: GeoLocation | undefined
+}
+export const AggregationsGeoCentroidAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  count: long.optional(),
+  location: GeoLocation.optional()
+}).meta({ id: 'AggregationsGeoCentroidAggregation' })
+export type AggregationsGeoCentroidAggregation = z.infer<typeof AggregationsGeoCentroidAggregation>
+
+export const AggregationsAggregationRange = z.object({
+  from: z.union([double, z.null()]).describe('Start of the range (inclusive).').optional(),
+  key: z.string().describe('Custom key to return the range with.').optional(),
+  to: z.union([double, z.null()]).describe('End of the range (exclusive).').optional()
+}).meta({ id: 'AggregationsAggregationRange' })
+export type AggregationsAggregationRange = z.infer<typeof AggregationsAggregationRange>
+
+export const AggregationsGeoDistanceAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  distance_type: GeoDistanceType.describe('The distance calculation type.').optional(),
+  field: Field.describe('A field of type `geo_point` used to evaluate the distance.').optional(),
+  origin: GeoLocation.describe('The origin  used to evaluate the distance.').optional(),
+  ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
+  unit: DistanceUnit.describe('The distance unit.').optional()
+}).meta({ id: 'AggregationsGeoDistanceAggregation' })
+export type AggregationsGeoDistanceAggregation = z.infer<typeof AggregationsGeoDistanceAggregation>
+
+/** A precision that can be expressed as a geohash length between 1 and 12, or a distance measure like "1km", "10m". */
+export const GeoHashPrecision = z.union([integer, z.string()]).meta({ id: 'GeoHashPrecision' })
+export type GeoHashPrecision = z.infer<typeof GeoHashPrecision>
+
+export const AggregationsGeoHashGridAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  bounds: GeoBounds.describe('The bounding box to filter the points in each bucket.').optional(),
+  field: Field.describe('Field containing indexed `geo_point` or `geo_shape` values. If the field contains an array, `geohash_grid` aggregates all array values.').optional(),
+  precision: GeoHashPrecision.describe('The string length of the geohashes used to define cells/buckets in the results.').optional(),
+  shard_size: integer.describe('Allows for more accurate counting of the top cells returned in the final result the aggregation. Defaults to returning `max(10,(size x number-of-shards))` buckets from each shard.').optional(),
+  size: integer.describe('The maximum number of geohash buckets to return.').optional()
+}).meta({ id: 'AggregationsGeoHashGridAggregation' })
+export type AggregationsGeoHashGridAggregation = z.infer<typeof AggregationsGeoHashGridAggregation>
+
+export const AggregationsGeoLinePoint = z.object({
+  field: Field.describe('The name of the geo_point field.')
+}).meta({ id: 'AggregationsGeoLinePoint' })
+export type AggregationsGeoLinePoint = z.infer<typeof AggregationsGeoLinePoint>
+
+export const AggregationsGeoLineSort = z.object({
+  field: Field.describe('The name of the numeric field to use as the sort key for ordering the points.')
+}).meta({ id: 'AggregationsGeoLineSort' })
+export type AggregationsGeoLineSort = z.infer<typeof AggregationsGeoLineSort>
+
+export const AggregationsGeoLineAggregation = z.object({
+  point: AggregationsGeoLinePoint.describe('The name of the geo_point field.'),
+  sort: AggregationsGeoLineSort.describe('The name of the numeric field to use as the sort key for ordering the points. When the `geo_line` aggregation is nested inside a `time_series` aggregation, this field defaults to `@timestamp`, and any other value will result in error.').optional(),
+  include_sort: z.boolean().describe('When `true`, returns an additional array of the sort values in the feature properties.').optional(),
+  sort_order: SortOrder.describe('The order in which the line is sorted (ascending or descending).').optional(),
+  size: integer.describe('The maximum length of the line represented in the aggregation. Valid sizes are between 1 and 10000.').optional()
+}).meta({ id: 'AggregationsGeoLineAggregation' })
+export type AggregationsGeoLineAggregation = z.infer<typeof AggregationsGeoLineAggregation>
+
+export const GeoTilePrecision = integer.meta({ id: 'GeoTilePrecision' })
+export type GeoTilePrecision = z.infer<typeof GeoTilePrecision>
+
+export const AggregationsGeoTileGridAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  field: Field.describe('Field containing indexed `geo_point` or `geo_shape` values. If the field contains an array, `geotile_grid` aggregates all array values.').optional(),
+  precision: GeoTilePrecision.describe('Integer zoom of the key used to define cells/buckets in the results. Values outside of the range [0,29] will be rejected.').optional(),
+  shard_size: integer.describe('Allows for more accurate counting of the top cells returned in the final result the aggregation. Defaults to returning `max(10,(size x number-of-shards))` buckets from each shard.').optional(),
+  size: integer.describe('The maximum number of buckets to return.').optional(),
+  bounds: GeoBounds.describe('A bounding box to filter the geo-points or geo-shapes in each bucket.').optional()
+}).meta({ id: 'AggregationsGeoTileGridAggregation' })
+export type AggregationsGeoTileGridAggregation = z.infer<typeof AggregationsGeoTileGridAggregation>
+
+export const AggregationsGeohexGridAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  field: Field.describe('Field containing indexed `geo_point` or `geo_shape` values. If the field contains an array, `geohex_grid` aggregates all array values.'),
+  precision: integer.describe('Integer zoom of the key used to defined cells or buckets in the results. Value should be between 0-15.').optional(),
+  bounds: GeoBounds.describe('Bounding box used to filter the geo-points in each bucket.').optional(),
+  size: integer.describe('Maximum number of buckets to return.').optional(),
+  shard_size: integer.describe('Number of buckets returned from each shard.').optional()
+}).meta({ id: 'AggregationsGeohexGridAggregation' })
+export type AggregationsGeohexGridAggregation = z.infer<typeof AggregationsGeohexGridAggregation>
+
+export const AggregationsGlobalAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape
+}).meta({ id: 'AggregationsGlobalAggregation' })
+export type AggregationsGlobalAggregation = z.infer<typeof AggregationsGlobalAggregation>
+
+export interface AggregationsHistogramAggregationShape {
+  extended_bounds?: AggregationsExtendedBounds | undefined
+  hard_bounds?: AggregationsExtendedBounds | undefined
+  field?: Field | undefined
+  interval?: double | undefined
+  min_doc_count?: integer | undefined
+  missing?: double | undefined
+  offset?: double | undefined
+  order?: AggregationsAggregateOrder | undefined
+  script?: ScriptShape | undefined
+  format?: string | undefined
+  keyed?: boolean | undefined
+}
+export const AggregationsHistogramAggregation = z.object({
+  extended_bounds: AggregationsExtendedBounds.describe('Enables extending the bounds of the histogram beyond the data itself.').optional(),
+  hard_bounds: AggregationsExtendedBounds.describe('Limits the range of buckets in the histogram. It is particularly useful in the case of open data ranges that can result in a very large number of buckets.').optional(),
+  field: Field.describe('The name of the field to aggregate on.').optional(),
+  interval: double.describe('The interval for the buckets. Must be a positive decimal.').optional(),
+  min_doc_count: integer.describe('Only returns buckets that have `min_doc_count` number of documents. By default, the response will fill gaps in the histogram with empty buckets.').optional(),
+  missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
+  order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  format: z.string().optional(),
+  keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
+}).meta({ id: 'AggregationsHistogramAggregation' })
+export type AggregationsHistogramAggregation = z.infer<typeof AggregationsHistogramAggregation>
+
+export const AggregationsIpRangeAggregationRange = z.object({
+  from: z.union([z.string(), z.null()]).describe('Start of the range.').optional(),
+  mask: z.string().describe('IP range defined as a CIDR mask.').optional(),
+  to: z.union([z.string(), z.null()]).describe('End of the range.').optional()
+}).meta({ id: 'AggregationsIpRangeAggregationRange' })
+export type AggregationsIpRangeAggregationRange = z.infer<typeof AggregationsIpRangeAggregationRange>
+
+export const AggregationsIpRangeAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  field: Field.describe('The date field whose values are used to build ranges.').optional(),
+  ranges: z.array(AggregationsIpRangeAggregationRange).describe('Array of IP ranges.').optional()
+}).meta({ id: 'AggregationsIpRangeAggregation' })
+export type AggregationsIpRangeAggregation = z.infer<typeof AggregationsIpRangeAggregation>
+
+export const AggregationsIpPrefixAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  field: Field.describe('The IP address field to aggregation on. The field mapping type must be `ip`.'),
+  prefix_length: integer.describe('Length of the network prefix. For IPv4 addresses the accepted range is [0, 32]. For IPv6 addresses the accepted range is [0, 128].'),
+  is_ipv6: z.boolean().describe('Defines whether the prefix applies to IPv6 addresses.').optional(),
+  append_prefix_length: z.boolean().describe('Defines whether the prefix length is appended to IP address keys in the response.').optional(),
+  keyed: z.boolean().describe('Defines whether buckets are returned as a hash rather than an array in the response.').optional(),
+  min_doc_count: long.describe('Minimum number of documents in a bucket for it to be included in the response.').optional()
+}).meta({ id: 'AggregationsIpPrefixAggregation' })
+export type AggregationsIpPrefixAggregation = z.infer<typeof AggregationsIpPrefixAggregation>
+
+export const MlRegressionInferenceOptions = z.object({
+  results_field: Field.describe('The field that is added to incoming documents to contain the inference prediction. Defaults to predicted_value.').optional(),
+  num_top_feature_importance_values: integer.describe('Specifies the maximum number of feature importance values per document.').optional()
+}).meta({ id: 'MlRegressionInferenceOptions' })
+export type MlRegressionInferenceOptions = z.infer<typeof MlRegressionInferenceOptions>
+
+export const MlClassificationInferenceOptions = z.object({
+  num_top_classes: integer.describe('Specifies the number of top class predictions to return. Defaults to 0.').optional(),
+  num_top_feature_importance_values: integer.describe('Specifies the maximum number of feature importance values per document.').optional(),
+  prediction_field_type: z.string().describe('Specifies the type of the predicted field to write. Acceptable values are: string, number, boolean. When boolean is provided 1.0 is transformed to true and 0.0 to false.').optional(),
+  results_field: z.string().describe('The field that is added to incoming documents to contain the inference prediction. Defaults to predicted_value.').optional(),
+  top_classes_results_field: z.string().describe('Specifies the field to which the top classes are written. Defaults to top_classes.').optional()
+}).meta({ id: 'MlClassificationInferenceOptions' })
+export type MlClassificationInferenceOptions = z.infer<typeof MlClassificationInferenceOptions>
+
+const AggregationsInferenceConfigContainerExclusiveProps = z.union([z.object({ regression: MlRegressionInferenceOptions }), z.object({ classification: MlClassificationInferenceOptions })])
+
+export const AggregationsInferenceConfigContainer = AggregationsInferenceConfigContainerExclusiveProps.meta({ id: 'AggregationsInferenceConfigContainer' })
+export type AggregationsInferenceConfigContainer = z.infer<typeof AggregationsInferenceConfigContainer>
+
+export const AggregationsInferenceAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape,
+  model_id: Name.describe('The ID or alias for the trained model.'),
+  inference_config: AggregationsInferenceConfigContainer.describe('Contains the inference type and its options.').optional()
+}).meta({ id: 'AggregationsInferenceAggregation' })
+export type AggregationsInferenceAggregation = z.infer<typeof AggregationsInferenceAggregation>
+
+export const AggregationsMatrixAggregation = z.object({
+  fields: Fields.describe('An array of fields for computing the statistics.').optional(),
+  missing: z.record(Field, double).describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
+}).meta({ id: 'AggregationsMatrixAggregation' })
+export type AggregationsMatrixAggregation = z.infer<typeof AggregationsMatrixAggregation>
+
+export const AggregationsMatrixStatsAggregation = z.object({
+  ...AggregationsMatrixAggregation.shape,
+  mode: SortMode.describe('Array value the aggregation will use for array or multi-valued fields.').optional()
+}).meta({ id: 'AggregationsMatrixStatsAggregation' })
+export type AggregationsMatrixStatsAggregation = z.infer<typeof AggregationsMatrixStatsAggregation>
+
+export interface AggregationsMaxAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  format?: string | undefined
+}
+export const AggregationsMaxAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  format: z.string().optional()
+}).meta({ id: 'AggregationsMaxAggregation' })
+export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
+
+export const AggregationsMaxBucketAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape
+}).meta({ id: 'AggregationsMaxBucketAggregation' })
+export type AggregationsMaxBucketAggregation = z.infer<typeof AggregationsMaxBucketAggregation>
+
+export interface AggregationsMedianAbsoluteDeviationAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  format?: string | undefined
+  compression?: double | undefined
+  execution_hint?: AggregationsTDigestExecutionHint | undefined
+}
+export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  format: z.string().optional(),
+  compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
+  execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
+}).meta({ id: 'AggregationsMedianAbsoluteDeviationAggregation' })
+export type AggregationsMedianAbsoluteDeviationAggregation = z.infer<typeof AggregationsMedianAbsoluteDeviationAggregation>
+
+export interface AggregationsMinAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  format?: string | undefined
+}
+export const AggregationsMinAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  format: z.string().optional()
+}).meta({ id: 'AggregationsMinAggregation' })
+export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
+
+export const AggregationsMinBucketAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape
+}).meta({ id: 'AggregationsMinBucketAggregation' })
+export type AggregationsMinBucketAggregation = z.infer<typeof AggregationsMinBucketAggregation>
+
+export const AggregationsMissingAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  field: Field.describe('The name of the field.').optional(),
+  missing: AggregationsMissing.optional()
+}).meta({ id: 'AggregationsMissingAggregation' })
+export type AggregationsMissingAggregation = z.infer<typeof AggregationsMissingAggregation>
+
+export const AggregationsMovingAverageAggregationBase = z.object({
+  ...AggregationsPipelineAggregationBase.shape,
+  minimize: z.boolean().optional(),
+  predict: integer.optional(),
+  window: integer.optional()
+}).meta({ id: 'AggregationsMovingAverageAggregationBase' })
+export type AggregationsMovingAverageAggregationBase = z.infer<typeof AggregationsMovingAverageAggregationBase>
+
+/** For empty Class assignments */
+export const EmptyObject = z.object({
+}).meta({ id: 'EmptyObject' })
+export type EmptyObject = z.infer<typeof EmptyObject>
+
+export const AggregationsLinearMovingAverageAggregation = z.object({
+  ...AggregationsMovingAverageAggregationBase.shape,
+  model: z.literal('linear'),
+  settings: EmptyObject
+}).meta({ id: 'AggregationsLinearMovingAverageAggregation' })
+export type AggregationsLinearMovingAverageAggregation = z.infer<typeof AggregationsLinearMovingAverageAggregation>
+
+export const AggregationsSimpleMovingAverageAggregation = z.object({
+  ...AggregationsMovingAverageAggregationBase.shape,
+  model: z.literal('simple'),
+  settings: EmptyObject
+}).meta({ id: 'AggregationsSimpleMovingAverageAggregation' })
+export type AggregationsSimpleMovingAverageAggregation = z.infer<typeof AggregationsSimpleMovingAverageAggregation>
+
+export const AggregationsEwmaModelSettings = z.object({
+  alpha: float.optional()
+}).meta({ id: 'AggregationsEwmaModelSettings' })
+export type AggregationsEwmaModelSettings = z.infer<typeof AggregationsEwmaModelSettings>
+
+export const AggregationsEwmaMovingAverageAggregation = z.object({
+  ...AggregationsMovingAverageAggregationBase.shape,
+  model: z.literal('ewma'),
+  settings: AggregationsEwmaModelSettings
+}).meta({ id: 'AggregationsEwmaMovingAverageAggregation' })
+export type AggregationsEwmaMovingAverageAggregation = z.infer<typeof AggregationsEwmaMovingAverageAggregation>
+
+export const AggregationsHoltLinearModelSettings = z.object({
+  alpha: float.optional(),
+  beta: float.optional()
+}).meta({ id: 'AggregationsHoltLinearModelSettings' })
+export type AggregationsHoltLinearModelSettings = z.infer<typeof AggregationsHoltLinearModelSettings>
+
+export const AggregationsHoltMovingAverageAggregation = z.object({
+  ...AggregationsMovingAverageAggregationBase.shape,
+  model: z.literal('holt'),
+  settings: AggregationsHoltLinearModelSettings
+}).meta({ id: 'AggregationsHoltMovingAverageAggregation' })
+export type AggregationsHoltMovingAverageAggregation = z.infer<typeof AggregationsHoltMovingAverageAggregation>
+
+export const AggregationsHoltWintersType = z.enum(['add', 'mult']).meta({ id: 'AggregationsHoltWintersType' })
+export type AggregationsHoltWintersType = z.infer<typeof AggregationsHoltWintersType>
+
+export const AggregationsHoltWintersModelSettings = z.object({
+  alpha: float.optional(),
+  beta: float.optional(),
+  gamma: float.optional(),
+  pad: z.boolean().optional(),
+  period: integer.optional(),
+  type: AggregationsHoltWintersType.optional()
+}).meta({ id: 'AggregationsHoltWintersModelSettings' })
+export type AggregationsHoltWintersModelSettings = z.infer<typeof AggregationsHoltWintersModelSettings>
+
+export const AggregationsHoltWintersMovingAverageAggregation = z.object({
+  ...AggregationsMovingAverageAggregationBase.shape,
+  model: z.literal('holt_winters'),
+  settings: AggregationsHoltWintersModelSettings
+}).meta({ id: 'AggregationsHoltWintersMovingAverageAggregation' })
+export type AggregationsHoltWintersMovingAverageAggregation = z.infer<typeof AggregationsHoltWintersMovingAverageAggregation>
+
+export const AggregationsMovingAverageAggregation = z.union([AggregationsLinearMovingAverageAggregation, AggregationsSimpleMovingAverageAggregation, AggregationsEwmaMovingAverageAggregation, AggregationsHoltMovingAverageAggregation, AggregationsHoltWintersMovingAverageAggregation]).meta({ id: 'AggregationsMovingAverageAggregation' })
+export type AggregationsMovingAverageAggregation = z.infer<typeof AggregationsMovingAverageAggregation>
+
+export const AggregationsMovingPercentilesAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape,
+  window: integer.describe('The size of window to "slide" across the histogram.').optional(),
+  shift: integer.describe('By default, the window consists of the last n values excluding the current bucket. Increasing `shift` by 1, moves the starting window position by 1 to the right.').optional(),
+  keyed: z.boolean().optional()
+}).meta({ id: 'AggregationsMovingPercentilesAggregation' })
+export type AggregationsMovingPercentilesAggregation = z.infer<typeof AggregationsMovingPercentilesAggregation>
+
+export const AggregationsMovingFunctionAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape,
+  script: z.string().describe('The script that should be executed on each window of data.').optional(),
+  shift: integer.describe('By default, the window consists of the last n values excluding the current bucket. Increasing `shift` by 1, moves the starting window position by 1 to the right.').optional(),
+  window: integer.describe('The size of window to "slide" across the histogram.').optional()
+}).meta({ id: 'AggregationsMovingFunctionAggregation' })
+export type AggregationsMovingFunctionAggregation = z.infer<typeof AggregationsMovingFunctionAggregation>
+
+export const AggregationsTermsAggregationCollectMode = z.enum(['depth_first', 'breadth_first']).meta({ id: 'AggregationsTermsAggregationCollectMode' })
+export type AggregationsTermsAggregationCollectMode = z.infer<typeof AggregationsTermsAggregationCollectMode>
+
+const AggregationsMultiTermLookupCommonProps = z.object({
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
+})
+
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
+
+export interface AggregationsMultiTermLookupShape {
+  missing?: AggregationsMissing | undefined
+  field?: Field | undefined
+  script?: Script | undefined
+}
+export const AggregationsMultiTermLookup: z.ZodType<AggregationsMultiTermLookupShape> = AggregationsMultiTermLookupCommonProps.and(AggregationsMultiTermLookupExclusiveProps).meta({ id: 'AggregationsMultiTermLookup' })
+export type AggregationsMultiTermLookup = z.infer<typeof AggregationsMultiTermLookup>
+
+export interface AggregationsMultiTermsAggregationShape {
+  collect_mode?: AggregationsTermsAggregationCollectMode | undefined
+  order?: AggregationsAggregateOrder | undefined
+  min_doc_count?: long | undefined
+  shard_min_doc_count?: long | undefined
+  shard_size?: integer | undefined
+  show_term_doc_count_error?: boolean | undefined
+  size?: integer | undefined
+  terms: AggregationsMultiTermLookupShape[]
+}
+export const AggregationsMultiTermsAggregation = z.object({
+  collect_mode: AggregationsTermsAggregationCollectMode.describe('Specifies the strategy for data collection.').optional(),
+  order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
+  min_doc_count: long.describe('The minimum number of documents in a bucket for it to be returned.').optional(),
+  shard_min_doc_count: long.describe('The minimum number of documents in a bucket on each shard for it to be returned.').optional(),
+  shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
+  show_term_doc_count_error: z.boolean().describe('Calculates the doc count error on per term basis.').optional(),
+  size: integer.describe('The number of term buckets should be returned out of the overall terms list.').optional(),
+  get terms () { return AggregationsMultiTermLookup.array().describe('The field from which to generate sets of terms.') }
+}).meta({ id: 'AggregationsMultiTermsAggregation' })
+export type AggregationsMultiTermsAggregation = z.infer<typeof AggregationsMultiTermsAggregation>
+
+export const AggregationsNestedAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  path: Field.describe('The path to the field of type `nested`.').optional()
+}).meta({ id: 'AggregationsNestedAggregation' })
+export type AggregationsNestedAggregation = z.infer<typeof AggregationsNestedAggregation>
+
+export const AggregationsNormalizeMethod = z.enum(['rescale_0_1', 'rescale_0_100', 'percent_of_sum', 'mean', 'z-score', 'softmax']).meta({ id: 'AggregationsNormalizeMethod' })
+export type AggregationsNormalizeMethod = z.infer<typeof AggregationsNormalizeMethod>
+
+export const AggregationsNormalizeAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape,
+  method: AggregationsNormalizeMethod.describe('The specific method to apply.').optional()
+}).meta({ id: 'AggregationsNormalizeAggregation' })
+export type AggregationsNormalizeAggregation = z.infer<typeof AggregationsNormalizeAggregation>
+
+export const AggregationsParentAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  type: RelationName.describe('The child type that should be selected.').optional()
+}).meta({ id: 'AggregationsParentAggregation' })
+export type AggregationsParentAggregation = z.infer<typeof AggregationsParentAggregation>
+
+export const AggregationsHdrMethod = z.object({
+  number_of_significant_value_digits: integer.describe('Specifies the resolution of values for the histogram in number of significant digits.').optional()
+}).meta({ id: 'AggregationsHdrMethod' })
+export type AggregationsHdrMethod = z.infer<typeof AggregationsHdrMethod>
+
+export const AggregationsTDigest = z.object({
+  compression: integer.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
+  execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
+}).meta({ id: 'AggregationsTDigest' })
+export type AggregationsTDigest = z.infer<typeof AggregationsTDigest>
+
+export interface AggregationsPercentileRanksAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  format?: string | undefined
+  keyed?: boolean | undefined
+  values?: double[] | null | undefined
+  hdr?: AggregationsHdrMethod | undefined
+  tdigest?: AggregationsTDigest | undefined
+}
+export const AggregationsPercentileRanksAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  format: z.string().optional(),
+  keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
+  values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
+  hdr: AggregationsHdrMethod.describe('Uses the alternative High Dynamic Range Histogram algorithm to calculate percentile ranks.').optional(),
+  tdigest: AggregationsTDigest.describe('Sets parameters for the default TDigest algorithm used to calculate percentile ranks.').optional()
+}).meta({ id: 'AggregationsPercentileRanksAggregation' })
+export type AggregationsPercentileRanksAggregation = z.infer<typeof AggregationsPercentileRanksAggregation>
+
+export interface AggregationsPercentilesAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  format?: string | undefined
+  keyed?: boolean | undefined
+  percents?: double | double[] | undefined
+  hdr?: AggregationsHdrMethod | undefined
+  tdigest?: AggregationsTDigest | undefined
+}
+export const AggregationsPercentilesAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  format: z.string().optional(),
+  keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
+  percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
+  hdr: AggregationsHdrMethod.describe('Uses the alternative High Dynamic Range Histogram algorithm to calculate percentiles.').optional(),
+  tdigest: AggregationsTDigest.describe('Sets parameters for the default TDigest algorithm used to calculate percentiles.').optional()
+}).meta({ id: 'AggregationsPercentilesAggregation' })
+export type AggregationsPercentilesAggregation = z.infer<typeof AggregationsPercentilesAggregation>
+
+export const AggregationsPercentilesBucketAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape,
+  percents: z.array(double).describe('The list of percentiles to calculate.').optional()
+}).meta({ id: 'AggregationsPercentilesBucketAggregation' })
+export type AggregationsPercentilesBucketAggregation = z.infer<typeof AggregationsPercentilesBucketAggregation>
+
+export interface AggregationsRangeAggregationShape {
+  field?: Field | undefined
+  missing?: integer | undefined
+  ranges?: AggregationsAggregationRange[] | undefined
+  script?: ScriptShape | undefined
+  keyed?: boolean | undefined
+  format?: string | undefined
+}
+export const AggregationsRangeAggregation = z.object({
+  field: Field.describe('The date field whose values are use to build ranges.').optional(),
+  missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
+  format: z.string().optional()
+}).meta({ id: 'AggregationsRangeAggregation' })
+export type AggregationsRangeAggregation = z.infer<typeof AggregationsRangeAggregation>
+
+export const AggregationsRareTermsAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  exclude: AggregationsTermsExclude.describe('Terms that should be excluded from the aggregation.').optional(),
+  field: Field.describe('The field from which to return rare terms.').optional(),
+  include: AggregationsTermsInclude.describe('Terms that should be included in the aggregation.').optional(),
+  max_doc_count: long.describe('The maximum number of documents a term should appear in.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  precision: double.describe('The precision of the internal CuckooFilters. Smaller precision leads to better approximation, but higher memory usage.').optional(),
+  value_type: z.string().optional()
+}).meta({ id: 'AggregationsRareTermsAggregation' })
+export type AggregationsRareTermsAggregation = z.infer<typeof AggregationsRareTermsAggregation>
+
+export const AggregationsRateMode = z.enum(['sum', 'value_count']).meta({ id: 'AggregationsRateMode' })
+export type AggregationsRateMode = z.infer<typeof AggregationsRateMode>
+
+export interface AggregationsRateAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  format?: string | undefined
+  unit?: AggregationsCalendarInterval | undefined
+  mode?: AggregationsRateMode | undefined
+}
+export const AggregationsRateAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  format: z.string().optional(),
+  unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
+  mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
+}).meta({ id: 'AggregationsRateAggregation' })
+export type AggregationsRateAggregation = z.infer<typeof AggregationsRateAggregation>
+
+export const AggregationsReverseNestedAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  path: Field.describe('Defines the nested object field that should be joined back to. The default is empty, which means that it joins back to the root/main document level.').optional()
+}).meta({ id: 'AggregationsReverseNestedAggregation' })
+export type AggregationsReverseNestedAggregation = z.infer<typeof AggregationsReverseNestedAggregation>
+
+export const AggregationsSamplerAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional()
+}).meta({ id: 'AggregationsSamplerAggregation' })
+export type AggregationsSamplerAggregation = z.infer<typeof AggregationsSamplerAggregation>
+
+export interface AggregationsScriptedMetricAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  combine_script?: ScriptShape | undefined
+  init_script?: ScriptShape | undefined
+  map_script?: ScriptShape | undefined
+  params?: Record<string, unknown> | undefined
+  reduce_script?: ScriptShape | undefined
+}
+export const AggregationsScriptedMetricAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+}).meta({ id: 'AggregationsScriptedMetricAggregation' })
+export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
+
+export const AggregationsSerialDifferencingAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape,
+  lag: integer.describe('The historical bucket to subtract from the current value. Must be a positive, non-zero integer.').optional()
+}).meta({ id: 'AggregationsSerialDifferencingAggregation' })
+export type AggregationsSerialDifferencingAggregation = z.infer<typeof AggregationsSerialDifferencingAggregation>
+
+export const AggregationsChiSquareHeuristic = z.object({
+  background_is_superset: z.boolean().describe('Set to `false` if you defined a custom background filter that represents a different set of documents that you want to compare to.'),
+  include_negatives: z.boolean().describe('Set to `false` to filter out the terms that appear less often in the subset than in documents outside the subset.')
+}).meta({ id: 'AggregationsChiSquareHeuristic' })
+export type AggregationsChiSquareHeuristic = z.infer<typeof AggregationsChiSquareHeuristic>
+
+export const AggregationsTermsAggregationExecutionHint = z.enum(['map', 'global_ordinals', 'global_ordinals_hash', 'global_ordinals_low_cardinality']).meta({ id: 'AggregationsTermsAggregationExecutionHint' })
+export type AggregationsTermsAggregationExecutionHint = z.infer<typeof AggregationsTermsAggregationExecutionHint>
+
+export const AggregationsGoogleNormalizedDistanceHeuristic = z.object({
+  background_is_superset: z.boolean().describe('Set to `false` if you defined a custom background filter that represents a different set of documents that you want to compare to.').optional()
+}).meta({ id: 'AggregationsGoogleNormalizedDistanceHeuristic' })
+export type AggregationsGoogleNormalizedDistanceHeuristic = z.infer<typeof AggregationsGoogleNormalizedDistanceHeuristic>
+
+export const AggregationsMutualInformationHeuristic = z.object({
+  background_is_superset: z.boolean().describe('Set to `false` if you defined a custom background filter that represents a different set of documents that you want to compare to.').optional(),
+  include_negatives: z.boolean().describe('Set to `false` to filter out the terms that appear less often in the subset than in documents outside the subset.').optional()
+}).meta({ id: 'AggregationsMutualInformationHeuristic' })
+export type AggregationsMutualInformationHeuristic = z.infer<typeof AggregationsMutualInformationHeuristic>
+
+export const AggregationsPercentageScoreHeuristic = z.object({
+}).meta({ id: 'AggregationsPercentageScoreHeuristic' })
+export type AggregationsPercentageScoreHeuristic = z.infer<typeof AggregationsPercentageScoreHeuristic>
+
+export interface AggregationsScriptedHeuristicShape {
+  script: ScriptShape
+}
+export const AggregationsScriptedHeuristic = z.object({
+  get script () { return z.union([Script, ScriptSource]) }
+}).meta({ id: 'AggregationsScriptedHeuristic' })
+export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
+
+export const AggregationsPValueHeuristic = z.object({
+  background_is_superset: z.boolean().optional(),
+  normalize_above: long.describe('Should the results be normalized when above the given value. Allows for consistent significance results at various scales. Note: `0` is a special value which means no normalization').optional()
+}).meta({ id: 'AggregationsPValueHeuristic' })
+export type AggregationsPValueHeuristic = z.infer<typeof AggregationsPValueHeuristic>
+
+export interface AggregationsSignificantTermsAggregationShape {
+  background_filter?: QueryDslQueryContainerShape | undefined
+  chi_square?: AggregationsChiSquareHeuristic | undefined
+  exclude?: AggregationsTermsExclude | undefined
+  execution_hint?: AggregationsTermsAggregationExecutionHint | undefined
+  field?: Field | undefined
+  gnd?: AggregationsGoogleNormalizedDistanceHeuristic | undefined
+  include?: AggregationsTermsInclude | undefined
+  jlh?: EmptyObject | undefined
+  min_doc_count?: long | undefined
+  mutual_information?: AggregationsMutualInformationHeuristic | undefined
+  percentage?: AggregationsPercentageScoreHeuristic | undefined
+  script_heuristic?: AggregationsScriptedHeuristicShape | undefined
+  p_value?: AggregationsPValueHeuristic | undefined
+  shard_min_doc_count?: long | undefined
+  shard_size?: integer | undefined
+  size?: integer | undefined
+}
+export const AggregationsSignificantTermsAggregation = z.object({
+  get background_filter () { return QueryDslQueryContainer.describe('A background filter that can be used to focus in on significant terms within a narrower context, instead of the entire index.').optional() },
+  chi_square: AggregationsChiSquareHeuristic.describe('Use Chi square, as described in "Information Retrieval", Manning et al., Chapter 13.5.2, as the significance score.').optional(),
+  exclude: AggregationsTermsExclude.describe('Terms to exclude.').optional(),
+  execution_hint: AggregationsTermsAggregationExecutionHint.describe('Mechanism by which the aggregation should be executed: using field values directly or using global ordinals.').optional(),
+  field: Field.describe('The field from which to return significant terms.').optional(),
+  gnd: AggregationsGoogleNormalizedDistanceHeuristic.describe('Use Google normalized distance as described in "The Google Similarity Distance", Cilibrasi and Vitanyi, 2007, as the significance score.').optional(),
+  include: AggregationsTermsInclude.describe('Terms to include.').optional(),
+  jlh: EmptyObject.describe('Use JLH score as the significance score.').optional(),
+  min_doc_count: long.describe('Only return terms that are found in more than `min_doc_count` hits.').optional(),
+  mutual_information: AggregationsMutualInformationHeuristic.describe('Use mutual information as described in "Information Retrieval", Manning et al., Chapter 13.5.1, as the significance score.').optional(),
+  percentage: AggregationsPercentageScoreHeuristic.describe('A simple calculation of the number of documents in the foreground sample with a term divided by the number of documents in the background with the term.').optional(),
+  get script_heuristic () { return AggregationsScriptedHeuristic.describe('Customized score, implemented via a script.').optional() },
+  p_value: AggregationsPValueHeuristic.describe('Significant terms heuristic that calculates the p-value between the term existing in foreground and background sets. The p-value is the probability of obtaining test results at least as extreme as the results actually observed, under the assumption that the null hypothesis is correct. The p-value is calculated assuming that the foreground set and the background set are independent https://en.wikipedia.org/wiki/Bernoulli_trial, with the null hypothesis that the probabilities are the same.').optional(),
+  shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
+  shard_size: integer.describe('Can be used to control the volumes of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
+  size: integer.describe('The number of buckets returned out of the overall terms list.').optional()
+}).meta({ id: 'AggregationsSignificantTermsAggregation' })
+export type AggregationsSignificantTermsAggregation = z.infer<typeof AggregationsSignificantTermsAggregation>
+
+export interface AggregationsSignificantTextAggregationShape {
+  background_filter?: QueryDslQueryContainerShape | undefined
+  chi_square?: AggregationsChiSquareHeuristic | undefined
+  exclude?: AggregationsTermsExclude | undefined
+  execution_hint?: AggregationsTermsAggregationExecutionHint | undefined
+  field?: Field | undefined
+  filter_duplicate_text?: boolean | undefined
+  gnd?: AggregationsGoogleNormalizedDistanceHeuristic | undefined
+  include?: AggregationsTermsInclude | undefined
+  jlh?: EmptyObject | undefined
+  min_doc_count?: long | undefined
+  mutual_information?: AggregationsMutualInformationHeuristic | undefined
+  percentage?: AggregationsPercentageScoreHeuristic | undefined
+  script_heuristic?: AggregationsScriptedHeuristicShape | undefined
+  shard_min_doc_count?: long | undefined
+  shard_size?: integer | undefined
+  size?: integer | undefined
+  source_fields?: Fields | undefined
+}
+export const AggregationsSignificantTextAggregation = z.object({
+  get background_filter () { return QueryDslQueryContainer.describe('A background filter that can be used to focus in on significant terms within a narrower context, instead of the entire index.').optional() },
+  chi_square: AggregationsChiSquareHeuristic.describe('Use Chi square, as described in "Information Retrieval", Manning et al., Chapter 13.5.2, as the significance score.').optional(),
+  exclude: AggregationsTermsExclude.describe('Values to exclude.').optional(),
+  execution_hint: AggregationsTermsAggregationExecutionHint.describe('Determines whether the aggregation will use field values directly or global ordinals.').optional(),
+  field: Field.describe('The field from which to return significant text.').optional(),
+  filter_duplicate_text: z.boolean().describe('Whether to out duplicate text to deal with noisy data.').optional(),
+  gnd: AggregationsGoogleNormalizedDistanceHeuristic.describe('Use Google normalized distance as described in "The Google Similarity Distance", Cilibrasi and Vitanyi, 2007, as the significance score.').optional(),
+  include: AggregationsTermsInclude.describe('Values to include.').optional(),
+  jlh: EmptyObject.describe('Use JLH score as the significance score.').optional(),
+  min_doc_count: long.describe('Only return values that are found in more than `min_doc_count` hits.').optional(),
+  mutual_information: AggregationsMutualInformationHeuristic.describe('Use mutual information as described in "Information Retrieval", Manning et al., Chapter 13.5.1, as the significance score.').optional(),
+  percentage: AggregationsPercentageScoreHeuristic.describe('A simple calculation of the number of documents in the foreground sample with a term divided by the number of documents in the background with the term.').optional(),
+  get script_heuristic () { return AggregationsScriptedHeuristic.describe('Customized score, implemented via a script.').optional() },
+  shard_min_doc_count: long.describe('Regulates the certainty a shard has if the values should actually be added to the candidate list or not with respect to the min_doc_count. Values will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
+  shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
+  size: integer.describe('The number of buckets returned out of the overall terms list.').optional(),
+  source_fields: Fields.describe('Overrides the JSON `_source` fields from which text will be analyzed.').optional()
+}).meta({ id: 'AggregationsSignificantTextAggregation' })
+export type AggregationsSignificantTextAggregation = z.infer<typeof AggregationsSignificantTextAggregation>
+
+export interface AggregationsStatsAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  format?: string | undefined
+}
+export const AggregationsStatsAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  format: z.string().optional()
+}).meta({ id: 'AggregationsStatsAggregation' })
+export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
+
+export const AggregationsStatsBucketAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape
+}).meta({ id: 'AggregationsStatsBucketAggregation' })
+export type AggregationsStatsBucketAggregation = z.infer<typeof AggregationsStatsBucketAggregation>
+
+export interface AggregationsStringStatsAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  show_distribution?: boolean | undefined
+}
+export const AggregationsStringStatsAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
+}).meta({ id: 'AggregationsStringStatsAggregation' })
+export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
+
+export interface AggregationsSumAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  format?: string | undefined
+}
+export const AggregationsSumAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  format: z.string().optional()
+}).meta({ id: 'AggregationsSumAggregation' })
+export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
+
+export const AggregationsSumBucketAggregation = z.object({
+  ...AggregationsPipelineAggregationBase.shape
+}).meta({ id: 'AggregationsSumBucketAggregation' })
+export type AggregationsSumBucketAggregation = z.infer<typeof AggregationsSumBucketAggregation>
+
+export interface AggregationsTermsAggregationShape {
+  collect_mode?: AggregationsTermsAggregationCollectMode | undefined
+  exclude?: AggregationsTermsExclude | undefined
+  execution_hint?: AggregationsTermsAggregationExecutionHint | undefined
+  field?: Field | undefined
+  include?: AggregationsTermsInclude | undefined
+  min_doc_count?: integer | undefined
+  missing?: AggregationsMissing | undefined
+  missing_order?: AggregationsMissingOrder | undefined
+  missing_bucket?: boolean | undefined
+  value_type?: string | undefined
+  order?: AggregationsAggregateOrder | undefined
+  script?: ScriptShape | undefined
+  shard_min_doc_count?: long | undefined
+  shard_size?: integer | undefined
+  show_term_doc_count_error?: boolean | undefined
+  size?: integer | undefined
+  format?: string | undefined
+}
+export const AggregationsTermsAggregation = z.object({
+  collect_mode: AggregationsTermsAggregationCollectMode.describe('Determines how child aggregations should be calculated: breadth-first or depth-first.').optional(),
+  exclude: AggregationsTermsExclude.describe('Values to exclude. Accepts regular expressions and partitions.').optional(),
+  execution_hint: AggregationsTermsAggregationExecutionHint.describe('Determines whether the aggregation will use field values directly or global ordinals.').optional(),
+  field: Field.describe('The field from which to return terms.').optional(),
+  include: AggregationsTermsInclude.describe('Values to include. Accepts regular expressions and partitions.').optional(),
+  min_doc_count: integer.describe('Only return values that are found in more than `min_doc_count` hits.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  missing_order: AggregationsMissingOrder.optional(),
+  missing_bucket: z.boolean().optional(),
+  value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
+  order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
+  shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
+  show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
+  size: integer.describe('The number of buckets returned out of the overall terms list.').optional(),
+  format: z.string().optional()
+}).meta({ id: 'AggregationsTermsAggregation' })
+export type AggregationsTermsAggregation = z.infer<typeof AggregationsTermsAggregation>
+
+export const AggregationsTimeSeriesAggregation = z.object({
+  ...AggregationsBucketAggregationBase.shape,
+  size: integer.describe('The maximum number of results to return.').optional(),
+  keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and returns the ranges as a hash rather than an array.').optional()
+}).meta({ id: 'AggregationsTimeSeriesAggregation' })
+export type AggregationsTimeSeriesAggregation = z.infer<typeof AggregationsTimeSeriesAggregation>
+
+export interface AggregationsTopHitsAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  docvalue_fields?: QueryDslFieldAndFormat[] | undefined
+  explain?: boolean | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
+  from?: integer | undefined
+  highlight?: SearchHighlightShape | undefined
+  script_fields?: Record<string, ScriptFieldShape> | undefined
+  size?: integer | undefined
+  sort?: SortShape | undefined
+  _source?: SearchSourceConfig | undefined
+  stored_fields?: Fields | undefined
+  track_scores?: boolean | undefined
+  version?: boolean | undefined
+  seq_no_primary_term?: boolean | undefined
+}
+export const AggregationsTopHitsAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
+  explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  from: integer.describe('Starting document offset.').optional(),
+  get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
+  get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
+  size: integer.describe('The maximum number of top matching hits to return per bucket.').optional(),
+  get sort () { return Sort.describe('Sort order of the top matching hits. By default, the hits are sorted by the score of the main query.').optional() },
+  _source: SearchSourceConfig.describe('Selects the fields of the source that are returned.').optional(),
+  stored_fields: Fields.describe('Returns values for the specified stored fields (fields that use the `store` mapping option).').optional(),
+  track_scores: z.boolean().describe('If `true`, calculates and returns document scores, even if the scores are not used for sorting.').optional(),
+  version: z.boolean().describe('If `true`, returns document version as part of a hit.').optional(),
+  seq_no_primary_term: z.boolean().describe('If `true`, returns sequence number and primary term of the last modification of each hit.').optional()
+}).meta({ id: 'AggregationsTopHitsAggregation' })
+export type AggregationsTopHitsAggregation = z.infer<typeof AggregationsTopHitsAggregation>
+
+export interface AggregationsTestPopulationShape {
+  field: Field
+  script?: ScriptShape | undefined
+  filter?: QueryDslQueryContainerShape | undefined
+}
+export const AggregationsTestPopulation = z.object({
+  field: Field.describe('The field to aggregate.'),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
+}).meta({ id: 'AggregationsTestPopulation' })
+export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
+
+export const AggregationsTTestType = z.enum(['paired', 'homoscedastic', 'heteroscedastic']).meta({ id: 'AggregationsTTestType' })
+export type AggregationsTTestType = z.infer<typeof AggregationsTTestType>
+
+export interface AggregationsTTestAggregationShape {
+  a?: AggregationsTestPopulationShape | undefined
+  b?: AggregationsTestPopulationShape | undefined
+  type?: AggregationsTTestType | undefined
+}
+export const AggregationsTTestAggregation = z.object({
+  get a () { return AggregationsTestPopulation.describe('Test population A.').optional() },
+  get b () { return AggregationsTestPopulation.describe('Test population B.').optional() },
+  type: AggregationsTTestType.describe('The type of test.').optional()
+}).meta({ id: 'AggregationsTTestAggregation' })
+export type AggregationsTTestAggregation = z.infer<typeof AggregationsTTestAggregation>
+
+export const AggregationsTopMetricsValue = z.object({
+  field: Field.describe('A field to return as a metric.')
+}).meta({ id: 'AggregationsTopMetricsValue' })
+export type AggregationsTopMetricsValue = z.infer<typeof AggregationsTopMetricsValue>
+
+export interface AggregationsTopMetricsAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  metrics?: AggregationsTopMetricsValue | AggregationsTopMetricsValue[] | undefined
+  size?: integer | undefined
+  sort?: SortShape | undefined
+}
+export const AggregationsTopMetricsAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
+  size: integer.describe('The number of top documents from which to return metrics.').optional(),
+  get sort () { return Sort.describe('The sort order of the documents.').optional() }
+}).meta({ id: 'AggregationsTopMetricsAggregation' })
+export type AggregationsTopMetricsAggregation = z.infer<typeof AggregationsTopMetricsAggregation>
+
+export interface AggregationsFormattableMetricAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  format?: string | undefined
+}
+export const AggregationsFormattableMetricAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  format: z.string().optional()
+}).meta({ id: 'AggregationsFormattableMetricAggregation' })
+export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
+
+export interface AggregationsValueCountAggregationShape {
+  field?: Field | undefined
+  missing?: AggregationsMissing | undefined
+  script?: ScriptShape | undefined
+  format?: string | undefined
+}
+export const AggregationsValueCountAggregation = z.object({
+  field: Field.describe('The field on which to run the aggregation.').optional(),
+  missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  format: z.string().optional()
+}).meta({ id: 'AggregationsValueCountAggregation' })
+export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
+
+export interface AggregationsWeightedAverageValueShape {
+  field?: Field | undefined
+  missing?: double | undefined
+  script?: ScriptShape | undefined
+}
+export const AggregationsWeightedAverageValue = z.object({
+  field: Field.describe('The field from which to extract the values or weights.').optional(),
+  missing: double.describe('A value or weight to use if the field is missing.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() }
+}).meta({ id: 'AggregationsWeightedAverageValue' })
+export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
+
+export interface AggregationsWeightedAverageAggregationShape {
+  format?: string | undefined
+  value?: AggregationsWeightedAverageValueShape | undefined
+  value_type?: AggregationsValueType | undefined
+  weight?: AggregationsWeightedAverageValueShape | undefined
+}
+export const AggregationsWeightedAverageAggregation = z.object({
+  format: z.string().describe('A numeric response formatter.').optional(),
+  get value () { return AggregationsWeightedAverageValue.describe('Configuration for the field that provides the values.').optional() },
+  value_type: AggregationsValueType.optional(),
+  get weight () { return AggregationsWeightedAverageValue.describe('Configuration for the field or script that provides the weights.').optional() }
+}).meta({ id: 'AggregationsWeightedAverageAggregation' })
+export type AggregationsWeightedAverageAggregation = z.infer<typeof AggregationsWeightedAverageAggregation>
+
+export interface AggregationsVariableWidthHistogramAggregationShape {
+  field?: Field | undefined
+  buckets?: integer | undefined
+  shard_size?: integer | undefined
+  initial_buffer?: integer | undefined
+  script?: ScriptShape | undefined
+}
+export const AggregationsVariableWidthHistogramAggregation = z.object({
+  field: Field.describe('The name of the field.').optional(),
+  buckets: integer.describe('The target number of buckets.').optional(),
+  shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
+  initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() }
+}).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
+export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
+
+const AggregationsAggregationContainerCommonProps = z.object({
+  aggregations: z.record(z.string(), z.lazy(() => AggregationsAggregationContainer)).describe('Sub-aggregations for this aggregation. Only applies to bucket aggregations.').optional(),
+  aggs: z.record(z.string(), z.lazy(() => AggregationsAggregationContainer)).describe('Sub-aggregations for this aggregation. Only applies to bucket aggregations.').optional(),
+  meta: Metadata.optional()
+})
+
+const AggregationsAggregationContainerExclusiveProps = z.union([z.object({ adjacency_matrix: z.lazy(() => AggregationsAdjacencyMatrixAggregation) }), z.object({ auto_date_histogram: z.lazy(() => AggregationsAutoDateHistogramAggregation) }), z.object({ avg: z.lazy(() => AggregationsAverageAggregation) }), z.object({ avg_bucket: AggregationsAverageBucketAggregation }), z.object({ boxplot: z.lazy(() => AggregationsBoxplotAggregation) }), z.object({ bucket_script: z.lazy(() => AggregationsBucketScriptAggregation) }), z.object({ bucket_selector: z.lazy(() => AggregationsBucketSelectorAggregation) }), z.object({ bucket_sort: z.lazy(() => AggregationsBucketSortAggregation) }), z.object({ bucket_count_ks_test: AggregationsBucketKsAggregation }), z.object({ bucket_correlation: AggregationsBucketCorrelationAggregation }), z.object({ cardinality: z.lazy(() => AggregationsCardinalityAggregation) }), z.object({ cartesian_bounds: z.lazy(() => AggregationsCartesianBoundsAggregation) }), z.object({ cartesian_centroid: z.lazy(() => AggregationsCartesianCentroidAggregation) }), z.object({ categorize_text: AggregationsCategorizeTextAggregation }), z.object({ change_point: AggregationsChangePointAggregation }), z.object({ children: AggregationsChildrenAggregation }), z.object({ composite: z.lazy(() => AggregationsCompositeAggregation) }), z.object({ cumulative_cardinality: AggregationsCumulativeCardinalityAggregation }), z.object({ cumulative_sum: AggregationsCumulativeSumAggregation }), z.object({ date_histogram: z.lazy(() => AggregationsDateHistogramAggregation) }), z.object({ date_range: AggregationsDateRangeAggregation }), z.object({ derivative: AggregationsDerivativeAggregation }), z.object({ diversified_sampler: z.lazy(() => AggregationsDiversifiedSamplerAggregation) }), z.object({ extended_stats: z.lazy(() => AggregationsExtendedStatsAggregation) }), z.object({ extended_stats_bucket: AggregationsExtendedStatsBucketAggregation }), z.object({ frequent_item_sets: z.lazy(() => AggregationsFrequentItemSetsAggregation) }), z.object({ filter: z.lazy(() => QueryDslQueryContainer) }), z.object({ filters: AggregationsFiltersAggregation }), z.object({ geo_bounds: z.lazy(() => AggregationsGeoBoundsAggregation) }), z.object({ geo_centroid: z.lazy(() => AggregationsGeoCentroidAggregation) }), z.object({ geo_distance: AggregationsGeoDistanceAggregation }), z.object({ geohash_grid: AggregationsGeoHashGridAggregation }), z.object({ geo_line: AggregationsGeoLineAggregation }), z.object({ geotile_grid: AggregationsGeoTileGridAggregation }), z.object({ geohex_grid: AggregationsGeohexGridAggregation }), z.object({ global: AggregationsGlobalAggregation }), z.object({ histogram: z.lazy(() => AggregationsHistogramAggregation) }), z.object({ ip_range: AggregationsIpRangeAggregation }), z.object({ ip_prefix: AggregationsIpPrefixAggregation }), z.object({ inference: AggregationsInferenceAggregation }), z.object({ line: AggregationsGeoLineAggregation }), z.object({ matrix_stats: AggregationsMatrixStatsAggregation }), z.object({ max: z.lazy(() => AggregationsMaxAggregation) }), z.object({ max_bucket: AggregationsMaxBucketAggregation }), z.object({ median_absolute_deviation: z.lazy(() => AggregationsMedianAbsoluteDeviationAggregation) }), z.object({ min: z.lazy(() => AggregationsMinAggregation) }), z.object({ min_bucket: AggregationsMinBucketAggregation }), z.object({ missing: AggregationsMissingAggregation }), z.object({ moving_avg: AggregationsMovingAverageAggregation }), z.object({ moving_percentiles: AggregationsMovingPercentilesAggregation }), z.object({ moving_fn: AggregationsMovingFunctionAggregation }), z.object({ multi_terms: z.lazy(() => AggregationsMultiTermsAggregation) }), z.object({ nested: AggregationsNestedAggregation }), z.object({ normalize: AggregationsNormalizeAggregation }), z.object({ parent: AggregationsParentAggregation }), z.object({ percentile_ranks: z.lazy(() => AggregationsPercentileRanksAggregation) }), z.object({ percentiles: z.lazy(() => AggregationsPercentilesAggregation) }), z.object({ percentiles_bucket: AggregationsPercentilesBucketAggregation }), z.object({ range: z.lazy(() => AggregationsRangeAggregation) }), z.object({ rare_terms: AggregationsRareTermsAggregation }), z.object({ rate: z.lazy(() => AggregationsRateAggregation) }), z.object({ reverse_nested: AggregationsReverseNestedAggregation }), z.object({ sampler: AggregationsSamplerAggregation }), z.object({ scripted_metric: z.lazy(() => AggregationsScriptedMetricAggregation) }), z.object({ serial_diff: AggregationsSerialDifferencingAggregation }), z.object({ significant_terms: z.lazy(() => AggregationsSignificantTermsAggregation) }), z.object({ significant_text: z.lazy(() => AggregationsSignificantTextAggregation) }), z.object({ stats: z.lazy(() => AggregationsStatsAggregation) }), z.object({ stats_bucket: AggregationsStatsBucketAggregation }), z.object({ string_stats: z.lazy(() => AggregationsStringStatsAggregation) }), z.object({ sum: z.lazy(() => AggregationsSumAggregation) }), z.object({ sum_bucket: AggregationsSumBucketAggregation }), z.object({ terms: z.lazy(() => AggregationsTermsAggregation) }), z.object({ time_series: AggregationsTimeSeriesAggregation }), z.object({ top_hits: z.lazy(() => AggregationsTopHitsAggregation) }), z.object({ t_test: z.lazy(() => AggregationsTTestAggregation) }), z.object({ top_metrics: z.lazy(() => AggregationsTopMetricsAggregation) }), z.object({ value_count: z.lazy(() => AggregationsValueCountAggregation) }), z.object({ weighted_avg: z.lazy(() => AggregationsWeightedAverageAggregation) }), z.object({ variable_width_histogram: z.lazy(() => AggregationsVariableWidthHistogramAggregation) })])
+
+export interface AggregationsAggregationContainerShape {
+  aggregations?: Record<string, AggregationsAggregationContainerShape> | undefined
+  meta?: Metadata | undefined
+  adjacency_matrix?: AggregationsAdjacencyMatrixAggregation | undefined
+  auto_date_histogram?: AggregationsAutoDateHistogramAggregation | undefined
+  avg?: AggregationsAverageAggregation | undefined
+  avg_bucket?: AggregationsAverageBucketAggregation | undefined
+  boxplot?: AggregationsBoxplotAggregation | undefined
+  bucket_script?: AggregationsBucketScriptAggregation | undefined
+  bucket_selector?: AggregationsBucketSelectorAggregation | undefined
+  bucket_sort?: AggregationsBucketSortAggregation | undefined
+  bucket_count_ks_test?: AggregationsBucketKsAggregation | undefined
+  bucket_correlation?: AggregationsBucketCorrelationAggregation | undefined
+  cardinality?: AggregationsCardinalityAggregation | undefined
+  cartesian_bounds?: AggregationsCartesianBoundsAggregation | undefined
+  cartesian_centroid?: AggregationsCartesianCentroidAggregation | undefined
+  categorize_text?: AggregationsCategorizeTextAggregation | undefined
+  change_point?: AggregationsChangePointAggregation | undefined
+  children?: AggregationsChildrenAggregation | undefined
+  composite?: AggregationsCompositeAggregation | undefined
+  cumulative_cardinality?: AggregationsCumulativeCardinalityAggregation | undefined
+  cumulative_sum?: AggregationsCumulativeSumAggregation | undefined
+  date_histogram?: AggregationsDateHistogramAggregation | undefined
+  date_range?: AggregationsDateRangeAggregation | undefined
+  derivative?: AggregationsDerivativeAggregation | undefined
+  diversified_sampler?: AggregationsDiversifiedSamplerAggregation | undefined
+  extended_stats?: AggregationsExtendedStatsAggregation | undefined
+  extended_stats_bucket?: AggregationsExtendedStatsBucketAggregation | undefined
+  frequent_item_sets?: AggregationsFrequentItemSetsAggregation | undefined
+  filter?: QueryDslQueryContainer | undefined
+  filters?: AggregationsFiltersAggregation | undefined
+  geo_bounds?: AggregationsGeoBoundsAggregation | undefined
+  geo_centroid?: AggregationsGeoCentroidAggregation | undefined
+  geo_distance?: AggregationsGeoDistanceAggregation | undefined
+  geohash_grid?: AggregationsGeoHashGridAggregation | undefined
+  geo_line?: AggregationsGeoLineAggregation | undefined
+  geotile_grid?: AggregationsGeoTileGridAggregation | undefined
+  geohex_grid?: AggregationsGeohexGridAggregation | undefined
+  global?: AggregationsGlobalAggregation | undefined
+  histogram?: AggregationsHistogramAggregation | undefined
+  ip_range?: AggregationsIpRangeAggregation | undefined
+  ip_prefix?: AggregationsIpPrefixAggregation | undefined
+  inference?: AggregationsInferenceAggregation | undefined
+  line?: AggregationsGeoLineAggregation | undefined
+  matrix_stats?: AggregationsMatrixStatsAggregation | undefined
+  max?: AggregationsMaxAggregation | undefined
+  max_bucket?: AggregationsMaxBucketAggregation | undefined
+  median_absolute_deviation?: AggregationsMedianAbsoluteDeviationAggregation | undefined
+  min?: AggregationsMinAggregation | undefined
+  min_bucket?: AggregationsMinBucketAggregation | undefined
+  missing?: AggregationsMissingAggregation | undefined
+  moving_avg?: AggregationsMovingAverageAggregation | undefined
+  moving_percentiles?: AggregationsMovingPercentilesAggregation | undefined
+  moving_fn?: AggregationsMovingFunctionAggregation | undefined
+  multi_terms?: AggregationsMultiTermsAggregation | undefined
+  nested?: AggregationsNestedAggregation | undefined
+  normalize?: AggregationsNormalizeAggregation | undefined
+  parent?: AggregationsParentAggregation | undefined
+  percentile_ranks?: AggregationsPercentileRanksAggregation | undefined
+  percentiles?: AggregationsPercentilesAggregation | undefined
+  percentiles_bucket?: AggregationsPercentilesBucketAggregation | undefined
+  range?: AggregationsRangeAggregation | undefined
+  rare_terms?: AggregationsRareTermsAggregation | undefined
+  rate?: AggregationsRateAggregation | undefined
+  reverse_nested?: AggregationsReverseNestedAggregation | undefined
+  sampler?: AggregationsSamplerAggregation | undefined
+  scripted_metric?: AggregationsScriptedMetricAggregation | undefined
+  serial_diff?: AggregationsSerialDifferencingAggregation | undefined
+  significant_terms?: AggregationsSignificantTermsAggregation | undefined
+  significant_text?: AggregationsSignificantTextAggregation | undefined
+  stats?: AggregationsStatsAggregation | undefined
+  stats_bucket?: AggregationsStatsBucketAggregation | undefined
+  string_stats?: AggregationsStringStatsAggregation | undefined
+  sum?: AggregationsSumAggregation | undefined
+  sum_bucket?: AggregationsSumBucketAggregation | undefined
+  terms?: AggregationsTermsAggregation | undefined
+  time_series?: AggregationsTimeSeriesAggregation | undefined
+  top_hits?: AggregationsTopHitsAggregation | undefined
+  t_test?: AggregationsTTestAggregation | undefined
+  top_metrics?: AggregationsTopMetricsAggregation | undefined
+  value_count?: AggregationsValueCountAggregation | undefined
+  weighted_avg?: AggregationsWeightedAverageAggregation | undefined
+  variable_width_histogram?: AggregationsVariableWidthHistogramAggregation | undefined
+}
+export const AggregationsAggregationContainer: z.ZodType<AggregationsAggregationContainerShape> = AggregationsAggregationContainerCommonProps.and(AggregationsAggregationContainerExclusiveProps).meta({ id: 'AggregationsAggregationContainer' })
+export type AggregationsAggregationContainer = z.infer<typeof AggregationsAggregationContainer>
+
+/**
+ * Number of hits matching the query to count accurately. If true, the exact
+ * number of hits is returned at the cost of some performance. If false, the
+ * response does not include the total number of hits matching the query.
+ * Defaults to 10,000 hits.
+ */
+export const SearchTrackHits = z.union([z.boolean(), integer]).meta({ id: 'SearchTrackHits' })
+export type SearchTrackHits = z.infer<typeof SearchTrackHits>
+
+export interface KnnSearchShape {
+  field: Field
+  query_vector?: QueryVector | undefined
+  query_vector_builder?: QueryVectorBuilder | undefined
+  k?: integer | undefined
+  num_candidates?: integer | undefined
+  visit_percentage?: float | undefined
+  boost?: float | undefined
+  filter?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+  similarity?: float | undefined
+  inner_hits?: SearchInnerHitsShape | undefined
+  rescore_vector?: RescoreVector | undefined
+  query_name?: string | undefined
+}
+export const KnnSearch = z.object({
+  field: Field.describe('The name of the vector field to search against'),
+  query_vector: QueryVector.describe('The query vector').optional(),
+  query_vector_builder: QueryVectorBuilder.describe('The query vector builder. You must provide a query_vector_builder or query_vector, but not both.').optional(),
+  k: integer.describe('The final number of nearest neighbors to return as top hits').optional(),
+  num_candidates: integer.describe('The number of nearest neighbor candidates to consider per shard').optional(),
+  visit_percentage: float.describe('The percentage of vectors to explore per shard while doing knn search with bbq_disk').optional(),
+  boost: float.describe('Boost value to apply to kNN scores').optional(),
+  get filter (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('Filters for the kNN search query').optional() },
+  similarity: float.describe('The minimum similarity for a vector to be considered a match').optional(),
+  get inner_hits () { return SearchInnerHits.describe('If defined, each search hit will contain inner hits.').optional() },
+  rescore_vector: RescoreVector.describe('Apply oversampling and rescoring to quantized vectors').optional(),
+  query_name: z.string().optional()
+}).meta({ id: 'KnnSearch' })
+export type KnnSearch = z.infer<typeof KnnSearch>
+
+export const SearchScoreMode = z.enum(['avg', 'max', 'min', 'multiply', 'total']).meta({ id: 'SearchScoreMode' })
+export type SearchScoreMode = z.infer<typeof SearchScoreMode>
+
+export interface SearchRescoreQueryShape {
+  Query: QueryDslQueryContainerShape
+  query_weight?: double | undefined
+  rescore_query_weight?: double | undefined
+  score_mode?: SearchScoreMode | undefined
+}
+export const SearchRescoreQuery = z.object({
+  get Query () { return QueryDslQueryContainer.describe('The query to use for rescoring. This query is only run on the Top-K results returned by the `query` and `post_filter` phases.') },
+  query_weight: double.describe('Relative importance of the original query versus the rescore query.').optional(),
+  rescore_query_weight: double.describe('Relative importance of the rescore query versus the original query.').optional(),
+  score_mode: SearchScoreMode.describe('Determines how scores are combined.').optional()
+}).meta({ id: 'SearchRescoreQuery' })
+export type SearchRescoreQuery = z.infer<typeof SearchRescoreQuery>
+
+export const SearchLearningToRank = z.object({
+  model_id: z.string().describe('The unique identifier of the trained model uploaded to Elasticsearch'),
+  params: z.record(z.string(), z.any()).describe('Named parameters to be passed to the query templates used for feature').optional()
+}).meta({ id: 'SearchLearningToRank' })
+export type SearchLearningToRank = z.infer<typeof SearchLearningToRank>
+
+export interface SearchScriptRescoreShape {
+  script: ScriptShape
+}
+export const SearchScriptRescore = z.object({
+  get script () { return z.union([Script, ScriptSource]) }
+}).meta({ id: 'SearchScriptRescore' })
+export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
+
+const SearchRescoreCommonProps = z.object({
+  window_size: integer.optional()
+})
+
+const SearchRescoreExclusiveProps = z.union([z.object({ query: z.lazy(() => SearchRescoreQuery) }), z.object({ learning_to_rank: SearchLearningToRank }), z.object({ script: z.lazy(() => SearchScriptRescore) })])
+
+export interface SearchRescoreShape {
+  window_size?: integer | undefined
+  query?: SearchRescoreQuery | undefined
+  learning_to_rank?: SearchLearningToRank | undefined
+  script?: SearchScriptRescore | undefined
+}
+export const SearchRescore: z.ZodType<SearchRescoreShape> = SearchRescoreCommonProps.and(SearchRescoreExclusiveProps).meta({ id: 'SearchRescore' })
+export type SearchRescore = z.infer<typeof SearchRescore>
+
+export interface RetrieverBaseShape {
+  filter?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+  min_score?: float | undefined
+  _name?: string | undefined
+}
+export const RetrieverBase = z.object({
+  get filter (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('Query to filter the documents that can match.').optional() },
+  min_score: float.describe('Minimum _score for matching documents. Documents with a lower _score are not included in the top documents.').optional(),
+  _name: z.string().describe('Retriever name.').optional()
+}).meta({ id: 'RetrieverBase' })
+export type RetrieverBase = z.infer<typeof RetrieverBase>
+
+export interface StandardRetrieverShape {
+  filter?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+  min_score?: float | undefined
+  _name?: string | undefined
+  query?: QueryDslQueryContainerShape | undefined
+  search_after?: SortResults | undefined
+  terminate_after?: integer | undefined
+  sort?: SortShape | undefined
+  collapse?: SearchFieldCollapseShape | undefined
+}
+export const StandardRetriever = z.object({
+  get filter (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('Query to filter the documents that can match.').optional() },
+  min_score: float.describe('Minimum _score for matching documents. Documents with a lower _score are not included in the top documents.').optional(),
+  _name: z.string().describe('Retriever name.').optional(),
+  get query () { return QueryDslQueryContainer.describe('Defines a query to retrieve a set of top documents.').optional() },
+  search_after: SortResults.describe('Defines a search after object parameter used for pagination.').optional(),
+  terminate_after: integer.describe('Maximum number of documents to collect for each shard.').optional(),
+  get sort () { return Sort.describe('A sort object that that specifies the order of matching documents.').optional() },
+  get collapse () { return SearchFieldCollapse.describe('Collapses the top documents by a specified key into a single top document per key.').optional() }
+}).meta({ id: 'StandardRetriever' })
+export type StandardRetriever = z.infer<typeof StandardRetriever>
+
+export interface KnnRetrieverShape {
+  filter?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+  min_score?: float | undefined
+  _name?: string | undefined
+  field: string
+  query_vector?: QueryVector | undefined
+  query_vector_builder?: QueryVectorBuilder | undefined
+  k: integer
+  num_candidates: integer
+  visit_percentage?: float | undefined
+  similarity?: float | undefined
+  rescore_vector?: RescoreVector | undefined
+}
+export const KnnRetriever = z.object({
+  get filter (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('Query to filter the documents that can match.').optional() },
+  min_score: float.describe('Minimum _score for matching documents. Documents with a lower _score are not included in the top documents.').optional(),
+  _name: z.string().describe('Retriever name.').optional(),
+  field: z.string().describe('The name of the vector field to search against.'),
+  query_vector: QueryVector.describe('Query vector. Must have the same number of dimensions as the vector field you are searching against. You must provide a query_vector_builder or query_vector, but not both.').optional(),
+  query_vector_builder: QueryVectorBuilder.describe('Defines a model to build a query vector.').optional(),
+  k: integer.describe('Number of nearest neighbors to return as top hits.'),
+  num_candidates: integer.describe('Number of nearest neighbor candidates to consider per shard.'),
+  visit_percentage: float.describe('The percentage of vectors to explore per shard while doing knn search with bbq_disk').optional(),
+  similarity: float.describe('The minimum similarity required for a document to be considered a match.').optional(),
+  rescore_vector: RescoreVector.describe('Apply oversampling and rescoring to quantized vectors').optional()
+}).meta({ id: 'KnnRetriever' })
+export type KnnRetriever = z.infer<typeof KnnRetriever>
+
+export interface RRFRetrieverComponentShape {
+  retriever: RetrieverContainerShape
+  weight?: float | undefined
+}
+/** Wraps a retriever with an optional weight for RRF scoring. */
+export const RRFRetrieverComponent = z.object({
+  get retriever () { return RetrieverContainer.describe('The nested retriever configuration.') },
+  weight: float.describe('Weight multiplier for this retriever\'s contribution to the RRF score. Higher values increase influence. Defaults to 1.0 if not specified. Must be non-negative.').optional()
+}).meta({ id: 'RRFRetrieverComponent' })
+export type RRFRetrieverComponent = z.infer<typeof RRFRetrieverComponent>
+
+export type RRFRetrieverEntryShape = RetrieverContainerShape | RRFRetrieverComponentShape
+/** Either a direct RetrieverContainer (backward compatible) or an RRFRetrieverComponent with weight. */
+export const RRFRetrieverEntry: z.ZodType<RRFRetrieverEntryShape> = z.union([z.lazy(() => RetrieverContainer), z.lazy(() => RRFRetrieverComponent)]).meta({ id: 'RRFRetrieverEntry' })
+export type RRFRetrieverEntry = z.infer<typeof RRFRetrieverEntry>
+
+export interface RRFRetrieverShape {
+  filter?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+  min_score?: float | undefined
+  _name?: string | undefined
+  retrievers: RRFRetrieverEntryShape[]
+  rank_constant?: integer | undefined
+  rank_window_size?: integer | undefined
+  query?: string | undefined
+  fields?: string[] | undefined
+}
+export const RRFRetriever = z.object({
+  get filter (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('Query to filter the documents that can match.').optional() },
+  min_score: float.describe('Minimum _score for matching documents. Documents with a lower _score are not included in the top documents.').optional(),
+  _name: z.string().describe('Retriever name.').optional(),
+  get retrievers () { return RRFRetrieverEntry.array().describe('A list of child retrievers to specify which sets of returned top documents will have the RRF formula applied to them. Each retriever can optionally include a weight parameter.') },
+  rank_constant: integer.describe('This value determines how much influence documents in individual result sets per query have over the final ranked result set.').optional(),
+  rank_window_size: integer.describe('This value determines the size of the individual result sets per query.').optional(),
+  query: z.string().optional(),
+  fields: z.array(z.string()).optional()
+}).meta({ id: 'RRFRetriever' })
+export type RRFRetriever = z.infer<typeof RRFRetriever>
+
+export const MappingChunkRescorerChunkingSettings = z.object({
+  max_chunk_size: integer.describe('The maximum size of a chunk in words. This value cannot be lower than `20` (for `sentence` strategy) or `10` (for `word` strategy). This value should not exceed the window size for the associated model.'),
+  overlap: integer.describe('The number of overlapping words for chunks. It is applicable only to a `word` chunking strategy. This value cannot be higher than half the `max_chunk_size` value.').optional(),
+  sentence_overlap: integer.describe('The number of overlapping sentences for chunks. It is applicable only for a `sentence` chunking strategy. It can be either `1` or `0`.').optional(),
+  separator_group: z.string().describe('Only applicable to the `recursive` strategy and required when using it. Sets a predefined list of separators in the saved chunking settings based on the selected text type. Values can be `markdown` or `plaintext`. Using this parameter is an alternative to manually specifying a custom `separators` list.').optional(),
+  separators: z.array(z.string()).describe('Only applicable to the `recursive` strategy and required when using it. A list of strings used as possible split points when chunking text. Each string can be a plain string or a regular expression (regex) pattern. The system tries each separator in order to split the text, starting from the first item in the list. After splitting, it attempts to recombine smaller pieces into larger chunks that stay within the `max_chunk_size` limit, to reduce the total number of chunks generated.').optional(),
+  strategy: z.string().describe('The chunking strategy: `sentence`, `word`, `none` or `recursive`.  * If `strategy` is set to `recursive`, you must also specify: - `max_chunk_size` - either `separators` or`separator_group` Learn more about different chunking strategies in the linked documentation.').optional()
+}).meta({ id: 'MappingChunkRescorerChunkingSettings' })
+export type MappingChunkRescorerChunkingSettings = z.infer<typeof MappingChunkRescorerChunkingSettings>
+
+export const ChunkRescorer = z.object({
+  size: integer.describe('The number of chunks per document to evaluate for reranking.').optional(),
+  chunking_settings: MappingChunkRescorerChunkingSettings.describe('Chunking settings to apply').optional()
+}).meta({ id: 'ChunkRescorer' })
+export type ChunkRescorer = z.infer<typeof ChunkRescorer>
+
+export interface TextSimilarityRerankerShape {
+  filter?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+  min_score?: float | undefined
+  _name?: string | undefined
+  retriever: RetrieverContainerShape
+  rank_window_size?: integer | undefined
+  inference_id?: string | undefined
+  inference_text: string
+  field: string
+  chunk_rescorer?: ChunkRescorer | undefined
+}
+export const TextSimilarityReranker = z.object({
+  get filter (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('Query to filter the documents that can match.').optional() },
+  min_score: float.describe('Minimum _score for matching documents. Documents with a lower _score are not included in the top documents.').optional(),
+  _name: z.string().describe('Retriever name.').optional(),
+  get retriever () { return RetrieverContainer.describe('The nested retriever which will produce the first-level results, that will later be used for reranking.') },
+  rank_window_size: integer.describe('This value determines how many documents we will consider from the nested retriever.').optional(),
+  inference_id: z.string().describe('Unique identifier of the inference endpoint created using the inference API.').optional(),
+  inference_text: z.string().describe('The text snippet used as the basis for similarity comparison.'),
+  field: z.string().describe('The document field to be used for text similarity comparisons. This field should contain the text that will be evaluated against the inference_text.'),
+  chunk_rescorer: ChunkRescorer.describe('Whether to rescore on only the best matching chunks.').optional()
+}).meta({ id: 'TextSimilarityReranker' })
+export type TextSimilarityReranker = z.infer<typeof TextSimilarityReranker>
+
+export interface RuleRetrieverShape {
+  filter?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+  min_score?: float | undefined
+  _name?: string | undefined
+  ruleset_ids: Id | Id[]
+  match_criteria: unknown
+  retriever: RetrieverContainerShape
+  rank_window_size?: integer | undefined
+}
+export const RuleRetriever = z.object({
+  get filter (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('Query to filter the documents that can match.').optional() },
+  min_score: float.describe('Minimum _score for matching documents. Documents with a lower _score are not included in the top documents.').optional(),
+  _name: z.string().describe('Retriever name.').optional(),
+  ruleset_ids: z.union([Id, z.array(Id)]).describe('The ruleset IDs containing the rules this retriever is evaluating against.'),
+  match_criteria: z.any().describe('The match criteria that will determine if a rule in the provided rulesets should be applied.'),
+  get retriever () { return RetrieverContainer.describe('The retriever whose results rules should be applied to.') },
+  rank_window_size: integer.describe('This value determines the size of the individual result set.').optional()
+}).meta({ id: 'RuleRetriever' })
+export type RuleRetriever = z.infer<typeof RuleRetriever>
+
+export interface RescorerRetrieverShape {
+  filter?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+  min_score?: float | undefined
+  _name?: string | undefined
+  retriever: RetrieverContainerShape
+  rescore: SearchRescoreShape | SearchRescoreShape[]
+}
+export const RescorerRetriever = z.object({
+  get filter (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('Query to filter the documents that can match.').optional() },
+  min_score: float.describe('Minimum _score for matching documents. Documents with a lower _score are not included in the top documents.').optional(),
+  _name: z.string().describe('Retriever name.').optional(),
+  get retriever () { return RetrieverContainer.describe('Inner retriever.') },
+  get rescore (): z.ZodUnion<readonly [typeof SearchRescore, z.ZodArray<typeof SearchRescore>]> { return z.union([SearchRescore, SearchRescore.array()]) }
+}).meta({ id: 'RescorerRetriever' })
+export type RescorerRetriever = z.infer<typeof RescorerRetriever>
+
+export const ScoreNormalizer = z.enum(['none', 'minmax', 'l2_norm']).meta({ id: 'ScoreNormalizer' })
+export type ScoreNormalizer = z.infer<typeof ScoreNormalizer>
+
+export interface InnerRetrieverShape {
+  retriever: RetrieverContainerShape
+  weight: float
+  normalizer: ScoreNormalizer
+}
+export const InnerRetriever = z.object({
+  get retriever () { return RetrieverContainer },
+  weight: float,
+  normalizer: ScoreNormalizer
+}).meta({ id: 'InnerRetriever' })
+export type InnerRetriever = z.infer<typeof InnerRetriever>
+
+export interface LinearRetrieverShape {
+  filter?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+  min_score?: float | undefined
+  _name?: string | undefined
+  retrievers?: InnerRetrieverShape[] | undefined
+  rank_window_size?: integer | undefined
+  query?: string | undefined
+  fields?: string[] | undefined
+  normalizer?: ScoreNormalizer | undefined
+}
+export const LinearRetriever = z.object({
+  get filter (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('Query to filter the documents that can match.').optional() },
+  min_score: float.describe('Minimum _score for matching documents. Documents with a lower _score are not included in the top documents.').optional(),
+  _name: z.string().describe('Retriever name.').optional(),
+  get retrievers () { return InnerRetriever.array().describe('Inner retrievers.').optional() },
+  rank_window_size: integer.optional(),
+  query: z.string().optional(),
+  fields: z.array(z.string()).optional(),
+  normalizer: ScoreNormalizer.optional()
+}).meta({ id: 'LinearRetriever' })
+export type LinearRetriever = z.infer<typeof LinearRetriever>
+
+export const SpecifiedDocument = z.object({
+  index: IndexName.optional(),
+  id: Id
+}).meta({ id: 'SpecifiedDocument' })
+export type SpecifiedDocument = z.infer<typeof SpecifiedDocument>
+
+export interface PinnedRetrieverShape {
+  filter?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+  min_score?: float | undefined
+  _name?: string | undefined
+  retriever: RetrieverContainerShape
+  ids?: string[] | undefined
+  docs?: SpecifiedDocument[] | undefined
+  rank_window_size?: integer | undefined
+}
+export const PinnedRetriever = z.object({
+  get filter (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('Query to filter the documents that can match.').optional() },
+  min_score: float.describe('Minimum _score for matching documents. Documents with a lower _score are not included in the top documents.').optional(),
+  _name: z.string().describe('Retriever name.').optional(),
+  get retriever () { return RetrieverContainer.describe('Inner retriever.') },
+  ids: z.array(z.string()).optional(),
+  docs: z.array(SpecifiedDocument).optional(),
+  rank_window_size: integer.optional()
+}).meta({ id: 'PinnedRetriever' })
+export type PinnedRetriever = z.infer<typeof PinnedRetriever>
+
+export const DiversifyRetrieverTypes = z.enum(['mmr']).meta({ id: 'DiversifyRetrieverTypes' })
+export type DiversifyRetrieverTypes = z.infer<typeof DiversifyRetrieverTypes>
+
+export interface DiversifyRetrieverShape {
+  filter?: QueryDslQueryContainerShape | QueryDslQueryContainerShape[] | undefined
+  min_score?: float | undefined
+  _name?: string | undefined
+  type: DiversifyRetrieverTypes
+  field: string
+  retriever: RetrieverContainerShape
+  size?: integer | undefined
+  rank_window_size?: integer | undefined
+  query_vector?: QueryVector | undefined
+  query_vector_builder?: QueryVectorBuilder | undefined
+  lambda?: float | undefined
+}
+export const DiversifyRetriever = z.object({
+  get filter (): z.ZodOptional<z.ZodUnion<readonly [typeof QueryDslQueryContainer, z.ZodArray<typeof QueryDslQueryContainer>]>> { return z.union([QueryDslQueryContainer, QueryDslQueryContainer.array()]).describe('Query to filter the documents that can match.').optional() },
+  min_score: float.describe('Minimum _score for matching documents. Documents with a lower _score are not included in the top documents.').optional(),
+  _name: z.string().describe('Retriever name.').optional(),
+  type: DiversifyRetrieverTypes.describe('The diversification strategy to apply.'),
+  field: z.string().describe('The document field on which to diversify results on.'),
+  get retriever () { return RetrieverContainer.describe('The nested retriever whose results will be diversified.') },
+  size: integer.describe('The number of top documents to return after diversification.').optional(),
+  rank_window_size: integer.describe('The number of top documents from the nested retriever to consider for diversification.').optional(),
+  query_vector: QueryVector.describe('The query vector used for diversification.').optional(),
+  query_vector_builder: QueryVectorBuilder.describe('a dense vector query vector builder to use instead of a static query_vector').optional(),
+  lambda: float.describe('Controls the trade-off between relevance and diversity for MMR. A value of 0.0 focuses solely on diversity, while a value of 1.0 focuses solely on relevance. Required for MMR').optional()
+}).meta({ id: 'DiversifyRetriever' })
+export type DiversifyRetriever = z.infer<typeof DiversifyRetriever>
+
+const RetrieverContainerExclusiveProps = z.union([z.object({ standard: z.lazy(() => StandardRetriever) }), z.object({ knn: z.lazy(() => KnnRetriever) }), z.object({ rrf: z.lazy(() => RRFRetriever) }), z.object({ text_similarity_reranker: z.lazy(() => TextSimilarityReranker) }), z.object({ rule: z.lazy(() => RuleRetriever) }), z.object({ rescorer: z.lazy(() => RescorerRetriever) }), z.object({ linear: z.lazy(() => LinearRetriever) }), z.object({ pinned: z.lazy(() => PinnedRetriever) }), z.object({ diversify: z.lazy(() => DiversifyRetriever) })])
+
+export interface RetrieverContainerShape {
+  standard?: StandardRetriever | undefined
+  knn?: KnnRetriever | undefined
+  rrf?: RRFRetriever | undefined
+  text_similarity_reranker?: TextSimilarityReranker | undefined
+  rule?: RuleRetriever | undefined
+  rescorer?: RescorerRetriever | undefined
+  linear?: LinearRetriever | undefined
+  pinned?: PinnedRetriever | undefined
+  diversify?: DiversifyRetriever | undefined
+}
+export const RetrieverContainer: z.ZodType<RetrieverContainerShape> = RetrieverContainerExclusiveProps.meta({ id: 'RetrieverContainer' })
+export type RetrieverContainer = z.infer<typeof RetrieverContainer>
+
+export const SlicedScroll = z.object({
+  field: Field.optional(),
+  id: Id,
+  max: integer
+}).meta({ id: 'SlicedScroll' })
+export type SlicedScroll = z.infer<typeof SlicedScroll>
+
+export const SearchSuggester = z.object({
+  text: z.string().describe('Global suggest text, to avoid repetition when the same text is used in several suggesters').optional()
+}).catchall(z.any()).meta({ id: 'SearchSuggester' })
+export type SearchSuggester = z.infer<typeof SearchSuggester>
+
+export const SearchPointInTimeReference = z.object({
+  id: Id,
+  keep_alive: Duration.optional()
+}).meta({ id: 'SearchPointInTimeReference' })
+export type SearchPointInTimeReference = z.infer<typeof SearchPointInTimeReference>
+
+export const MappingRuntimeFieldType = z.enum(['boolean', 'composite', 'date', 'double', 'geo_point', 'geo_shape', 'ip', 'keyword', 'long', 'lookup']).meta({ id: 'MappingRuntimeFieldType' })
+export type MappingRuntimeFieldType = z.infer<typeof MappingRuntimeFieldType>
+
+export const MappingCompositeSubField = z.object({
+  type: MappingRuntimeFieldType
+}).meta({ id: 'MappingCompositeSubField' })
+export type MappingCompositeSubField = z.infer<typeof MappingCompositeSubField>
+
+export const MappingRuntimeFieldFetchFields = z.object({
+  field: Field,
+  format: z.string().optional()
+}).meta({ id: 'MappingRuntimeFieldFetchFields' })
+export type MappingRuntimeFieldFetchFields = z.infer<typeof MappingRuntimeFieldFetchFields>
+
+export interface MappingRuntimeFieldShape {
+  fields?: Record<string, MappingCompositeSubField> | undefined
+  fetch_fields?: MappingRuntimeFieldFetchFields[] | undefined
+  format?: string | undefined
+  input_field?: Field | undefined
+  target_field?: Field | undefined
+  target_index?: IndexName | undefined
+  script?: ScriptShape | undefined
+  type: MappingRuntimeFieldType
+}
+export const MappingRuntimeField = z.object({
+  fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
+  format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
+  input_field: Field.describe('For type `lookup`').optional(),
+  target_field: Field.describe('For type `lookup`').optional(),
+  target_index: IndexName.describe('For type `lookup`').optional(),
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
+  type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
+}).meta({ id: 'MappingRuntimeField' })
+export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
+
+export type MappingRuntimeFieldsShape = Record<Field, MappingRuntimeFieldShape>
+export const MappingRuntimeFields: z.ZodType<MappingRuntimeFieldsShape> = z.record(Field, z.lazy(() => MappingRuntimeField)).meta({ id: 'MappingRuntimeFields' })
+export type MappingRuntimeFields = z.infer<typeof MappingRuntimeFields>
+
+export interface SearchSearchRequestBodyShape {
+  aggregations?: Record<string, AggregationsAggregationContainerShape> | undefined
+  collapse?: SearchFieldCollapseShape | undefined
+  explain?: boolean | undefined
+  ext?: Record<string, unknown> | undefined
+  from?: integer | undefined
+  highlight?: SearchHighlightShape | undefined
+  track_total_hits?: SearchTrackHits | undefined
+  indices_boost?: Array<Record<IndexName, double>> | undefined
+  docvalue_fields?: QueryDslFieldAndFormat[] | undefined
+  knn?: KnnSearchShape | KnnSearchShape[] | undefined
+  min_score?: double | undefined
+  post_filter?: QueryDslQueryContainerShape | undefined
+  profile?: boolean | undefined
+  query?: QueryDslQueryContainerShape | undefined
+  rescore?: SearchRescoreShape | SearchRescoreShape[] | undefined
+  retriever?: RetrieverContainerShape | undefined
+  script_fields?: Record<string, ScriptFieldShape> | undefined
+  search_after?: SortResults | undefined
+  size?: integer | undefined
+  slice?: SlicedScroll | undefined
+  sort?: SortShape | undefined
+  _source?: SearchSourceConfig | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
+  suggest?: SearchSuggester | undefined
+  terminate_after?: long | undefined
+  timeout?: string | undefined
+  track_scores?: boolean | undefined
+  version?: boolean | undefined
+  seq_no_primary_term?: boolean | undefined
+  stored_fields?: Fields | undefined
+  pit?: SearchPointInTimeReference | undefined
+  runtime_mappings?: MappingRuntimeFieldsShape | undefined
+  stats?: string[] | undefined
+}
+export const SearchSearchRequestBody = z.object({
+  get aggregations (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof AggregationsAggregationContainer>> { return z.record(z.string(), AggregationsAggregationContainer).describe('Defines the aggregations that are run as part of the search request.').optional() },
+  get collapse () { return SearchFieldCollapse.describe('Collapses search results the values of the specified field.').optional() },
+  explain: z.boolean().describe('If `true`, the request returns detailed information about score computation as part of a hit.').optional(),
+  ext: z.record(z.string(), z.any()).describe('Configuration of search extensions defined by Elasticsearch plugins.').optional(),
+  from: integer.describe('The starting document offset, which must be non-negative. By default, you cannot page through more than 10,000 hits using the `from` and `size` parameters. To page through more hits, use the `search_after` parameter.').optional(),
+  get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
+  track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
+  indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
+  min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
+  get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
+  profile: z.boolean().describe('Set to `true` to return detailed timing information about the execution of individual components in a search request. NOTE: This is a debugging tool and adds significant overhead to search execution.').optional(),
+  get query () { return QueryDslQueryContainer.describe('The search definition using the Query DSL.').optional() },
+  get rescore (): z.ZodOptional<z.ZodUnion<readonly [typeof SearchRescore, z.ZodArray<typeof SearchRescore>]>> { return z.union([SearchRescore, SearchRescore.array()]).describe('Can be used to improve precision by reordering just the top (for example 100 - 500) documents returned by the `query` and `post_filter` phases.').optional() },
+  get retriever () { return RetrieverContainer.describe('A retriever is a specification to describe top documents returned from a search. A retriever replaces other elements of the search API that also return top documents such as `query` and `knn`.').optional() },
+  get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Retrieve a script evaluation (based on different fields) for each hit.').optional() },
+  search_after: SortResults.describe('Used to retrieve the next page of hits using a set of sort values from the previous page.').optional(),
+  size: integer.describe('The number of hits to return, which must not be negative. By default, you cannot page through more than 10,000 hits using the `from` and `size` parameters. To page through more hits, use the `search_after` property.').optional(),
+  slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
+  get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
+  _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
+  terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
+  timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
+  track_scores: z.boolean().describe('If `true`, calculate and return document scores, even if the scores are not used for sorting.').optional(),
+  version: z.boolean().describe('If `true`, the request returns the document version as part of a hit.').optional(),
+  seq_no_primary_term: z.boolean().describe('If `true`, the request returns sequence number and primary term of the last modification of each hit.').optional(),
+  stored_fields: Fields.describe('A comma-separated list of stored fields to return as part of a hit. If no fields are specified, no stored fields are included in the response. If this field is specified, the `_source` property defaults to `false`. You can pass `_source: true` to return both source fields and stored fields in the search response.').optional(),
+  pit: SearchPointInTimeReference.describe('Limit the search to a point in time (PIT). If you provide a PIT, you cannot specify an `<index>` in the request path.').optional(),
+  get runtime_mappings () { return MappingRuntimeFields.describe('One or more runtime fields in the search request. These fields take precedence over mapped fields with the same name.').optional() },
+  stats: z.array(z.string()).describe('The stats groups to associate with the search. Each group maintains a statistics aggregation for its associated searches. You can retrieve these stats using the indices stats API.').optional()
+}).meta({ id: 'SearchSearchRequestBody' })
+export type SearchSearchRequestBody = z.infer<typeof SearchSearchRequestBody>
+
+/**
+ * Coordinator snapshot of the original search request, serialized under `profile.request` when profiling is enabled.
+ * Introduced in Elasticsearch 9.5; omitted when the cluster contains mixed-version nodes that do not serialize this metadata.
+ */
+export const SearchSearchRequestCoordinatorMetadata = z.object({
+  source: z.lazy(() => SearchSearchRequestBody).describe('Original query source from the search request (`SearchSourceBuilder` as JSON).').optional(),
+  indices: z.array(IndexName).describe('Target index expressions from the request (before index resolution).').optional()
+}).meta({ id: 'SearchSearchRequestCoordinatorMetadata' })
+export type SearchSearchRequestCoordinatorMetadata = z.infer<typeof SearchSearchRequestCoordinatorMetadata>
+
 export const SearchProfile = z.object({
-  shards: z.array(SearchShardProfile)
+  shards: z.array(SearchShardProfile),
+  request: SearchSearchRequestCoordinatorMetadata.describe('When profiling is enabled, the original query source and target indices from the coordinating request.').optional()
 }).meta({ id: 'SearchProfile' })
 export type SearchProfile = z.infer<typeof SearchProfile>
 
@@ -593,30 +4539,6 @@ export const SearchSuggestBase = z.object({
   text: z.string()
 }).meta({ id: 'SearchSuggestBase' })
 export type SearchSuggestBase = z.infer<typeof SearchSuggestBase>
-
-export const LatLonGeoLocation = z.object({
-  lat: double.describe('Latitude'),
-  lon: double.describe('Longitude')
-}).meta({ id: 'LatLonGeoLocation' })
-export type LatLonGeoLocation = z.infer<typeof LatLonGeoLocation>
-
-export const GeoHash = z.string().meta({ id: 'GeoHash' })
-export type GeoHash = z.infer<typeof GeoHash>
-
-export const GeoHashLocation = z.object({
-  geohash: GeoHash
-}).meta({ id: 'GeoHashLocation' })
-export type GeoHashLocation = z.infer<typeof GeoHashLocation>
-
-/**
- * A latitude/longitude as a 2 dimensional point. It can be represented in various ways:
- * - as a `{lat, long}` object
- * - as a geo hash value
- * - as a `[lon, lat]` array
- * - as a string in `"<lat>, <lon>"` or WKT point formats
- */
-export const GeoLocation = z.union([LatLonGeoLocation, GeoHashLocation, z.array(double), z.string()]).meta({ id: 'GeoLocation' })
-export type GeoLocation = z.infer<typeof GeoLocation>
 
 /** Text or location that we want similar documents for or a lookup to a document's field for the text. */
 export const SearchContext = z.union([z.string(), GeoLocation]).meta({ id: 'SearchContext' })
@@ -691,9 +4613,6 @@ export const SearchResponseBody = z.object({
   terminated_early: z.boolean().optional()
 }).meta({ id: 'SearchResponseBody' })
 export type SearchResponseBody = z.infer<typeof SearchResponseBody>
-
-export const Name = z.string().meta({ id: 'Name' })
-export type Name = z.infer<typeof Name>
 
 export const RequestBase = z.object({
 }).meta({ id: 'RequestBase' })

--- a/packages/es-schemas/src/search_mvt.ts
+++ b/packages/es-schemas/src/search_mvt.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),

--- a/packages/es-schemas/src/search_shards.ts
+++ b/packages/es-schemas/src/search_shards.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),

--- a/packages/es-schemas/src/search_template.ts
+++ b/packages/es-schemas/src/search_template.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -636,7 +637,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -647,11 +648,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -667,7 +668,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -680,7 +681,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -694,7 +695,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -740,7 +741,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -756,7 +757,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -770,7 +771,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -835,7 +836,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -935,7 +936,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -950,7 +951,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -962,7 +963,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -1035,7 +1036,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -1053,7 +1054,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -1072,7 +1073,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -1103,7 +1104,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -1163,7 +1164,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -1246,7 +1247,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -1298,7 +1299,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -1314,7 +1315,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1386,7 +1387,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1401,7 +1402,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1507,7 +1508,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1589,7 +1590,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1610,7 +1611,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1626,7 +1627,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1741,7 +1742,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1818,7 +1819,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1840,7 +1841,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1867,7 +1868,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1899,7 +1900,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1931,12 +1932,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1974,7 +1975,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -2071,7 +2072,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -2090,7 +2091,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -2104,7 +2105,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -2145,7 +2146,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -2166,7 +2167,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -2181,7 +2182,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -2205,10 +2206,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -2229,7 +2230,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -2265,7 +2266,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -2281,7 +2282,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -2295,7 +2296,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -2308,7 +2309,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2338,7 +2339,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2449,6 +2450,36 @@ export type SearchTrackHits = z.infer<typeof SearchTrackHits>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2463,7 +2494,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2530,7 +2561,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2885,12 +2916,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2943,7 +2974,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2957,7 +2988,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2998,7 +3029,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -3176,7 +3207,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3700,7 +3731,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3716,7 +3747,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3879,7 +3910,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3955,7 +3986,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3996,7 +4027,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -4237,7 +4268,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -4249,13 +4281,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4445,8 +4478,19 @@ export const SearchShardProfile = z.object({
 }).meta({ id: 'SearchShardProfile' })
 export type SearchShardProfile = z.infer<typeof SearchShardProfile>
 
+/**
+ * Coordinator snapshot of the original search request, serialized under `profile.request` when profiling is enabled.
+ * Introduced in Elasticsearch 9.5; omitted when the cluster contains mixed-version nodes that do not serialize this metadata.
+ */
+export const SearchSearchRequestCoordinatorMetadata = z.object({
+  source: z.lazy(() => SearchSearchRequestBody).describe('Original query source from the search request (`SearchSourceBuilder` as JSON).').optional(),
+  indices: z.array(IndexName).describe('Target index expressions from the request (before index resolution).').optional()
+}).meta({ id: 'SearchSearchRequestCoordinatorMetadata' })
+export type SearchSearchRequestCoordinatorMetadata = z.infer<typeof SearchSearchRequestCoordinatorMetadata>
+
 export const SearchProfile = z.object({
-  shards: z.array(SearchShardProfile)
+  shards: z.array(SearchShardProfile),
+  request: SearchSearchRequestCoordinatorMetadata.describe('When profiling is enabled, the original query source and target indices from the coordinating request.').optional()
 }).meta({ id: 'SearchProfile' })
 export type SearchProfile = z.infer<typeof SearchProfile>
 

--- a/packages/es-schemas/src/searchable_snapshots_cache_stats.ts
+++ b/packages/es-schemas/src/searchable_snapshots_cache_stats.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/searchable_snapshots_clear_cache.ts
+++ b/packages/es-schemas/src/searchable_snapshots_clear_cache.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/searchable_snapshots_mount.ts
+++ b/packages/es-schemas/src/searchable_snapshots_mount.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/searchable_snapshots_stats.ts
+++ b/packages/es-schemas/src/searchable_snapshots_stats.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/security_activate_user_profile.ts
+++ b/packages/es-schemas/src/security_activate_user_profile.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/security_authenticate.ts
+++ b/packages/es-schemas/src/security_authenticate.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/security_bulk_delete_role.ts
+++ b/packages/es-schemas/src/security_bulk_delete_role.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/security_bulk_put_role.ts
+++ b/packages/es-schemas/src/security_bulk_put_role.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4024,7 +4057,7 @@ export const SecurityRoleTemplateScript = z.object({
 export type SecurityRoleTemplateScript = z.infer<typeof SecurityRoleTemplateScript>
 
 export const SecurityRoleTemplateQuery = z.object({
-  template: SecurityRoleTemplateScript.describe('When you create a role, you can specify a query that defines the document level security permissions. You can optionally use Mustache templates in the role query to insert the username of the current authenticated user into the role. Like other places in Elasticsearch that support templating or scripting, you can specify inline, stored, or file-based templates and define custom parameters. You access the details for the current authenticated user through the _user parameter.').optional()
+  template: z.union([SecurityRoleTemplateScript, SecurityRoleTemplateInlineQuery]).describe('When you create a role, you can specify a query that defines the document level security permissions. You can optionally use Mustache templates in the role query to insert the username of the current authenticated user into the role. Like other places in Elasticsearch that support templating or scripting, you can specify inline, stored, or file-based templates and define custom parameters. You access the details for the current authenticated user through the _user parameter.').optional()
 }).meta({ id: 'SecurityRoleTemplateQuery' })
 export type SecurityRoleTemplateQuery = z.infer<typeof SecurityRoleTemplateQuery>
 

--- a/packages/es-schemas/src/security_bulk_update_api_keys.ts
+++ b/packages/es-schemas/src/security_bulk_update_api_keys.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4021,7 +4054,7 @@ export const SecurityRoleTemplateScript = z.object({
 export type SecurityRoleTemplateScript = z.infer<typeof SecurityRoleTemplateScript>
 
 export const SecurityRoleTemplateQuery = z.object({
-  template: SecurityRoleTemplateScript.describe('When you create a role, you can specify a query that defines the document level security permissions. You can optionally use Mustache templates in the role query to insert the username of the current authenticated user into the role. Like other places in Elasticsearch that support templating or scripting, you can specify inline, stored, or file-based templates and define custom parameters. You access the details for the current authenticated user through the _user parameter.').optional()
+  template: z.union([SecurityRoleTemplateScript, SecurityRoleTemplateInlineQuery]).describe('When you create a role, you can specify a query that defines the document level security permissions. You can optionally use Mustache templates in the role query to insert the username of the current authenticated user into the role. Like other places in Elasticsearch that support templating or scripting, you can specify inline, stored, or file-based templates and define custom parameters. You access the details for the current authenticated user through the _user parameter.').optional()
 }).meta({ id: 'SecurityRoleTemplateQuery' })
 export type SecurityRoleTemplateQuery = z.infer<typeof SecurityRoleTemplateQuery>
 

--- a/packages/es-schemas/src/security_change_password.ts
+++ b/packages/es-schemas/src/security_change_password.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/security_clear_api_key_cache.ts
+++ b/packages/es-schemas/src/security_clear_api_key_cache.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/security_clear_cached_privileges.ts
+++ b/packages/es-schemas/src/security_clear_cached_privileges.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/security_clear_cached_realms.ts
+++ b/packages/es-schemas/src/security_clear_cached_realms.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/security_clear_cached_roles.ts
+++ b/packages/es-schemas/src/security_clear_cached_roles.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/security_clear_cached_service_tokens.ts
+++ b/packages/es-schemas/src/security_clear_cached_service_tokens.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/security_clone_api_key.ts
+++ b/packages/es-schemas/src/security_clone_api_key.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/security_create_api_key.ts
+++ b/packages/es-schemas/src/security_create_api_key.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -3996,7 +4029,7 @@ export const SecurityRoleTemplateScript = z.object({
 export type SecurityRoleTemplateScript = z.infer<typeof SecurityRoleTemplateScript>
 
 export const SecurityRoleTemplateQuery = z.object({
-  template: SecurityRoleTemplateScript.describe('When you create a role, you can specify a query that defines the document level security permissions. You can optionally use Mustache templates in the role query to insert the username of the current authenticated user into the role. Like other places in Elasticsearch that support templating or scripting, you can specify inline, stored, or file-based templates and define custom parameters. You access the details for the current authenticated user through the _user parameter.').optional()
+  template: z.union([SecurityRoleTemplateScript, SecurityRoleTemplateInlineQuery]).describe('When you create a role, you can specify a query that defines the document level security permissions. You can optionally use Mustache templates in the role query to insert the username of the current authenticated user into the role. Like other places in Elasticsearch that support templating or scripting, you can specify inline, stored, or file-based templates and define custom parameters. You access the details for the current authenticated user through the _user parameter.').optional()
 }).meta({ id: 'SecurityRoleTemplateQuery' })
 export type SecurityRoleTemplateQuery = z.infer<typeof SecurityRoleTemplateQuery>
 

--- a/packages/es-schemas/src/security_create_cross_cluster_api_key.ts
+++ b/packages/es-schemas/src/security_create_cross_cluster_api_key.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -3989,7 +4022,7 @@ export const SecurityRoleTemplateScript = z.object({
 export type SecurityRoleTemplateScript = z.infer<typeof SecurityRoleTemplateScript>
 
 export const SecurityRoleTemplateQuery = z.object({
-  template: SecurityRoleTemplateScript.describe('When you create a role, you can specify a query that defines the document level security permissions. You can optionally use Mustache templates in the role query to insert the username of the current authenticated user into the role. Like other places in Elasticsearch that support templating or scripting, you can specify inline, stored, or file-based templates and define custom parameters. You access the details for the current authenticated user through the _user parameter.').optional()
+  template: z.union([SecurityRoleTemplateScript, SecurityRoleTemplateInlineQuery]).describe('When you create a role, you can specify a query that defines the document level security permissions. You can optionally use Mustache templates in the role query to insert the username of the current authenticated user into the role. Like other places in Elasticsearch that support templating or scripting, you can specify inline, stored, or file-based templates and define custom parameters. You access the details for the current authenticated user through the _user parameter.').optional()
 }).meta({ id: 'SecurityRoleTemplateQuery' })
 export type SecurityRoleTemplateQuery = z.infer<typeof SecurityRoleTemplateQuery>
 

--- a/packages/es-schemas/src/security_create_service_token.ts
+++ b/packages/es-schemas/src/security_create_service_token.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -39,6 +40,9 @@ export type Service = z.infer<typeof Service>
  *
  * NOTE: Service account tokens never expire.
  * You must actively delete them if they are no longer needed.
+ *
+ * IMPORTANT: On Serverless, non-operator users can create tokens for only `elastic/fleet-server` and `elastic/fleet-server-remote`.
+ * Creating tokens for any other service account requires operator privileges.
  */
 export const SecurityCreateServiceTokenRequest = z.object({
   ...RequestBase.shape,

--- a/packages/es-schemas/src/security_delegate_pki.ts
+++ b/packages/es-schemas/src/security_delegate_pki.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/security_delete_privileges.ts
+++ b/packages/es-schemas/src/security_delete_privileges.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/security_delete_role.ts
+++ b/packages/es-schemas/src/security_delete_role.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/security_delete_role_mapping.ts
+++ b/packages/es-schemas/src/security_delete_role_mapping.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/security_delete_service_token.ts
+++ b/packages/es-schemas/src/security_delete_service_token.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -36,6 +37,9 @@ export type Service = z.infer<typeof Service>
  * Delete service account tokens.
  *
  * Delete service account tokens for a service in a specified namespace.
+ *
+ * IMPORTANT: On Serverless, non-operator users can delete tokens for only `elastic/fleet-server` and `elastic/fleet-server-remote`.
+ * Deleting tokens for any other service account requires operator privileges.
  */
 export const SecurityDeleteServiceTokenRequest = z.object({
   ...RequestBase.shape,

--- a/packages/es-schemas/src/security_delete_user.ts
+++ b/packages/es-schemas/src/security_delete_user.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/security_disable_user.ts
+++ b/packages/es-schemas/src/security_disable_user.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/security_disable_user_profile.ts
+++ b/packages/es-schemas/src/security_disable_user_profile.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/security_enable_user.ts
+++ b/packages/es-schemas/src/security_enable_user.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/security_enable_user_profile.ts
+++ b/packages/es-schemas/src/security_enable_user_profile.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/security_enroll_kibana.ts
+++ b/packages/es-schemas/src/security_enroll_kibana.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/security_enroll_node.ts
+++ b/packages/es-schemas/src/security_enroll_node.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/security_get_api_key.ts
+++ b/packages/es-schemas/src/security_get_api_key.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -3989,7 +4022,7 @@ export const SecurityRoleTemplateScript = z.object({
 export type SecurityRoleTemplateScript = z.infer<typeof SecurityRoleTemplateScript>
 
 export const SecurityRoleTemplateQuery = z.object({
-  template: SecurityRoleTemplateScript.describe('When you create a role, you can specify a query that defines the document level security permissions. You can optionally use Mustache templates in the role query to insert the username of the current authenticated user into the role. Like other places in Elasticsearch that support templating or scripting, you can specify inline, stored, or file-based templates and define custom parameters. You access the details for the current authenticated user through the _user parameter.').optional()
+  template: z.union([SecurityRoleTemplateScript, SecurityRoleTemplateInlineQuery]).describe('When you create a role, you can specify a query that defines the document level security permissions. You can optionally use Mustache templates in the role query to insert the username of the current authenticated user into the role. Like other places in Elasticsearch that support templating or scripting, you can specify inline, stored, or file-based templates and define custom parameters. You access the details for the current authenticated user through the _user parameter.').optional()
 }).meta({ id: 'SecurityRoleTemplateQuery' })
 export type SecurityRoleTemplateQuery = z.infer<typeof SecurityRoleTemplateQuery>
 

--- a/packages/es-schemas/src/security_get_builtin_privileges.ts
+++ b/packages/es-schemas/src/security_get_builtin_privileges.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/security_get_privileges.ts
+++ b/packages/es-schemas/src/security_get_privileges.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/security_get_role.ts
+++ b/packages/es-schemas/src/security_get_role.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -3996,7 +4029,7 @@ export const SecurityRoleTemplateScript = z.object({
 export type SecurityRoleTemplateScript = z.infer<typeof SecurityRoleTemplateScript>
 
 export const SecurityRoleTemplateQuery = z.object({
-  template: SecurityRoleTemplateScript.describe('When you create a role, you can specify a query that defines the document level security permissions. You can optionally use Mustache templates in the role query to insert the username of the current authenticated user into the role. Like other places in Elasticsearch that support templating or scripting, you can specify inline, stored, or file-based templates and define custom parameters. You access the details for the current authenticated user through the _user parameter.').optional()
+  template: z.union([SecurityRoleTemplateScript, SecurityRoleTemplateInlineQuery]).describe('When you create a role, you can specify a query that defines the document level security permissions. You can optionally use Mustache templates in the role query to insert the username of the current authenticated user into the role. Like other places in Elasticsearch that support templating or scripting, you can specify inline, stored, or file-based templates and define custom parameters. You access the details for the current authenticated user through the _user parameter.').optional()
 }).meta({ id: 'SecurityRoleTemplateQuery' })
 export type SecurityRoleTemplateQuery = z.infer<typeof SecurityRoleTemplateQuery>
 
@@ -4009,22 +4042,28 @@ export type SecurityRoleTemplateQuery = z.infer<typeof SecurityRoleTemplateQuery
 export const SecurityIndicesPrivilegesQuery = z.union([z.string(), z.lazy(() => QueryDslQueryContainer), SecurityRoleTemplateQuery]).meta({ id: 'SecurityIndicesPrivilegesQuery' })
 export type SecurityIndicesPrivilegesQuery = z.infer<typeof SecurityIndicesPrivilegesQuery>
 
-export const SecurityIndicesPrivileges = z.object({
-  field_security: SecurityFieldSecurity.describe('The document fields that the owners of the role have read access to.').optional(),
-  names: z.union([IndexName, z.array(IndexName)]).describe('A list of indices (or index name patterns) to which the permissions in this entry apply.'),
-  privileges: z.array(SecurityIndexPrivilege).describe('The index level privileges that owners of the role have on the specified indices.'),
-  query: SecurityIndicesPrivilegesQuery.describe('A search query that defines the documents the owners of the role have access to. A document within the specified indices must match this query for it to be accessible by the owners of the role.').optional()
-}).meta({ id: 'SecurityIndicesPrivileges' })
-export type SecurityIndicesPrivileges = z.infer<typeof SecurityIndicesPrivileges>
-
 export const SecurityTemplateFormat = z.enum(['string', 'json']).meta({ id: 'SecurityTemplateFormat' })
 export type SecurityTemplateFormat = z.infer<typeof SecurityTemplateFormat>
 
 export const SecurityRoleTemplate = z.object({
   format: SecurityTemplateFormat.optional(),
-  template: z.lazy(() => Script)
+  template: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)])
 }).meta({ id: 'SecurityRoleTemplate' })
 export type SecurityRoleTemplate = z.infer<typeof SecurityRoleTemplate>
+
+/**
+ * Read-side variant of `IndicesPrivileges` returned by the get role API.
+ * Carries the `implicitly_granted` marker that is set on entries contributed by
+ * a registered `ImplicitPrivilegesProvider` when `include_implicit` is `true`.
+ */
+export const SecurityGetRoleIndicesPrivilegesRead = z.object({
+  implicitly_granted: z.boolean().describe('Set to `true` on entries that were contributed by a registered `ImplicitPrivilegesProvider` rather than explicitly stored on the role. Only present when the get role API is called with `include_implicit=true`. The put role API rejects this field, so clients must not echo it back on a GET-then-PUT round-trip.').optional(),
+  field_security: SecurityFieldSecurity.describe('The document fields that the owners of the role have read access to.').optional(),
+  names: z.union([IndexName, z.array(IndexName)]).describe('A list of indices (or index name patterns) to which the permissions in this entry apply.'),
+  privileges: z.array(SecurityIndexPrivilege).describe('The index level privileges that owners of the role have on the specified indices.'),
+  query: SecurityIndicesPrivilegesQuery.describe('A search query that defines the documents the owners of the role have access to. A document within the specified indices must match this query for it to be accessible by the owners of the role.').optional()
+}).meta({ id: 'SecurityGetRoleIndicesPrivilegesRead' })
+export type SecurityGetRoleIndicesPrivilegesRead = z.infer<typeof SecurityGetRoleIndicesPrivilegesRead>
 
 /**
  * Get roles.
@@ -4035,13 +4074,14 @@ export type SecurityRoleTemplate = z.infer<typeof SecurityRoleTemplate>
  */
 export const SecurityGetRoleRequest = z.object({
   ...RequestBase.shape,
-  name: Names.describe('The name of the role. You can specify multiple roles as a comma-separated list. If you do not specify this parameter, the API returns information about all roles.').optional().meta({ found_in: 'path' })
+  name: Names.describe('The name of the role. You can specify multiple roles as a comma-separated list. If you do not specify this parameter, the API returns information about all roles.').optional().meta({ found_in: 'path' }),
+  include_implicit: z.boolean().describe('If `true`, include privileges that are implicitly granted by registered `ImplicitPrivilegesProviders` alongside the explicitly configured privileges. Each implicit entry in the response is annotated with `implicitly_granted: true`.').optional().meta({ found_in: 'query' })
 }).meta({ id: 'SecurityGetRoleRequest' })
 export type SecurityGetRoleRequest = z.infer<typeof SecurityGetRoleRequest>
 
 export const SecurityGetRoleRole = z.object({
   cluster: z.array(SecurityClusterPrivilege),
-  indices: z.array(SecurityIndicesPrivileges),
+  indices: z.array(SecurityGetRoleIndicesPrivilegesRead),
   metadata: Metadata,
   description: z.string().optional(),
   run_as: z.array(z.string()).optional(),

--- a/packages/es-schemas/src/security_get_role_mapping.ts
+++ b/packages/es-schemas/src/security_get_role_mapping.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -3969,7 +4002,7 @@ export type SecurityTemplateFormat = z.infer<typeof SecurityTemplateFormat>
 
 export const SecurityRoleTemplate = z.object({
   format: SecurityTemplateFormat.optional(),
-  template: z.lazy(() => Script)
+  template: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)])
 }).meta({ id: 'SecurityRoleTemplate' })
 export type SecurityRoleTemplate = z.infer<typeof SecurityRoleTemplate>
 

--- a/packages/es-schemas/src/security_get_service_accounts.ts
+++ b/packages/es-schemas/src/security_get_service_accounts.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -3999,7 +4032,7 @@ export const SecurityRoleTemplateScript = z.object({
 export type SecurityRoleTemplateScript = z.infer<typeof SecurityRoleTemplateScript>
 
 export const SecurityRoleTemplateQuery = z.object({
-  template: SecurityRoleTemplateScript.describe('When you create a role, you can specify a query that defines the document level security permissions. You can optionally use Mustache templates in the role query to insert the username of the current authenticated user into the role. Like other places in Elasticsearch that support templating or scripting, you can specify inline, stored, or file-based templates and define custom parameters. You access the details for the current authenticated user through the _user parameter.').optional()
+  template: z.union([SecurityRoleTemplateScript, SecurityRoleTemplateInlineQuery]).describe('When you create a role, you can specify a query that defines the document level security permissions. You can optionally use Mustache templates in the role query to insert the username of the current authenticated user into the role. Like other places in Elasticsearch that support templating or scripting, you can specify inline, stored, or file-based templates and define custom parameters. You access the details for the current authenticated user through the _user parameter.').optional()
 }).meta({ id: 'SecurityRoleTemplateQuery' })
 export type SecurityRoleTemplateQuery = z.infer<typeof SecurityRoleTemplateQuery>
 

--- a/packages/es-schemas/src/security_get_service_credentials.ts
+++ b/packages/es-schemas/src/security_get_service_credentials.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/security_get_settings.ts
+++ b/packages/es-schemas/src/security_get_settings.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4580,7 +4613,7 @@ export const AnalysisConditionTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('condition'),
   filter: z.array(z.string()).describe('Array of token filters. If a token matches the predicate script in the `script` parameter, these filters are applied to the token in the order provided.'),
-  script: z.lazy(() => Script).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
 }).meta({ id: 'AnalysisConditionTokenFilter' })
 export type AnalysisConditionTokenFilter = z.infer<typeof AnalysisConditionTokenFilter>
 
@@ -5061,7 +5094,7 @@ export type AnalysisPorterStemTokenFilter = z.infer<typeof AnalysisPorterStemTok
 export const AnalysisPredicateTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('predicate_token_filter'),
-  script: z.lazy(() => Script).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
 }).meta({ id: 'AnalysisPredicateTokenFilter' })
 export type AnalysisPredicateTokenFilter = z.infer<typeof AnalysisPredicateTokenFilter>
 
@@ -5544,8 +5577,8 @@ export type IndicesSettingsSimilarityLmj = z.infer<typeof IndicesSettingsSimilar
 
 export const IndicesSettingsSimilarityScripted = z.object({
   type: z.literal('scripted'),
-  script: z.lazy(() => Script),
-  weight_script: z.lazy(() => Script).optional()
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]),
+  weight_script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).optional()
 }).meta({ id: 'IndicesSettingsSimilarityScripted' })
 export type IndicesSettingsSimilarityScripted = z.infer<typeof IndicesSettingsSimilarityScripted>
 

--- a/packages/es-schemas/src/security_get_stats.ts
+++ b/packages/es-schemas/src/security_get_stats.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/security_get_token.ts
+++ b/packages/es-schemas/src/security_get_token.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/security_get_user.ts
+++ b/packages/es-schemas/src/security_get_user.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/security_get_user_privileges.ts
+++ b/packages/es-schemas/src/security_get_user_privileges.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4008,7 +4041,7 @@ export const SecurityRoleTemplateScript = z.object({
 export type SecurityRoleTemplateScript = z.infer<typeof SecurityRoleTemplateScript>
 
 export const SecurityRoleTemplateQuery = z.object({
-  template: SecurityRoleTemplateScript.describe('When you create a role, you can specify a query that defines the document level security permissions. You can optionally use Mustache templates in the role query to insert the username of the current authenticated user into the role. Like other places in Elasticsearch that support templating or scripting, you can specify inline, stored, or file-based templates and define custom parameters. You access the details for the current authenticated user through the _user parameter.').optional()
+  template: z.union([SecurityRoleTemplateScript, SecurityRoleTemplateInlineQuery]).describe('When you create a role, you can specify a query that defines the document level security permissions. You can optionally use Mustache templates in the role query to insert the username of the current authenticated user into the role. Like other places in Elasticsearch that support templating or scripting, you can specify inline, stored, or file-based templates and define custom parameters. You access the details for the current authenticated user through the _user parameter.').optional()
 }).meta({ id: 'SecurityRoleTemplateQuery' })
 export type SecurityRoleTemplateQuery = z.infer<typeof SecurityRoleTemplateQuery>
 

--- a/packages/es-schemas/src/security_get_user_profile.ts
+++ b/packages/es-schemas/src/security_get_user_profile.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/security_grant_api_key.ts
+++ b/packages/es-schemas/src/security_grant_api_key.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4002,7 +4035,7 @@ export const SecurityRoleTemplateScript = z.object({
 export type SecurityRoleTemplateScript = z.infer<typeof SecurityRoleTemplateScript>
 
 export const SecurityRoleTemplateQuery = z.object({
-  template: SecurityRoleTemplateScript.describe('When you create a role, you can specify a query that defines the document level security permissions. You can optionally use Mustache templates in the role query to insert the username of the current authenticated user into the role. Like other places in Elasticsearch that support templating or scripting, you can specify inline, stored, or file-based templates and define custom parameters. You access the details for the current authenticated user through the _user parameter.').optional()
+  template: z.union([SecurityRoleTemplateScript, SecurityRoleTemplateInlineQuery]).describe('When you create a role, you can specify a query that defines the document level security permissions. You can optionally use Mustache templates in the role query to insert the username of the current authenticated user into the role. Like other places in Elasticsearch that support templating or scripting, you can specify inline, stored, or file-based templates and define custom parameters. You access the details for the current authenticated user through the _user parameter.').optional()
 }).meta({ id: 'SecurityRoleTemplateQuery' })
 export type SecurityRoleTemplateQuery = z.infer<typeof SecurityRoleTemplateQuery>
 

--- a/packages/es-schemas/src/security_has_privileges.ts
+++ b/packages/es-schemas/src/security_has_privileges.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/security_has_privileges_user_profile.ts
+++ b/packages/es-schemas/src/security_has_privileges_user_profile.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/security_invalidate_api_key.ts
+++ b/packages/es-schemas/src/security_invalidate_api_key.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/security_invalidate_token.ts
+++ b/packages/es-schemas/src/security_invalidate_token.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/security_oidc_authenticate.ts
+++ b/packages/es-schemas/src/security_oidc_authenticate.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/security_oidc_logout.ts
+++ b/packages/es-schemas/src/security_oidc_logout.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/security_oidc_prepare_authentication.ts
+++ b/packages/es-schemas/src/security_oidc_prepare_authentication.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/security_put_privileges.ts
+++ b/packages/es-schemas/src/security_put_privileges.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/security_put_role.ts
+++ b/packages/es-schemas/src/security_put_role.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4001,7 +4034,7 @@ export const SecurityRoleTemplateScript = z.object({
 export type SecurityRoleTemplateScript = z.infer<typeof SecurityRoleTemplateScript>
 
 export const SecurityRoleTemplateQuery = z.object({
-  template: SecurityRoleTemplateScript.describe('When you create a role, you can specify a query that defines the document level security permissions. You can optionally use Mustache templates in the role query to insert the username of the current authenticated user into the role. Like other places in Elasticsearch that support templating or scripting, you can specify inline, stored, or file-based templates and define custom parameters. You access the details for the current authenticated user through the _user parameter.').optional()
+  template: z.union([SecurityRoleTemplateScript, SecurityRoleTemplateInlineQuery]).describe('When you create a role, you can specify a query that defines the document level security permissions. You can optionally use Mustache templates in the role query to insert the username of the current authenticated user into the role. Like other places in Elasticsearch that support templating or scripting, you can specify inline, stored, or file-based templates and define custom parameters. You access the details for the current authenticated user through the _user parameter.').optional()
 }).meta({ id: 'SecurityRoleTemplateQuery' })
 export type SecurityRoleTemplateQuery = z.infer<typeof SecurityRoleTemplateQuery>
 

--- a/packages/es-schemas/src/security_put_role_mapping.ts
+++ b/packages/es-schemas/src/security_put_role_mapping.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -3985,7 +4018,7 @@ export type SecurityTemplateFormat = z.infer<typeof SecurityTemplateFormat>
 
 export const SecurityRoleTemplate = z.object({
   format: SecurityTemplateFormat.optional(),
-  template: z.lazy(() => Script)
+  template: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)])
 }).meta({ id: 'SecurityRoleTemplate' })
 export type SecurityRoleTemplate = z.infer<typeof SecurityRoleTemplate>
 

--- a/packages/es-schemas/src/security_put_user.ts
+++ b/packages/es-schemas/src/security_put_user.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/security_query_api_keys.ts
+++ b/packages/es-schemas/src/security_query_api_keys.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4106,7 +4139,7 @@ export const SecurityRoleTemplateScript = z.object({
 export type SecurityRoleTemplateScript = z.infer<typeof SecurityRoleTemplateScript>
 
 export const SecurityRoleTemplateQuery = z.object({
-  template: SecurityRoleTemplateScript.describe('When you create a role, you can specify a query that defines the document level security permissions. You can optionally use Mustache templates in the role query to insert the username of the current authenticated user into the role. Like other places in Elasticsearch that support templating or scripting, you can specify inline, stored, or file-based templates and define custom parameters. You access the details for the current authenticated user through the _user parameter.').optional()
+  template: z.union([SecurityRoleTemplateScript, SecurityRoleTemplateInlineQuery]).describe('When you create a role, you can specify a query that defines the document level security permissions. You can optionally use Mustache templates in the role query to insert the username of the current authenticated user into the role. Like other places in Elasticsearch that support templating or scripting, you can specify inline, stored, or file-based templates and define custom parameters. You access the details for the current authenticated user through the _user parameter.').optional()
 }).meta({ id: 'SecurityRoleTemplateQuery' })
 export type SecurityRoleTemplateQuery = z.infer<typeof SecurityRoleTemplateQuery>
 
@@ -4200,7 +4233,7 @@ export type SecurityApiKey = z.infer<typeof SecurityApiKey>
 export const SecurityQueryApiKeysApiKeyAggregate = z.union([AggregationsCardinalityAggregate, AggregationsValueCountAggregate, AggregationsStringTermsAggregate, AggregationsLongTermsAggregate, AggregationsDoubleTermsAggregate, AggregationsUnmappedTermsAggregate, AggregationsMultiTermsAggregate, AggregationsMissingAggregate, AggregationsFilterAggregate, AggregationsFiltersAggregate, AggregationsRangeAggregate, AggregationsDateRangeAggregate, AggregationsCompositeAggregate]).meta({ id: 'SecurityQueryApiKeysApiKeyAggregate' })
 export type SecurityQueryApiKeysApiKeyAggregate = z.infer<typeof SecurityQueryApiKeysApiKeyAggregate>
 
-const SecurityQueryApiKeysApiKeyQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ exists: QueryDslExistsQuery }), z.object({ ids: QueryDslIdsQuery }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) })])
+const SecurityQueryApiKeysApiKeyQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ exists: QueryDslExistsQuery }), z.object({ ids: QueryDslIdsQuery }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) })])
 
 export const SecurityQueryApiKeysApiKeyQueryContainer = SecurityQueryApiKeysApiKeyQueryContainerExclusiveProps.meta({ id: 'SecurityQueryApiKeysApiKeyQueryContainer' })
 export type SecurityQueryApiKeysApiKeyQueryContainer = z.infer<typeof SecurityQueryApiKeysApiKeyQueryContainer>

--- a/packages/es-schemas/src/security_query_role.ts
+++ b/packages/es-schemas/src/security_query_role.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -3993,7 +4026,7 @@ export const SecurityRoleTemplateScript = z.object({
 export type SecurityRoleTemplateScript = z.infer<typeof SecurityRoleTemplateScript>
 
 export const SecurityRoleTemplateQuery = z.object({
-  template: SecurityRoleTemplateScript.describe('When you create a role, you can specify a query that defines the document level security permissions. You can optionally use Mustache templates in the role query to insert the username of the current authenticated user into the role. Like other places in Elasticsearch that support templating or scripting, you can specify inline, stored, or file-based templates and define custom parameters. You access the details for the current authenticated user through the _user parameter.').optional()
+  template: z.union([SecurityRoleTemplateScript, SecurityRoleTemplateInlineQuery]).describe('When you create a role, you can specify a query that defines the document level security permissions. You can optionally use Mustache templates in the role query to insert the username of the current authenticated user into the role. Like other places in Elasticsearch that support templating or scripting, you can specify inline, stored, or file-based templates and define custom parameters. You access the details for the current authenticated user through the _user parameter.').optional()
 }).meta({ id: 'SecurityRoleTemplateQuery' })
 export type SecurityRoleTemplateQuery = z.infer<typeof SecurityRoleTemplateQuery>
 
@@ -4042,7 +4075,7 @@ export const SecurityQueryRoleQueryRole = z.object({
 }).meta({ id: 'SecurityQueryRoleQueryRole' })
 export type SecurityQueryRoleQueryRole = z.infer<typeof SecurityQueryRoleQueryRole>
 
-const SecurityQueryRoleRoleQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ exists: QueryDslExistsQuery }), z.object({ ids: QueryDslIdsQuery }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) })])
+const SecurityQueryRoleRoleQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ exists: QueryDslExistsQuery }), z.object({ ids: QueryDslIdsQuery }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) })])
 
 export const SecurityQueryRoleRoleQueryContainer = SecurityQueryRoleRoleQueryContainerExclusiveProps.meta({ id: 'SecurityQueryRoleRoleQueryContainer' })
 export type SecurityQueryRoleRoleQueryContainer = z.infer<typeof SecurityQueryRoleRoleQueryContainer>

--- a/packages/es-schemas/src/security_query_user.ts
+++ b/packages/es-schemas/src/security_query_user.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -3984,7 +4017,7 @@ export const SecurityQueryUserQueryUser = z.object({
 }).meta({ id: 'SecurityQueryUserQueryUser' })
 export type SecurityQueryUserQueryUser = z.infer<typeof SecurityQueryUserQueryUser>
 
-const SecurityQueryUserUserQueryContainerExclusiveProps = z.union([z.object({ ids: QueryDslIdsQuery }), z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ exists: QueryDslExistsQuery }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) })])
+const SecurityQueryUserUserQueryContainerExclusiveProps = z.union([z.object({ ids: QueryDslIdsQuery }), z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ exists: QueryDslExistsQuery }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) })])
 
 export const SecurityQueryUserUserQueryContainer = SecurityQueryUserUserQueryContainerExclusiveProps.meta({ id: 'SecurityQueryUserUserQueryContainer' })
 export type SecurityQueryUserUserQueryContainer = z.infer<typeof SecurityQueryUserUserQueryContainer>

--- a/packages/es-schemas/src/security_saml_authenticate.ts
+++ b/packages/es-schemas/src/security_saml_authenticate.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/security_saml_complete_logout.ts
+++ b/packages/es-schemas/src/security_saml_complete_logout.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/security_saml_invalidate.ts
+++ b/packages/es-schemas/src/security_saml_invalidate.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/security_saml_logout.ts
+++ b/packages/es-schemas/src/security_saml_logout.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/security_saml_prepare_authentication.ts
+++ b/packages/es-schemas/src/security_saml_prepare_authentication.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/security_saml_service_provider_metadata.ts
+++ b/packages/es-schemas/src/security_saml_service_provider_metadata.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/security_suggest_user_profiles.ts
+++ b/packages/es-schemas/src/security_suggest_user_profiles.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/security_update_api_key.ts
+++ b/packages/es-schemas/src/security_update_api_key.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -3993,7 +4026,7 @@ export const SecurityRoleTemplateScript = z.object({
 export type SecurityRoleTemplateScript = z.infer<typeof SecurityRoleTemplateScript>
 
 export const SecurityRoleTemplateQuery = z.object({
-  template: SecurityRoleTemplateScript.describe('When you create a role, you can specify a query that defines the document level security permissions. You can optionally use Mustache templates in the role query to insert the username of the current authenticated user into the role. Like other places in Elasticsearch that support templating or scripting, you can specify inline, stored, or file-based templates and define custom parameters. You access the details for the current authenticated user through the _user parameter.').optional()
+  template: z.union([SecurityRoleTemplateScript, SecurityRoleTemplateInlineQuery]).describe('When you create a role, you can specify a query that defines the document level security permissions. You can optionally use Mustache templates in the role query to insert the username of the current authenticated user into the role. Like other places in Elasticsearch that support templating or scripting, you can specify inline, stored, or file-based templates and define custom parameters. You access the details for the current authenticated user through the _user parameter.').optional()
 }).meta({ id: 'SecurityRoleTemplateQuery' })
 export type SecurityRoleTemplateQuery = z.infer<typeof SecurityRoleTemplateQuery>
 

--- a/packages/es-schemas/src/security_update_cross_cluster_api_key.ts
+++ b/packages/es-schemas/src/security_update_cross_cluster_api_key.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -3986,7 +4019,7 @@ export const SecurityRoleTemplateScript = z.object({
 export type SecurityRoleTemplateScript = z.infer<typeof SecurityRoleTemplateScript>
 
 export const SecurityRoleTemplateQuery = z.object({
-  template: SecurityRoleTemplateScript.describe('When you create a role, you can specify a query that defines the document level security permissions. You can optionally use Mustache templates in the role query to insert the username of the current authenticated user into the role. Like other places in Elasticsearch that support templating or scripting, you can specify inline, stored, or file-based templates and define custom parameters. You access the details for the current authenticated user through the _user parameter.').optional()
+  template: z.union([SecurityRoleTemplateScript, SecurityRoleTemplateInlineQuery]).describe('When you create a role, you can specify a query that defines the document level security permissions. You can optionally use Mustache templates in the role query to insert the username of the current authenticated user into the role. Like other places in Elasticsearch that support templating or scripting, you can specify inline, stored, or file-based templates and define custom parameters. You access the details for the current authenticated user through the _user parameter.').optional()
 }).meta({ id: 'SecurityRoleTemplateQuery' })
 export type SecurityRoleTemplateQuery = z.infer<typeof SecurityRoleTemplateQuery>
 

--- a/packages/es-schemas/src/security_update_settings.ts
+++ b/packages/es-schemas/src/security_update_settings.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4580,7 +4613,7 @@ export const AnalysisConditionTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('condition'),
   filter: z.array(z.string()).describe('Array of token filters. If a token matches the predicate script in the `script` parameter, these filters are applied to the token in the order provided.'),
-  script: z.lazy(() => Script).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
 }).meta({ id: 'AnalysisConditionTokenFilter' })
 export type AnalysisConditionTokenFilter = z.infer<typeof AnalysisConditionTokenFilter>
 
@@ -5061,7 +5094,7 @@ export type AnalysisPorterStemTokenFilter = z.infer<typeof AnalysisPorterStemTok
 export const AnalysisPredicateTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('predicate_token_filter'),
-  script: z.lazy(() => Script).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
 }).meta({ id: 'AnalysisPredicateTokenFilter' })
 export type AnalysisPredicateTokenFilter = z.infer<typeof AnalysisPredicateTokenFilter>
 
@@ -5544,8 +5577,8 @@ export type IndicesSettingsSimilarityLmj = z.infer<typeof IndicesSettingsSimilar
 
 export const IndicesSettingsSimilarityScripted = z.object({
   type: z.literal('scripted'),
-  script: z.lazy(() => Script),
-  weight_script: z.lazy(() => Script).optional()
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]),
+  weight_script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).optional()
 }).meta({ id: 'IndicesSettingsSimilarityScripted' })
 export type IndicesSettingsSimilarityScripted = z.infer<typeof IndicesSettingsSimilarityScripted>
 

--- a/packages/es-schemas/src/security_update_user_profile_data.ts
+++ b/packages/es-schemas/src/security_update_user_profile_data.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/shutdown_delete_node.ts
+++ b/packages/es-schemas/src/shutdown_delete_node.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/shutdown_get_node.ts
+++ b/packages/es-schemas/src/shutdown_get_node.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/shutdown_put_node.ts
+++ b/packages/es-schemas/src/shutdown_put_node.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/simulate_ingest.ts
+++ b/packages/es-schemas/src/simulate_ingest.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4623,7 +4656,7 @@ export const AnalysisConditionTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('condition'),
   filter: z.array(z.string()).describe('Array of token filters. If a token matches the predicate script in the `script` parameter, these filters are applied to the token in the order provided.'),
-  script: z.lazy(() => Script).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
 }).meta({ id: 'AnalysisConditionTokenFilter' })
 export type AnalysisConditionTokenFilter = z.infer<typeof AnalysisConditionTokenFilter>
 
@@ -5104,7 +5137,7 @@ export type AnalysisPorterStemTokenFilter = z.infer<typeof AnalysisPorterStemTok
 export const AnalysisPredicateTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('predicate_token_filter'),
-  script: z.lazy(() => Script).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
 }).meta({ id: 'AnalysisPredicateTokenFilter' })
 export type AnalysisPredicateTokenFilter = z.infer<typeof AnalysisPredicateTokenFilter>
 
@@ -5653,7 +5686,7 @@ export const MappingBooleanProperty = z.object({
   index: z.boolean().optional(),
   null_value: z.boolean().optional(),
   ignore_malformed: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('boolean')
@@ -5694,7 +5727,7 @@ export const MappingNumberPropertyBase = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional()
 }).meta({ id: 'MappingNumberPropertyBase' })
@@ -5736,7 +5769,7 @@ export const MappingByteNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('byte'),
@@ -5865,7 +5898,7 @@ export const MappingDateNanosProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -5910,7 +5943,7 @@ export const MappingDateProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -6049,7 +6082,7 @@ export const MappingDoubleNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('double'),
@@ -6138,7 +6171,7 @@ export const MappingDynamicProperty = z.object({
   null_value: FieldValue.optional(),
   boost: double.optional(),
   coerce: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   ignore_malformed: z.boolean().optional(),
   time_series_metric: MappingTimeSeriesMetricType.optional(),
@@ -6302,7 +6335,7 @@ export const MappingFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('float'),
@@ -6376,7 +6409,7 @@ export const MappingGeoPointProperty = z.object({
   null_value: GeoLocation.optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   type: z.literal('geo_point'),
   time_series_metric: MappingGeoPointMetricType.optional()
 }).meta({ id: 'MappingGeoPointProperty' })
@@ -6460,7 +6493,7 @@ export const MappingHalfFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('half_float'),
@@ -6591,7 +6624,7 @@ export const MappingIntegerNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('integer'),
@@ -6665,7 +6698,7 @@ export const MappingIpProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   null_value: z.string().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('ip')
 }).meta({ id: 'MappingIpProperty' })
@@ -6765,7 +6798,7 @@ export const MappingKeywordProperty = z.object({
   eager_global_ordinals: z.boolean().optional(),
   index: z.boolean().optional(),
   index_options: MappingIndexOptions.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   normalizer: z.string().optional(),
   norms: z.boolean().optional(),
@@ -6813,7 +6846,7 @@ export const MappingLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('long'),
@@ -7130,7 +7163,7 @@ export const MappingScaledFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('scaled_float'),
@@ -7255,7 +7288,7 @@ export const MappingShortNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('short'),
@@ -7452,7 +7485,7 @@ export const MappingUnsignedLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('unsigned_long'),
@@ -7767,8 +7800,8 @@ export type IndicesSettingsSimilarityLmj = z.infer<typeof IndicesSettingsSimilar
 
 export const IndicesSettingsSimilarityScripted = z.object({
   type: z.literal('scripted'),
-  script: z.lazy(() => Script),
-  weight_script: z.lazy(() => Script).optional()
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]),
+  weight_script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).optional()
 }).meta({ id: 'IndicesSettingsSimilarityScripted' })
 export type IndicesSettingsSimilarityScripted = z.infer<typeof IndicesSettingsSimilarityScripted>
 
@@ -7985,6 +8018,9 @@ export const IndicesAliasDefinition = z.object({
 }).meta({ id: 'IndicesAliasDefinition' })
 export type IndicesAliasDefinition = z.infer<typeof IndicesAliasDefinition>
 
+export const IndicesRetentionSource = z.enum(['data_stream_configuration', 'default_global_retention', 'max_global_retention', 'default_failures_retention']).meta({ id: 'IndicesRetentionSource' })
+export type IndicesRetentionSource = z.infer<typeof IndicesRetentionSource>
+
 export const IndicesDownsamplingRound = z.object({
   after: Duration.describe('The duration since rollover when this downsampling round should execute'),
   fixed_interval: DurationLarge.describe('The downsample interval.')
@@ -7997,6 +8033,8 @@ export type IndicesSamplingMethod = z.infer<typeof IndicesSamplingMethod>
 /** Data stream lifecycle denotes that a data stream is managed by the data stream lifecycle and contains the configuration. */
 export const IndicesDataStreamLifecycle = z.object({
   data_retention: Duration.describe('If defined, every document added to this data stream will be stored at least for this time frame. Any time after this duration the document could be deleted. When empty, every document in this data stream will be stored indefinitely.').optional(),
+  effective_retention: Duration.describe('The least amount of time data should be kept by elasticsearch.').optional(),
+  retention_determined_by: IndicesRetentionSource.describe('Configuration source that can influence the retention of a data stream.').optional(),
   downsampling: z.array(IndicesDownsamplingRound).describe('The list of downsampling rounds to execute as part of this downsampling configuration').optional(),
   downsampling_method: IndicesSamplingMethod.describe('The method used to downsample the data. There are two options `aggregate` and `last_value`. It requires `downsampling` to be defined. Defaults to `aggregate`.').optional(),
   enabled: z.boolean().describe('If defined, it turns data stream lifecycle on/off (`true`/`false`) for this data stream. A data stream lifecycle that\'s disabled (enabled: `false`) will have no effect on the data stream.').optional(),
@@ -8202,7 +8240,7 @@ export interface IngestProcessorBaseShape {
 }
 export const IngestProcessorBase = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional()
@@ -8224,7 +8262,7 @@ export interface IngestAppendProcessorShape {
 }
 export const IngestAppendProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -8247,6 +8285,7 @@ export interface IngestAttachmentProcessorShape {
   ignore_missing?: boolean | undefined
   indexed_chars?: long | undefined
   indexed_chars_field?: Field | undefined
+  max_field_bytes?: ByteSize | undefined
   properties?: string[] | undefined
   target_field?: Field | undefined
   remove_binary?: boolean | undefined
@@ -8254,7 +8293,7 @@ export interface IngestAttachmentProcessorShape {
 }
 export const IngestAttachmentProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -8262,6 +8301,7 @@ export const IngestAttachmentProcessor = z.object({
   ignore_missing: z.boolean().describe('If `true` and field does not exist, the processor quietly exits without modifying the document.').optional(),
   indexed_chars: long.describe('The number of chars being used for extraction to prevent huge fields. Use `-1` for no limit.').optional(),
   indexed_chars_field: Field.describe('Field name from which you can overwrite the number of chars being used for extraction.').optional(),
+  max_field_bytes: ByteSize.describe('Maximum allowed size of the attachment `field` value in bytes: length of a string (if base64 in JSON, checked before base64 decoding) or byte array length for binary (for example, CBOR). If set to `-1`, there is no per-processor limit. The node setting `ingest.attachment.max_field_size` also applies.').optional(),
   properties: z.array(z.string()).describe('Array of properties to select to be stored. Can be `content`, `title`, `name`, `author`, `keywords`, `date`, `content_type`, `content_length`, `language`.').optional(),
   target_field: Field.describe('The field that will hold the attachment information.').optional(),
   remove_binary: z.boolean().describe('If true, the binary field will be removed from the document').optional(),
@@ -8281,7 +8321,7 @@ export interface IngestBytesProcessorShape {
 }
 export const IngestBytesProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -8305,7 +8345,7 @@ export interface IngestCefProcessorShape {
 }
 export const IngestCefProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -8331,7 +8371,7 @@ export interface IngestCircleProcessorShape {
 }
 export const IngestCircleProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -8363,7 +8403,7 @@ export interface IngestCommunityIDProcessorShape {
 }
 export const IngestCommunityIDProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -8394,7 +8434,7 @@ export interface IngestConvertProcessorShape {
 }
 export const IngestConvertProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -8421,7 +8461,7 @@ export interface IngestCsvProcessorShape {
 }
 export const IngestCsvProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -8451,7 +8491,7 @@ export interface IngestDateIndexNameProcessorShape {
 }
 export const IngestDateIndexNameProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -8480,7 +8520,7 @@ export interface IngestDateProcessorShape {
 }
 export const IngestDateProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -8506,7 +8546,7 @@ export interface IngestDissectProcessorShape {
 }
 export const IngestDissectProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -8536,7 +8576,7 @@ export interface IngestDotExpanderProcessorShape {
 }
 export const IngestDotExpanderProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -8555,7 +8595,7 @@ export interface IngestDropProcessorShape {
 }
 export const IngestDropProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional()
@@ -8578,7 +8618,7 @@ export interface IngestEnrichProcessorShape {
 }
 export const IngestEnrichProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -8602,7 +8642,7 @@ export interface IngestFailProcessorShape {
 }
 export const IngestFailProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -8627,7 +8667,7 @@ export interface IngestFingerprintProcessorShape {
 }
 export const IngestFingerprintProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -8651,7 +8691,7 @@ export interface IngestForeachProcessorShape {
 }
 export const IngestForeachProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -8679,7 +8719,7 @@ export interface IngestGeoGridProcessorShape {
 }
 export const IngestGeoGridProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -8711,7 +8751,7 @@ export interface IngestGeoIpProcessorShape {
 }
 export const IngestGeoIpProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -8741,7 +8781,7 @@ export interface IngestGrokProcessorShape {
 }
 export const IngestGrokProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -8769,7 +8809,7 @@ export interface IngestGsubProcessorShape {
 }
 export const IngestGsubProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -8793,7 +8833,7 @@ export interface IngestHtmlStripProcessorShape {
 }
 export const IngestHtmlStripProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -8818,7 +8858,7 @@ export interface IngestInferenceProcessorShape {
 }
 export const IngestInferenceProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -8847,7 +8887,7 @@ export interface IngestIpLocationProcessorShape {
 }
 export const IngestIpLocationProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -8873,7 +8913,7 @@ export interface IngestJoinProcessorShape {
 }
 export const IngestJoinProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -8897,7 +8937,7 @@ export interface IngestJsonProcessorShape {
 }
 export const IngestJsonProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -8929,7 +8969,7 @@ export interface IngestKeyValueProcessorShape {
 }
 export const IngestKeyValueProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -8959,7 +8999,7 @@ export interface IngestLowercaseProcessorShape {
 }
 export const IngestLowercaseProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -8984,7 +9024,7 @@ export interface IngestNetworkDirectionProcessorShape {
 }
 export const IngestNetworkDirectionProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -9023,7 +9063,7 @@ export interface IngestPipelineProcessorShape {
 }
 export const IngestPipelineProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -9049,7 +9089,7 @@ export interface IngestRedactProcessorShape {
 }
 export const IngestRedactProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -9076,7 +9116,7 @@ export interface IngestRegisteredDomainProcessorShape {
 }
 export const IngestRegisteredDomainProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -9098,7 +9138,7 @@ export interface IngestRemoveProcessorShape {
 }
 export const IngestRemoveProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -9120,7 +9160,7 @@ export interface IngestRenameProcessorShape {
 }
 export const IngestRenameProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -9142,7 +9182,7 @@ export interface IngestRerouteProcessorShape {
 }
 export const IngestRerouteProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -9165,7 +9205,7 @@ export interface IngestScriptProcessorShape {
 }
 export const IngestScriptProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -9191,7 +9231,7 @@ export interface IngestSetProcessorShape {
 }
 export const IngestSetProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -9215,7 +9255,7 @@ export interface IngestSetSecurityUserProcessorShape {
 }
 export const IngestSetSecurityUserProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -9236,7 +9276,7 @@ export interface IngestSortProcessorShape {
 }
 export const IngestSortProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -9260,7 +9300,7 @@ export interface IngestSplitProcessorShape {
 }
 export const IngestSplitProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -9281,7 +9321,7 @@ export interface IngestTerminateProcessorShape {
 }
 export const IngestTerminateProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional()
@@ -9300,7 +9340,7 @@ export interface IngestTrimProcessorShape {
 }
 export const IngestTrimProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -9322,7 +9362,7 @@ export interface IngestUppercaseProcessorShape {
 }
 export const IngestUppercaseProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -9346,7 +9386,7 @@ export interface IngestUriPartsProcessorShape {
 }
 export const IngestUriPartsProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -9370,7 +9410,7 @@ export interface IngestUrlDecodeProcessorShape {
 }
 export const IngestUrlDecodeProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -9395,7 +9435,7 @@ export interface IngestUserAgentProcessorShape {
 }
 export const IngestUserAgentProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),

--- a/packages/es-schemas/src/slm_delete_lifecycle.ts
+++ b/packages/es-schemas/src/slm_delete_lifecycle.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/slm_execute_lifecycle.ts
+++ b/packages/es-schemas/src/slm_execute_lifecycle.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/slm_execute_retention.ts
+++ b/packages/es-schemas/src/slm_execute_retention.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/slm_get_lifecycle.ts
+++ b/packages/es-schemas/src/slm_get_lifecycle.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/slm_get_stats.ts
+++ b/packages/es-schemas/src/slm_get_stats.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/slm_get_status.ts
+++ b/packages/es-schemas/src/slm_get_status.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/slm_put_lifecycle.ts
+++ b/packages/es-schemas/src/slm_put_lifecycle.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/slm_start.ts
+++ b/packages/es-schemas/src/slm_start.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/slm_stop.ts
+++ b/packages/es-schemas/src/slm_stop.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/snapshot_cleanup_repository.ts
+++ b/packages/es-schemas/src/snapshot_cleanup_repository.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/snapshot_clone.ts
+++ b/packages/es-schemas/src/snapshot_clone.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/snapshot_create.ts
+++ b/packages/es-schemas/src/snapshot_create.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/snapshot_create_repository.ts
+++ b/packages/es-schemas/src/snapshot_create_repository.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -154,13 +155,70 @@ export const SnapshotSharedFileSystemRepository = z.object({
 }).meta({ id: 'SnapshotSharedFileSystemRepository' })
 export type SnapshotSharedFileSystemRepository = z.infer<typeof SnapshotSharedFileSystemRepository>
 
-export const SnapshotSourceOnlyRepositorySettings = z.object({
-  ...SnapshotRepositorySettingsBase.shape,
-  delegate_type: z.string().describe('The delegated repository type. For valid values, refer to the `type` parameter. Source repositories can use `settings` properties for its delegated repository type.').optional(),
+export const SnapshotSourceOnlyRepositorySettingsForSharedFileSystem = z.object({
+  delegate_type: z.literal('fs'),
+  location: z.string().describe('The location of the shared filesystem used to store and retrieve snapshots. This location must be registered in the `path.repo` setting on all master and data nodes in the cluster. Unlike `path.repo`, this setting supports only a single file path.'),
   max_number_of_snapshots: integer.describe('The maximum number of snapshots the repository can contain. The default is `Integer.MAX_VALUE`, which is 2^31-1 or `2147483647`.').optional(),
-  read_only: z.boolean().describe('If `true`, the repository is read-only. The cluster can retrieve and restore snapshots from the repository but not write to the repository or create snapshots in it. Only a cluster with write access can create snapshots in the repository. All other clusters connected to the repository should have the `readonly` parameter set to `true`. If `false`, the cluster can write to the repository and create snapshots in it. IMPORTANT: If you register the same snapshot repository with multiple clusters, only one cluster should have write access to the repository. Having multiple clusters write to the repository at the same time risks corrupting the contents of the repository.').optional(),
   readonly: z.boolean().describe('If `true`, the repository is read-only. The cluster can retrieve and restore snapshots from the repository but not write to the repository or create snapshots in it. Only a cluster with write access can create snapshots in the repository. All other clusters connected to the repository should have the `readonly` parameter set to `true`. If `false`, the cluster can write to the repository and create snapshots in it. IMPORTANT: If you register the same snapshot repository with multiple clusters, only one cluster should have write access to the repository. Having multiple clusters write to the repository at the same time risks corrupting the contents of the repository.').optional()
-}).meta({ id: 'SnapshotSourceOnlyRepositorySettings' })
+}).meta({ id: 'SnapshotSourceOnlyRepositorySettingsForSharedFileSystem' })
+export type SnapshotSourceOnlyRepositorySettingsForSharedFileSystem = z.infer<typeof SnapshotSourceOnlyRepositorySettingsForSharedFileSystem>
+
+export const SnapshotSourceOnlyRepositorySettingsForReadOnlyUrl = z.object({
+  delegate_type: z.literal('url'),
+  http_max_retries: integer.describe('The maximum number of retries for HTTP and HTTPS URLs.').optional(),
+  http_socket_timeout: Duration.describe('The maximum wait time for data transfers over a connection.').optional(),
+  max_number_of_snapshots: integer.describe('The maximum number of snapshots the repository can contain. The default is `Integer.MAX_VALUE`, which is 2^31-1 or `2147483647`.').optional(),
+  url: z.string().describe('The URL location of the root of the shared filesystem repository. The following protocols are supported: * `file` * `ftp` * `http` * `https` * `jar` URLs using the HTTP, HTTPS, or FTP protocols must be explicitly allowed with the `repositories.url.allowed_urls` cluster setting. This setting supports wildcards in the place of a host, path, query, or fragment in the URL. URLs using the file protocol must point to the location of a shared filesystem accessible to all master and data nodes in the cluster. This location must be registered in the `path.repo` setting. You don\'t need to register URLs using the FTP, HTTP, HTTPS, or JAR protocols in the `path.repo` setting.')
+}).meta({ id: 'SnapshotSourceOnlyRepositorySettingsForReadOnlyUrl' })
+export type SnapshotSourceOnlyRepositorySettingsForReadOnlyUrl = z.infer<typeof SnapshotSourceOnlyRepositorySettingsForReadOnlyUrl>
+
+export const SnapshotSourceOnlyRepositorySettingsForAzure = z.object({
+  delegate_type: z.literal('azure'),
+  base_path: z.string().describe('The path to the repository data within the container. It defaults to the root directory. NOTE: Don\'t set `base_path` when configuring a snapshot repository for Elastic Cloud Enterprise. Elastic Cloud Enterprise automatically generates the `base_path` for each deployment so that multiple deployments can share the same bucket.').optional(),
+  client: z.string().describe('The name of the Azure repository client to use.').optional(),
+  container: z.string().describe('The Azure container.').optional(),
+  delete_objects_max_size: integer.describe('The maxmimum batch size, between 1 and 256, used for `BlobBatch` requests. Defaults to 256 which is the maximum number supported by the Azure blob batch API.').optional(),
+  location_mode: z.string().describe('Either `primary_only` or `secondary_only`. Note that if you set it to `secondary_only`, it will force `readonly` to `true`.').optional(),
+  max_concurrent_batch_deletes: integer.describe('The maximum number of concurrent batch delete requests that will be submitted for any individual bulk delete with `BlobBatch`. Note that the effective number of concurrent deletes is further limited by the Azure client connection and event loop thread limits. Defaults to 10, minimum is 1, maximum is 100.').optional(),
+  readonly: z.boolean().describe('If `true`, the repository is read-only. The cluster can retrieve and restore snapshots from the repository but not write to the repository or create snapshots in it. Only a cluster with write access can create snapshots in the repository. All other clusters connected to the repository should have the `readonly` parameter set to `true`. If `false`, the cluster can write to the repository and create snapshots in it. IMPORTANT: If you register the same snapshot repository with multiple clusters, only one cluster should have write access to the repository. Having multiple clusters write to the repository at the same time risks corrupting the contents of the repository.').optional()
+}).meta({ id: 'SnapshotSourceOnlyRepositorySettingsForAzure' })
+export type SnapshotSourceOnlyRepositorySettingsForAzure = z.infer<typeof SnapshotSourceOnlyRepositorySettingsForAzure>
+
+export const SnapshotSourceOnlyRepositorySettingsForGcs = z.object({
+  delegate_type: z.literal('gcs'),
+  bucket: z.string().describe('The name of the bucket to be used for snapshots.'),
+  application_name: z.string().describe('The name used by the client when it uses the Google Cloud Storage service.').optional(),
+  base_path: z.string().describe('The path to the repository data within the bucket. It defaults to the root of the bucket. NOTE: Don\'t set `base_path` when configuring a snapshot repository for Elastic Cloud Enterprise. Elastic Cloud Enterprise automatically generates the `base_path` for each deployment so that multiple deployments can share the same bucket.').optional(),
+  client: z.string().describe('The name of the client to use to connect to Google Cloud Storage.').optional(),
+  readonly: z.boolean().describe('If `true`, the repository is read-only. The cluster can retrieve and restore snapshots from the repository but not write to the repository or create snapshots in it. Only a cluster with write access can create snapshots in the repository. All other clusters connected to the repository should have the `readonly` parameter set to `true`. If `false`, the cluster can write to the repository and create snapshots in it. IMPORTANT: If you register the same snapshot repository with multiple clusters, only one cluster should have write access to the repository. Having multiple clusters write to the repository at the same time risks corrupting the contents of the repository.').optional()
+}).meta({ id: 'SnapshotSourceOnlyRepositorySettingsForGcs' })
+export type SnapshotSourceOnlyRepositorySettingsForGcs = z.infer<typeof SnapshotSourceOnlyRepositorySettingsForGcs>
+
+export const SnapshotSourceOnlyRepositorySettingsForS3 = z.object({
+  delegate_type: z.literal('s3'),
+  bucket: z.string().describe('The name of the S3 bucket to use for snapshots. The bucket name must adhere to Amazon\'s S3 bucket naming rules.'),
+  base_path: z.string().describe('The path to the repository data within its bucket. It defaults to an empty string, meaning that the repository is at the root of the bucket. The value of this setting should not start or end with a forward slash (`/`). NOTE: Don\'t set base_path when configuring a snapshot repository for Elastic Cloud Enterprise. Elastic Cloud Enterprise automatically generates the `base_path` for each deployment so that multiple deployments may share the same bucket.').optional(),
+  buffer_size: ByteSize.describe('The minimum threshold below which the chunk is uploaded using a single request. Beyond this threshold, the S3 repository will use the AWS Multipart Upload API to split the chunk into several parts, each of `buffer_size` length, and to upload each part in its own request. Note that setting a buffer size lower than 5mb is not allowed since it will prevent the use of the Multipart API and may result in upload errors. It is also not possible to set a buffer size greater than 5gb as it is the maximum upload size allowed by S3. Defaults to `100mb` or 5% of JVM heap, whichever is smaller.').optional(),
+  canned_acl: z.string().describe('The S3 repository supports all S3 canned ACLs: `private`, `public-read`, `public-read-write`, `authenticated-read`, `log-delivery-write`, `bucket-owner-read`, `bucket-owner-full-control`. You could specify a canned ACL using the `canned_acl` setting. When the S3 repository creates buckets and objects, it adds the canned ACL into the buckets and objects.').optional(),
+  client: z.string().describe('The name of the S3 client to use to connect to S3.').optional(),
+  delete_objects_max_size: integer.describe('The maxmimum batch size, between 1 and 1000, used for `DeleteObjects` requests. Defaults to 1000 which is the maximum number supported by the  AWS DeleteObjects API.').optional(),
+  get_register_retry_delay: Duration.describe('The time to wait before trying again if an attempt to read a linearizable register fails.').optional(),
+  max_multipart_parts: integer.describe('The maximum number of parts that Elasticsearch will write during a multipart upload of a single object. Files which are larger than `buffer_size × max_multipart_parts` will be chunked into several smaller objects. Elasticsearch may also split a file across multiple objects to satisfy other constraints such as the `chunk_size` limit. Defaults to `10000` which is the maximum number of parts in a multipart upload in AWS S3.').optional(),
+  max_multipart_upload_cleanup_size: integer.describe('The maximum number of possibly-dangling multipart uploads to clean up in each batch of snapshot deletions. Defaults to 1000 which is the maximum number supported by the AWS ListMultipartUploads API. If set to `0`, Elasticsearch will not attempt to clean up dangling multipart uploads.').optional(),
+  readonly: z.boolean().describe('If true, the repository is read-only. The cluster can retrieve and restore snapshots from the repository but not write to the repository or create snapshots in it. Only a cluster with write access can create snapshots in the repository. All other clusters connected to the repository should have the `readonly` parameter set to `true`. If `false`, the cluster can write to the repository and create snapshots in it. IMPORTANT: If you register the same snapshot repository with multiple clusters, only one cluster should have write access to the repository. Having multiple clusters write to the repository at the same time risks corrupting the contents of the repository.').optional(),
+  server_side_encryption: z.boolean().describe('When set to `true`, files are encrypted on server side using an AES256 algorithm.').optional(),
+  storage_class: z.string().describe('The S3 storage class for objects written to the repository. Values may be `standard`, `reduced_redundancy`, `standard_ia`, `onezone_ia`, and `intelligent_tiering`.').optional(),
+  'throttled_delete_retry.delay_increment': Duration.describe('The delay before the first retry and the amount the delay is incremented by on each subsequent retry. The default is 50ms and the minimum is 0ms.').optional(),
+  'throttled_delete_retry.maximum_delay': Duration.describe('The upper bound on how long the delays between retries will grow to. The default is 5s and the minimum is 0ms.').optional(),
+  'throttled_delete_retry.maximum_number_of_retries': integer.describe('The number times to retry a throttled snapshot deletion. The default is 10 and the minimum value is 0 which will disable retries altogether. Note that if retries are enabled in the Azure client, each of these retries comprises that many client-level retries.').optional()
+}).meta({ id: 'SnapshotSourceOnlyRepositorySettingsForS3' })
+export type SnapshotSourceOnlyRepositorySettingsForS3 = z.infer<typeof SnapshotSourceOnlyRepositorySettingsForS3>
+
+/**
+ * The delegated repository type.
+ * Source repositories can use `settings` properties for its delegated repository type.
+ */
+export const SnapshotSourceOnlyRepositorySettings = z.union([SnapshotSourceOnlyRepositorySettingsForSharedFileSystem, SnapshotSourceOnlyRepositorySettingsForReadOnlyUrl, SnapshotSourceOnlyRepositorySettingsForAzure, SnapshotSourceOnlyRepositorySettingsForGcs, SnapshotSourceOnlyRepositorySettingsForS3]).meta({ id: 'SnapshotSourceOnlyRepositorySettings' })
 export type SnapshotSourceOnlyRepositorySettings = z.infer<typeof SnapshotSourceOnlyRepositorySettings>
 
 export const SnapshotSourceOnlyRepository = z.object({

--- a/packages/es-schemas/src/snapshot_delete.ts
+++ b/packages/es-schemas/src/snapshot_delete.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/snapshot_delete_repository.ts
+++ b/packages/es-schemas/src/snapshot_delete_repository.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/snapshot_get.ts
+++ b/packages/es-schemas/src/snapshot_get.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/snapshot_get_repository.ts
+++ b/packages/es-schemas/src/snapshot_get_repository.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -152,13 +153,70 @@ export const SnapshotSharedFileSystemRepository = z.object({
 }).meta({ id: 'SnapshotSharedFileSystemRepository' })
 export type SnapshotSharedFileSystemRepository = z.infer<typeof SnapshotSharedFileSystemRepository>
 
-export const SnapshotSourceOnlyRepositorySettings = z.object({
-  ...SnapshotRepositorySettingsBase.shape,
-  delegate_type: z.string().describe('The delegated repository type. For valid values, refer to the `type` parameter. Source repositories can use `settings` properties for its delegated repository type.').optional(),
+export const SnapshotSourceOnlyRepositorySettingsForSharedFileSystem = z.object({
+  delegate_type: z.literal('fs'),
+  location: z.string().describe('The location of the shared filesystem used to store and retrieve snapshots. This location must be registered in the `path.repo` setting on all master and data nodes in the cluster. Unlike `path.repo`, this setting supports only a single file path.'),
   max_number_of_snapshots: integer.describe('The maximum number of snapshots the repository can contain. The default is `Integer.MAX_VALUE`, which is 2^31-1 or `2147483647`.').optional(),
-  read_only: z.boolean().describe('If `true`, the repository is read-only. The cluster can retrieve and restore snapshots from the repository but not write to the repository or create snapshots in it. Only a cluster with write access can create snapshots in the repository. All other clusters connected to the repository should have the `readonly` parameter set to `true`. If `false`, the cluster can write to the repository and create snapshots in it. IMPORTANT: If you register the same snapshot repository with multiple clusters, only one cluster should have write access to the repository. Having multiple clusters write to the repository at the same time risks corrupting the contents of the repository.').optional(),
   readonly: z.boolean().describe('If `true`, the repository is read-only. The cluster can retrieve and restore snapshots from the repository but not write to the repository or create snapshots in it. Only a cluster with write access can create snapshots in the repository. All other clusters connected to the repository should have the `readonly` parameter set to `true`. If `false`, the cluster can write to the repository and create snapshots in it. IMPORTANT: If you register the same snapshot repository with multiple clusters, only one cluster should have write access to the repository. Having multiple clusters write to the repository at the same time risks corrupting the contents of the repository.').optional()
-}).meta({ id: 'SnapshotSourceOnlyRepositorySettings' })
+}).meta({ id: 'SnapshotSourceOnlyRepositorySettingsForSharedFileSystem' })
+export type SnapshotSourceOnlyRepositorySettingsForSharedFileSystem = z.infer<typeof SnapshotSourceOnlyRepositorySettingsForSharedFileSystem>
+
+export const SnapshotSourceOnlyRepositorySettingsForReadOnlyUrl = z.object({
+  delegate_type: z.literal('url'),
+  http_max_retries: integer.describe('The maximum number of retries for HTTP and HTTPS URLs.').optional(),
+  http_socket_timeout: Duration.describe('The maximum wait time for data transfers over a connection.').optional(),
+  max_number_of_snapshots: integer.describe('The maximum number of snapshots the repository can contain. The default is `Integer.MAX_VALUE`, which is 2^31-1 or `2147483647`.').optional(),
+  url: z.string().describe('The URL location of the root of the shared filesystem repository. The following protocols are supported: * `file` * `ftp` * `http` * `https` * `jar` URLs using the HTTP, HTTPS, or FTP protocols must be explicitly allowed with the `repositories.url.allowed_urls` cluster setting. This setting supports wildcards in the place of a host, path, query, or fragment in the URL. URLs using the file protocol must point to the location of a shared filesystem accessible to all master and data nodes in the cluster. This location must be registered in the `path.repo` setting. You don\'t need to register URLs using the FTP, HTTP, HTTPS, or JAR protocols in the `path.repo` setting.')
+}).meta({ id: 'SnapshotSourceOnlyRepositorySettingsForReadOnlyUrl' })
+export type SnapshotSourceOnlyRepositorySettingsForReadOnlyUrl = z.infer<typeof SnapshotSourceOnlyRepositorySettingsForReadOnlyUrl>
+
+export const SnapshotSourceOnlyRepositorySettingsForAzure = z.object({
+  delegate_type: z.literal('azure'),
+  base_path: z.string().describe('The path to the repository data within the container. It defaults to the root directory. NOTE: Don\'t set `base_path` when configuring a snapshot repository for Elastic Cloud Enterprise. Elastic Cloud Enterprise automatically generates the `base_path` for each deployment so that multiple deployments can share the same bucket.').optional(),
+  client: z.string().describe('The name of the Azure repository client to use.').optional(),
+  container: z.string().describe('The Azure container.').optional(),
+  delete_objects_max_size: integer.describe('The maxmimum batch size, between 1 and 256, used for `BlobBatch` requests. Defaults to 256 which is the maximum number supported by the Azure blob batch API.').optional(),
+  location_mode: z.string().describe('Either `primary_only` or `secondary_only`. Note that if you set it to `secondary_only`, it will force `readonly` to `true`.').optional(),
+  max_concurrent_batch_deletes: integer.describe('The maximum number of concurrent batch delete requests that will be submitted for any individual bulk delete with `BlobBatch`. Note that the effective number of concurrent deletes is further limited by the Azure client connection and event loop thread limits. Defaults to 10, minimum is 1, maximum is 100.').optional(),
+  readonly: z.boolean().describe('If `true`, the repository is read-only. The cluster can retrieve and restore snapshots from the repository but not write to the repository or create snapshots in it. Only a cluster with write access can create snapshots in the repository. All other clusters connected to the repository should have the `readonly` parameter set to `true`. If `false`, the cluster can write to the repository and create snapshots in it. IMPORTANT: If you register the same snapshot repository with multiple clusters, only one cluster should have write access to the repository. Having multiple clusters write to the repository at the same time risks corrupting the contents of the repository.').optional()
+}).meta({ id: 'SnapshotSourceOnlyRepositorySettingsForAzure' })
+export type SnapshotSourceOnlyRepositorySettingsForAzure = z.infer<typeof SnapshotSourceOnlyRepositorySettingsForAzure>
+
+export const SnapshotSourceOnlyRepositorySettingsForGcs = z.object({
+  delegate_type: z.literal('gcs'),
+  bucket: z.string().describe('The name of the bucket to be used for snapshots.'),
+  application_name: z.string().describe('The name used by the client when it uses the Google Cloud Storage service.').optional(),
+  base_path: z.string().describe('The path to the repository data within the bucket. It defaults to the root of the bucket. NOTE: Don\'t set `base_path` when configuring a snapshot repository for Elastic Cloud Enterprise. Elastic Cloud Enterprise automatically generates the `base_path` for each deployment so that multiple deployments can share the same bucket.').optional(),
+  client: z.string().describe('The name of the client to use to connect to Google Cloud Storage.').optional(),
+  readonly: z.boolean().describe('If `true`, the repository is read-only. The cluster can retrieve and restore snapshots from the repository but not write to the repository or create snapshots in it. Only a cluster with write access can create snapshots in the repository. All other clusters connected to the repository should have the `readonly` parameter set to `true`. If `false`, the cluster can write to the repository and create snapshots in it. IMPORTANT: If you register the same snapshot repository with multiple clusters, only one cluster should have write access to the repository. Having multiple clusters write to the repository at the same time risks corrupting the contents of the repository.').optional()
+}).meta({ id: 'SnapshotSourceOnlyRepositorySettingsForGcs' })
+export type SnapshotSourceOnlyRepositorySettingsForGcs = z.infer<typeof SnapshotSourceOnlyRepositorySettingsForGcs>
+
+export const SnapshotSourceOnlyRepositorySettingsForS3 = z.object({
+  delegate_type: z.literal('s3'),
+  bucket: z.string().describe('The name of the S3 bucket to use for snapshots. The bucket name must adhere to Amazon\'s S3 bucket naming rules.'),
+  base_path: z.string().describe('The path to the repository data within its bucket. It defaults to an empty string, meaning that the repository is at the root of the bucket. The value of this setting should not start or end with a forward slash (`/`). NOTE: Don\'t set base_path when configuring a snapshot repository for Elastic Cloud Enterprise. Elastic Cloud Enterprise automatically generates the `base_path` for each deployment so that multiple deployments may share the same bucket.').optional(),
+  buffer_size: ByteSize.describe('The minimum threshold below which the chunk is uploaded using a single request. Beyond this threshold, the S3 repository will use the AWS Multipart Upload API to split the chunk into several parts, each of `buffer_size` length, and to upload each part in its own request. Note that setting a buffer size lower than 5mb is not allowed since it will prevent the use of the Multipart API and may result in upload errors. It is also not possible to set a buffer size greater than 5gb as it is the maximum upload size allowed by S3. Defaults to `100mb` or 5% of JVM heap, whichever is smaller.').optional(),
+  canned_acl: z.string().describe('The S3 repository supports all S3 canned ACLs: `private`, `public-read`, `public-read-write`, `authenticated-read`, `log-delivery-write`, `bucket-owner-read`, `bucket-owner-full-control`. You could specify a canned ACL using the `canned_acl` setting. When the S3 repository creates buckets and objects, it adds the canned ACL into the buckets and objects.').optional(),
+  client: z.string().describe('The name of the S3 client to use to connect to S3.').optional(),
+  delete_objects_max_size: integer.describe('The maxmimum batch size, between 1 and 1000, used for `DeleteObjects` requests. Defaults to 1000 which is the maximum number supported by the  AWS DeleteObjects API.').optional(),
+  get_register_retry_delay: Duration.describe('The time to wait before trying again if an attempt to read a linearizable register fails.').optional(),
+  max_multipart_parts: integer.describe('The maximum number of parts that Elasticsearch will write during a multipart upload of a single object. Files which are larger than `buffer_size × max_multipart_parts` will be chunked into several smaller objects. Elasticsearch may also split a file across multiple objects to satisfy other constraints such as the `chunk_size` limit. Defaults to `10000` which is the maximum number of parts in a multipart upload in AWS S3.').optional(),
+  max_multipart_upload_cleanup_size: integer.describe('The maximum number of possibly-dangling multipart uploads to clean up in each batch of snapshot deletions. Defaults to 1000 which is the maximum number supported by the AWS ListMultipartUploads API. If set to `0`, Elasticsearch will not attempt to clean up dangling multipart uploads.').optional(),
+  readonly: z.boolean().describe('If true, the repository is read-only. The cluster can retrieve and restore snapshots from the repository but not write to the repository or create snapshots in it. Only a cluster with write access can create snapshots in the repository. All other clusters connected to the repository should have the `readonly` parameter set to `true`. If `false`, the cluster can write to the repository and create snapshots in it. IMPORTANT: If you register the same snapshot repository with multiple clusters, only one cluster should have write access to the repository. Having multiple clusters write to the repository at the same time risks corrupting the contents of the repository.').optional(),
+  server_side_encryption: z.boolean().describe('When set to `true`, files are encrypted on server side using an AES256 algorithm.').optional(),
+  storage_class: z.string().describe('The S3 storage class for objects written to the repository. Values may be `standard`, `reduced_redundancy`, `standard_ia`, `onezone_ia`, and `intelligent_tiering`.').optional(),
+  'throttled_delete_retry.delay_increment': Duration.describe('The delay before the first retry and the amount the delay is incremented by on each subsequent retry. The default is 50ms and the minimum is 0ms.').optional(),
+  'throttled_delete_retry.maximum_delay': Duration.describe('The upper bound on how long the delays between retries will grow to. The default is 5s and the minimum is 0ms.').optional(),
+  'throttled_delete_retry.maximum_number_of_retries': integer.describe('The number times to retry a throttled snapshot deletion. The default is 10 and the minimum value is 0 which will disable retries altogether. Note that if retries are enabled in the Azure client, each of these retries comprises that many client-level retries.').optional()
+}).meta({ id: 'SnapshotSourceOnlyRepositorySettingsForS3' })
+export type SnapshotSourceOnlyRepositorySettingsForS3 = z.infer<typeof SnapshotSourceOnlyRepositorySettingsForS3>
+
+/**
+ * The delegated repository type.
+ * Source repositories can use `settings` properties for its delegated repository type.
+ */
+export const SnapshotSourceOnlyRepositorySettings = z.union([SnapshotSourceOnlyRepositorySettingsForSharedFileSystem, SnapshotSourceOnlyRepositorySettingsForReadOnlyUrl, SnapshotSourceOnlyRepositorySettingsForAzure, SnapshotSourceOnlyRepositorySettingsForGcs, SnapshotSourceOnlyRepositorySettingsForS3]).meta({ id: 'SnapshotSourceOnlyRepositorySettings' })
 export type SnapshotSourceOnlyRepositorySettings = z.infer<typeof SnapshotSourceOnlyRepositorySettings>
 
 export const SnapshotSourceOnlyRepository = z.object({

--- a/packages/es-schemas/src/snapshot_repository_analyze.ts
+++ b/packages/es-schemas/src/snapshot_repository_analyze.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/snapshot_repository_verify_integrity.ts
+++ b/packages/es-schemas/src/snapshot_repository_verify_integrity.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/snapshot_restore.ts
+++ b/packages/es-schemas/src/snapshot_restore.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4630,7 +4663,7 @@ export const AnalysisConditionTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('condition'),
   filter: z.array(z.string()).describe('Array of token filters. If a token matches the predicate script in the `script` parameter, these filters are applied to the token in the order provided.'),
-  script: z.lazy(() => Script).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
 }).meta({ id: 'AnalysisConditionTokenFilter' })
 export type AnalysisConditionTokenFilter = z.infer<typeof AnalysisConditionTokenFilter>
 
@@ -5111,7 +5144,7 @@ export type AnalysisPorterStemTokenFilter = z.infer<typeof AnalysisPorterStemTok
 export const AnalysisPredicateTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('predicate_token_filter'),
-  script: z.lazy(() => Script).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
 }).meta({ id: 'AnalysisPredicateTokenFilter' })
 export type AnalysisPredicateTokenFilter = z.infer<typeof AnalysisPredicateTokenFilter>
 
@@ -5594,8 +5627,8 @@ export type IndicesSettingsSimilarityLmj = z.infer<typeof IndicesSettingsSimilar
 
 export const IndicesSettingsSimilarityScripted = z.object({
   type: z.literal('scripted'),
-  script: z.lazy(() => Script),
-  weight_script: z.lazy(() => Script).optional()
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]),
+  weight_script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).optional()
 }).meta({ id: 'IndicesSettingsSimilarityScripted' })
 export type IndicesSettingsSimilarityScripted = z.infer<typeof IndicesSettingsSimilarityScripted>
 

--- a/packages/es-schemas/src/snapshot_status.ts
+++ b/packages/es-schemas/src/snapshot_status.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/snapshot_verify_repository.ts
+++ b/packages/es-schemas/src/snapshot_verify_repository.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/sql_clear_cursor.ts
+++ b/packages/es-schemas/src/sql_clear_cursor.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/sql_delete_async.ts
+++ b/packages/es-schemas/src/sql_delete_async.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/sql_get_async.ts
+++ b/packages/es-schemas/src/sql_get_async.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/sql_get_async_status.ts
+++ b/packages/es-schemas/src/sql_get_async_status.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/sql_query.ts
+++ b/packages/es-schemas/src/sql_query.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),

--- a/packages/es-schemas/src/sql_translate.ts
+++ b/packages/es-schemas/src/sql_translate.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -3980,7 +4013,7 @@ export const SqlTranslateResponse = z.object({
   aggregations: z.record(z.string(), z.lazy(() => AggregationsAggregationContainer)).optional(),
   size: long.optional(),
   _source: SearchSourceConfig.optional(),
-  fields: z.array(QueryDslFieldAndFormat).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   query: z.lazy(() => QueryDslQueryContainer).optional(),
   sort: z.lazy(() => Sort).optional(),
   track_total_hits: SearchTrackHits.optional()

--- a/packages/es-schemas/src/ssl_certificates.ts
+++ b/packages/es-schemas/src/ssl_certificates.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/streams_logs_disable.ts
+++ b/packages/es-schemas/src/streams_logs_disable.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/streams_logs_enable.ts
+++ b/packages/es-schemas/src/streams_logs_enable.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/streams_status.ts
+++ b/packages/es-schemas/src/streams_status.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/synonyms_delete_synonym.ts
+++ b/packages/es-schemas/src/synonyms_delete_synonym.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/synonyms_delete_synonym_rule.ts
+++ b/packages/es-schemas/src/synonyms_delete_synonym_rule.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/synonyms_get_synonym.ts
+++ b/packages/es-schemas/src/synonyms_get_synonym.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/synonyms_get_synonym_rule.ts
+++ b/packages/es-schemas/src/synonyms_get_synonym_rule.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/synonyms_get_synonyms_sets.ts
+++ b/packages/es-schemas/src/synonyms_get_synonyms_sets.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/synonyms_put_synonym.ts
+++ b/packages/es-schemas/src/synonyms_put_synonym.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/synonyms_put_synonym_rule.ts
+++ b/packages/es-schemas/src/synonyms_put_synonym_rule.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/tasks_cancel.ts
+++ b/packages/es-schemas/src/tasks_cancel.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/tasks_get.ts
+++ b/packages/es-schemas/src/tasks_get.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/tasks_list.ts
+++ b/packages/es-schemas/src/tasks_list.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/terms_enum.ts
+++ b/packages/es-schemas/src/terms_enum.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),

--- a/packages/es-schemas/src/termvectors.ts
+++ b/packages/es-schemas/src/termvectors.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/text_structure_find_field_structure.ts
+++ b/packages/es-schemas/src/text_structure_find_field_structure.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -3956,6 +3989,9 @@ export const SearchFieldCollapse = z.object({
   get collapse () { return SearchFieldCollapse.optional() }
 }).meta({ id: 'SearchFieldCollapse' })
 export type SearchFieldCollapse = z.infer<typeof SearchFieldCollapse>
+
+export const ByteSize = z.union([long, z.string()]).meta({ id: 'ByteSize' })
+export type ByteSize = z.infer<typeof ByteSize>
 
 export const GeoShapeRelation = z.enum(['intersects', 'disjoint', 'within', 'contains']).meta({ id: 'GeoShapeRelation' })
 export type GeoShapeRelation = z.infer<typeof GeoShapeRelation>
@@ -4313,7 +4349,7 @@ export const MappingBooleanProperty = z.object({
   index: z.boolean().optional(),
   null_value: z.boolean().optional(),
   ignore_malformed: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('boolean')
@@ -4354,7 +4390,7 @@ export const MappingNumberPropertyBase = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional()
 }).meta({ id: 'MappingNumberPropertyBase' })
@@ -4396,7 +4432,7 @@ export const MappingByteNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('byte'),
@@ -4525,7 +4561,7 @@ export const MappingDateNanosProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -4570,7 +4606,7 @@ export const MappingDateProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -4709,7 +4745,7 @@ export const MappingDoubleNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('double'),
@@ -4798,7 +4834,7 @@ export const MappingDynamicProperty = z.object({
   null_value: FieldValue.optional(),
   boost: double.optional(),
   coerce: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   ignore_malformed: z.boolean().optional(),
   time_series_metric: MappingTimeSeriesMetricType.optional(),
@@ -4962,7 +4998,7 @@ export const MappingFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('float'),
@@ -5036,7 +5072,7 @@ export const MappingGeoPointProperty = z.object({
   null_value: GeoLocation.optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   type: z.literal('geo_point'),
   time_series_metric: MappingGeoPointMetricType.optional()
 }).meta({ id: 'MappingGeoPointProperty' })
@@ -5120,7 +5156,7 @@ export const MappingHalfFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('half_float'),
@@ -5251,7 +5287,7 @@ export const MappingIntegerNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('integer'),
@@ -5325,7 +5361,7 @@ export const MappingIpProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   null_value: z.string().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('ip')
 }).meta({ id: 'MappingIpProperty' })
@@ -5425,7 +5461,7 @@ export const MappingKeywordProperty = z.object({
   eager_global_ordinals: z.boolean().optional(),
   index: z.boolean().optional(),
   index_options: MappingIndexOptions.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   normalizer: z.string().optional(),
   norms: z.boolean().optional(),
@@ -5473,7 +5509,7 @@ export const MappingLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('long'),
@@ -5790,7 +5826,7 @@ export const MappingScaledFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('scaled_float'),
@@ -5915,7 +5951,7 @@ export const MappingShortNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('short'),
@@ -6112,7 +6148,7 @@ export const MappingUnsignedLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('unsigned_long'),
@@ -6283,7 +6319,7 @@ export interface IngestProcessorBaseShape {
 }
 export const IngestProcessorBase = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional()
@@ -6305,7 +6341,7 @@ export interface IngestAppendProcessorShape {
 }
 export const IngestAppendProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6328,6 +6364,7 @@ export interface IngestAttachmentProcessorShape {
   ignore_missing?: boolean | undefined
   indexed_chars?: long | undefined
   indexed_chars_field?: Field | undefined
+  max_field_bytes?: ByteSize | undefined
   properties?: string[] | undefined
   target_field?: Field | undefined
   remove_binary?: boolean | undefined
@@ -6335,7 +6372,7 @@ export interface IngestAttachmentProcessorShape {
 }
 export const IngestAttachmentProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6343,6 +6380,7 @@ export const IngestAttachmentProcessor = z.object({
   ignore_missing: z.boolean().describe('If `true` and field does not exist, the processor quietly exits without modifying the document.').optional(),
   indexed_chars: long.describe('The number of chars being used for extraction to prevent huge fields. Use `-1` for no limit.').optional(),
   indexed_chars_field: Field.describe('Field name from which you can overwrite the number of chars being used for extraction.').optional(),
+  max_field_bytes: ByteSize.describe('Maximum allowed size of the attachment `field` value in bytes: length of a string (if base64 in JSON, checked before base64 decoding) or byte array length for binary (for example, CBOR). If set to `-1`, there is no per-processor limit. The node setting `ingest.attachment.max_field_size` also applies.').optional(),
   properties: z.array(z.string()).describe('Array of properties to select to be stored. Can be `content`, `title`, `name`, `author`, `keywords`, `date`, `content_type`, `content_length`, `language`.').optional(),
   target_field: Field.describe('The field that will hold the attachment information.').optional(),
   remove_binary: z.boolean().describe('If true, the binary field will be removed from the document').optional(),
@@ -6362,7 +6400,7 @@ export interface IngestBytesProcessorShape {
 }
 export const IngestBytesProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6386,7 +6424,7 @@ export interface IngestCefProcessorShape {
 }
 export const IngestCefProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6412,7 +6450,7 @@ export interface IngestCircleProcessorShape {
 }
 export const IngestCircleProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6444,7 +6482,7 @@ export interface IngestCommunityIDProcessorShape {
 }
 export const IngestCommunityIDProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6475,7 +6513,7 @@ export interface IngestConvertProcessorShape {
 }
 export const IngestConvertProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6502,7 +6540,7 @@ export interface IngestCsvProcessorShape {
 }
 export const IngestCsvProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6532,7 +6570,7 @@ export interface IngestDateIndexNameProcessorShape {
 }
 export const IngestDateIndexNameProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6561,7 +6599,7 @@ export interface IngestDateProcessorShape {
 }
 export const IngestDateProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6587,7 +6625,7 @@ export interface IngestDissectProcessorShape {
 }
 export const IngestDissectProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6610,7 +6648,7 @@ export interface IngestDotExpanderProcessorShape {
 }
 export const IngestDotExpanderProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6629,7 +6667,7 @@ export interface IngestDropProcessorShape {
 }
 export const IngestDropProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional()
@@ -6652,7 +6690,7 @@ export interface IngestEnrichProcessorShape {
 }
 export const IngestEnrichProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6676,7 +6714,7 @@ export interface IngestFailProcessorShape {
 }
 export const IngestFailProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6698,7 +6736,7 @@ export interface IngestFingerprintProcessorShape {
 }
 export const IngestFingerprintProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6722,7 +6760,7 @@ export interface IngestForeachProcessorShape {
 }
 export const IngestForeachProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6750,7 +6788,7 @@ export interface IngestGeoGridProcessorShape {
 }
 export const IngestGeoGridProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6782,7 +6820,7 @@ export interface IngestGeoIpProcessorShape {
 }
 export const IngestGeoIpProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6812,7 +6850,7 @@ export interface IngestGrokProcessorShape {
 }
 export const IngestGrokProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6840,7 +6878,7 @@ export interface IngestGsubProcessorShape {
 }
 export const IngestGsubProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6864,7 +6902,7 @@ export interface IngestHtmlStripProcessorShape {
 }
 export const IngestHtmlStripProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6889,7 +6927,7 @@ export interface IngestInferenceProcessorShape {
 }
 export const IngestInferenceProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6918,7 +6956,7 @@ export interface IngestIpLocationProcessorShape {
 }
 export const IngestIpLocationProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6944,7 +6982,7 @@ export interface IngestJoinProcessorShape {
 }
 export const IngestJoinProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6968,7 +7006,7 @@ export interface IngestJsonProcessorShape {
 }
 export const IngestJsonProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7000,7 +7038,7 @@ export interface IngestKeyValueProcessorShape {
 }
 export const IngestKeyValueProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7030,7 +7068,7 @@ export interface IngestLowercaseProcessorShape {
 }
 export const IngestLowercaseProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7055,7 +7093,7 @@ export interface IngestNetworkDirectionProcessorShape {
 }
 export const IngestNetworkDirectionProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7086,7 +7124,7 @@ export interface IngestPipelineProcessorShape {
 }
 export const IngestPipelineProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7112,7 +7150,7 @@ export interface IngestRedactProcessorShape {
 }
 export const IngestRedactProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7139,7 +7177,7 @@ export interface IngestRegisteredDomainProcessorShape {
 }
 export const IngestRegisteredDomainProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7161,7 +7199,7 @@ export interface IngestRemoveProcessorShape {
 }
 export const IngestRemoveProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7183,7 +7221,7 @@ export interface IngestRenameProcessorShape {
 }
 export const IngestRenameProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7205,7 +7243,7 @@ export interface IngestRerouteProcessorShape {
 }
 export const IngestRerouteProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7228,7 +7266,7 @@ export interface IngestScriptProcessorShape {
 }
 export const IngestScriptProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7254,7 +7292,7 @@ export interface IngestSetProcessorShape {
 }
 export const IngestSetProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7278,7 +7316,7 @@ export interface IngestSetSecurityUserProcessorShape {
 }
 export const IngestSetSecurityUserProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7299,7 +7337,7 @@ export interface IngestSortProcessorShape {
 }
 export const IngestSortProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7323,7 +7361,7 @@ export interface IngestSplitProcessorShape {
 }
 export const IngestSplitProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7344,7 +7382,7 @@ export interface IngestTerminateProcessorShape {
 }
 export const IngestTerminateProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional()
@@ -7363,7 +7401,7 @@ export interface IngestTrimProcessorShape {
 }
 export const IngestTrimProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7385,7 +7423,7 @@ export interface IngestUppercaseProcessorShape {
 }
 export const IngestUppercaseProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7409,7 +7447,7 @@ export interface IngestUriPartsProcessorShape {
 }
 export const IngestUriPartsProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7433,7 +7471,7 @@ export interface IngestUrlDecodeProcessorShape {
 }
 export const IngestUrlDecodeProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7458,7 +7496,7 @@ export interface IngestUserAgentProcessorShape {
 }
 export const IngestUserAgentProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),

--- a/packages/es-schemas/src/text_structure_find_message_structure.ts
+++ b/packages/es-schemas/src/text_structure_find_message_structure.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -3956,6 +3989,9 @@ export const SearchFieldCollapse = z.object({
   get collapse () { return SearchFieldCollapse.optional() }
 }).meta({ id: 'SearchFieldCollapse' })
 export type SearchFieldCollapse = z.infer<typeof SearchFieldCollapse>
+
+export const ByteSize = z.union([long, z.string()]).meta({ id: 'ByteSize' })
+export type ByteSize = z.infer<typeof ByteSize>
 
 export const GeoShapeRelation = z.enum(['intersects', 'disjoint', 'within', 'contains']).meta({ id: 'GeoShapeRelation' })
 export type GeoShapeRelation = z.infer<typeof GeoShapeRelation>
@@ -4310,7 +4346,7 @@ export const MappingBooleanProperty = z.object({
   index: z.boolean().optional(),
   null_value: z.boolean().optional(),
   ignore_malformed: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('boolean')
@@ -4351,7 +4387,7 @@ export const MappingNumberPropertyBase = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional()
 }).meta({ id: 'MappingNumberPropertyBase' })
@@ -4393,7 +4429,7 @@ export const MappingByteNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('byte'),
@@ -4522,7 +4558,7 @@ export const MappingDateNanosProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -4567,7 +4603,7 @@ export const MappingDateProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -4706,7 +4742,7 @@ export const MappingDoubleNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('double'),
@@ -4795,7 +4831,7 @@ export const MappingDynamicProperty = z.object({
   null_value: FieldValue.optional(),
   boost: double.optional(),
   coerce: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   ignore_malformed: z.boolean().optional(),
   time_series_metric: MappingTimeSeriesMetricType.optional(),
@@ -4959,7 +4995,7 @@ export const MappingFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('float'),
@@ -5033,7 +5069,7 @@ export const MappingGeoPointProperty = z.object({
   null_value: GeoLocation.optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   type: z.literal('geo_point'),
   time_series_metric: MappingGeoPointMetricType.optional()
 }).meta({ id: 'MappingGeoPointProperty' })
@@ -5117,7 +5153,7 @@ export const MappingHalfFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('half_float'),
@@ -5248,7 +5284,7 @@ export const MappingIntegerNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('integer'),
@@ -5322,7 +5358,7 @@ export const MappingIpProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   null_value: z.string().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('ip')
 }).meta({ id: 'MappingIpProperty' })
@@ -5422,7 +5458,7 @@ export const MappingKeywordProperty = z.object({
   eager_global_ordinals: z.boolean().optional(),
   index: z.boolean().optional(),
   index_options: MappingIndexOptions.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   normalizer: z.string().optional(),
   norms: z.boolean().optional(),
@@ -5470,7 +5506,7 @@ export const MappingLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('long'),
@@ -5787,7 +5823,7 @@ export const MappingScaledFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('scaled_float'),
@@ -5912,7 +5948,7 @@ export const MappingShortNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('short'),
@@ -6109,7 +6145,7 @@ export const MappingUnsignedLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('unsigned_long'),
@@ -6280,7 +6316,7 @@ export interface IngestProcessorBaseShape {
 }
 export const IngestProcessorBase = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional()
@@ -6302,7 +6338,7 @@ export interface IngestAppendProcessorShape {
 }
 export const IngestAppendProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6325,6 +6361,7 @@ export interface IngestAttachmentProcessorShape {
   ignore_missing?: boolean | undefined
   indexed_chars?: long | undefined
   indexed_chars_field?: Field | undefined
+  max_field_bytes?: ByteSize | undefined
   properties?: string[] | undefined
   target_field?: Field | undefined
   remove_binary?: boolean | undefined
@@ -6332,7 +6369,7 @@ export interface IngestAttachmentProcessorShape {
 }
 export const IngestAttachmentProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6340,6 +6377,7 @@ export const IngestAttachmentProcessor = z.object({
   ignore_missing: z.boolean().describe('If `true` and field does not exist, the processor quietly exits without modifying the document.').optional(),
   indexed_chars: long.describe('The number of chars being used for extraction to prevent huge fields. Use `-1` for no limit.').optional(),
   indexed_chars_field: Field.describe('Field name from which you can overwrite the number of chars being used for extraction.').optional(),
+  max_field_bytes: ByteSize.describe('Maximum allowed size of the attachment `field` value in bytes: length of a string (if base64 in JSON, checked before base64 decoding) or byte array length for binary (for example, CBOR). If set to `-1`, there is no per-processor limit. The node setting `ingest.attachment.max_field_size` also applies.').optional(),
   properties: z.array(z.string()).describe('Array of properties to select to be stored. Can be `content`, `title`, `name`, `author`, `keywords`, `date`, `content_type`, `content_length`, `language`.').optional(),
   target_field: Field.describe('The field that will hold the attachment information.').optional(),
   remove_binary: z.boolean().describe('If true, the binary field will be removed from the document').optional(),
@@ -6359,7 +6397,7 @@ export interface IngestBytesProcessorShape {
 }
 export const IngestBytesProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6383,7 +6421,7 @@ export interface IngestCefProcessorShape {
 }
 export const IngestCefProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6409,7 +6447,7 @@ export interface IngestCircleProcessorShape {
 }
 export const IngestCircleProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6441,7 +6479,7 @@ export interface IngestCommunityIDProcessorShape {
 }
 export const IngestCommunityIDProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6472,7 +6510,7 @@ export interface IngestConvertProcessorShape {
 }
 export const IngestConvertProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6499,7 +6537,7 @@ export interface IngestCsvProcessorShape {
 }
 export const IngestCsvProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6529,7 +6567,7 @@ export interface IngestDateIndexNameProcessorShape {
 }
 export const IngestDateIndexNameProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6558,7 +6596,7 @@ export interface IngestDateProcessorShape {
 }
 export const IngestDateProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6584,7 +6622,7 @@ export interface IngestDissectProcessorShape {
 }
 export const IngestDissectProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6607,7 +6645,7 @@ export interface IngestDotExpanderProcessorShape {
 }
 export const IngestDotExpanderProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6626,7 +6664,7 @@ export interface IngestDropProcessorShape {
 }
 export const IngestDropProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional()
@@ -6649,7 +6687,7 @@ export interface IngestEnrichProcessorShape {
 }
 export const IngestEnrichProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6673,7 +6711,7 @@ export interface IngestFailProcessorShape {
 }
 export const IngestFailProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6695,7 +6733,7 @@ export interface IngestFingerprintProcessorShape {
 }
 export const IngestFingerprintProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6719,7 +6757,7 @@ export interface IngestForeachProcessorShape {
 }
 export const IngestForeachProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6747,7 +6785,7 @@ export interface IngestGeoGridProcessorShape {
 }
 export const IngestGeoGridProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6779,7 +6817,7 @@ export interface IngestGeoIpProcessorShape {
 }
 export const IngestGeoIpProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6809,7 +6847,7 @@ export interface IngestGrokProcessorShape {
 }
 export const IngestGrokProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6837,7 +6875,7 @@ export interface IngestGsubProcessorShape {
 }
 export const IngestGsubProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6861,7 +6899,7 @@ export interface IngestHtmlStripProcessorShape {
 }
 export const IngestHtmlStripProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6886,7 +6924,7 @@ export interface IngestInferenceProcessorShape {
 }
 export const IngestInferenceProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6915,7 +6953,7 @@ export interface IngestIpLocationProcessorShape {
 }
 export const IngestIpLocationProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6941,7 +6979,7 @@ export interface IngestJoinProcessorShape {
 }
 export const IngestJoinProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6965,7 +7003,7 @@ export interface IngestJsonProcessorShape {
 }
 export const IngestJsonProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6997,7 +7035,7 @@ export interface IngestKeyValueProcessorShape {
 }
 export const IngestKeyValueProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7027,7 +7065,7 @@ export interface IngestLowercaseProcessorShape {
 }
 export const IngestLowercaseProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7052,7 +7090,7 @@ export interface IngestNetworkDirectionProcessorShape {
 }
 export const IngestNetworkDirectionProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7083,7 +7121,7 @@ export interface IngestPipelineProcessorShape {
 }
 export const IngestPipelineProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7109,7 +7147,7 @@ export interface IngestRedactProcessorShape {
 }
 export const IngestRedactProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7136,7 +7174,7 @@ export interface IngestRegisteredDomainProcessorShape {
 }
 export const IngestRegisteredDomainProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7158,7 +7196,7 @@ export interface IngestRemoveProcessorShape {
 }
 export const IngestRemoveProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7180,7 +7218,7 @@ export interface IngestRenameProcessorShape {
 }
 export const IngestRenameProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7202,7 +7240,7 @@ export interface IngestRerouteProcessorShape {
 }
 export const IngestRerouteProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7225,7 +7263,7 @@ export interface IngestScriptProcessorShape {
 }
 export const IngestScriptProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7251,7 +7289,7 @@ export interface IngestSetProcessorShape {
 }
 export const IngestSetProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7275,7 +7313,7 @@ export interface IngestSetSecurityUserProcessorShape {
 }
 export const IngestSetSecurityUserProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7296,7 +7334,7 @@ export interface IngestSortProcessorShape {
 }
 export const IngestSortProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7320,7 +7358,7 @@ export interface IngestSplitProcessorShape {
 }
 export const IngestSplitProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7341,7 +7379,7 @@ export interface IngestTerminateProcessorShape {
 }
 export const IngestTerminateProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional()
@@ -7360,7 +7398,7 @@ export interface IngestTrimProcessorShape {
 }
 export const IngestTrimProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7382,7 +7420,7 @@ export interface IngestUppercaseProcessorShape {
 }
 export const IngestUppercaseProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7406,7 +7444,7 @@ export interface IngestUriPartsProcessorShape {
 }
 export const IngestUriPartsProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7430,7 +7468,7 @@ export interface IngestUrlDecodeProcessorShape {
 }
 export const IngestUrlDecodeProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7455,7 +7493,7 @@ export interface IngestUserAgentProcessorShape {
 }
 export const IngestUserAgentProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),

--- a/packages/es-schemas/src/text_structure_find_structure.ts
+++ b/packages/es-schemas/src/text_structure_find_structure.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -3956,6 +3989,9 @@ export const SearchFieldCollapse = z.object({
   get collapse () { return SearchFieldCollapse.optional() }
 }).meta({ id: 'SearchFieldCollapse' })
 export type SearchFieldCollapse = z.infer<typeof SearchFieldCollapse>
+
+export const ByteSize = z.union([long, z.string()]).meta({ id: 'ByteSize' })
+export type ByteSize = z.infer<typeof ByteSize>
 
 export const GeoShapeRelation = z.enum(['intersects', 'disjoint', 'within', 'contains']).meta({ id: 'GeoShapeRelation' })
 export type GeoShapeRelation = z.infer<typeof GeoShapeRelation>
@@ -4309,7 +4345,7 @@ export const MappingBooleanProperty = z.object({
   index: z.boolean().optional(),
   null_value: z.boolean().optional(),
   ignore_malformed: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('boolean')
@@ -4350,7 +4386,7 @@ export const MappingNumberPropertyBase = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional()
 }).meta({ id: 'MappingNumberPropertyBase' })
@@ -4392,7 +4428,7 @@ export const MappingByteNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('byte'),
@@ -4521,7 +4557,7 @@ export const MappingDateNanosProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -4566,7 +4602,7 @@ export const MappingDateProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -4705,7 +4741,7 @@ export const MappingDoubleNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('double'),
@@ -4794,7 +4830,7 @@ export const MappingDynamicProperty = z.object({
   null_value: FieldValue.optional(),
   boost: double.optional(),
   coerce: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   ignore_malformed: z.boolean().optional(),
   time_series_metric: MappingTimeSeriesMetricType.optional(),
@@ -4958,7 +4994,7 @@ export const MappingFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('float'),
@@ -5032,7 +5068,7 @@ export const MappingGeoPointProperty = z.object({
   null_value: GeoLocation.optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   type: z.literal('geo_point'),
   time_series_metric: MappingGeoPointMetricType.optional()
 }).meta({ id: 'MappingGeoPointProperty' })
@@ -5116,7 +5152,7 @@ export const MappingHalfFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('half_float'),
@@ -5247,7 +5283,7 @@ export const MappingIntegerNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('integer'),
@@ -5321,7 +5357,7 @@ export const MappingIpProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   null_value: z.string().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('ip')
 }).meta({ id: 'MappingIpProperty' })
@@ -5421,7 +5457,7 @@ export const MappingKeywordProperty = z.object({
   eager_global_ordinals: z.boolean().optional(),
   index: z.boolean().optional(),
   index_options: MappingIndexOptions.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   normalizer: z.string().optional(),
   norms: z.boolean().optional(),
@@ -5469,7 +5505,7 @@ export const MappingLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('long'),
@@ -5786,7 +5822,7 @@ export const MappingScaledFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('scaled_float'),
@@ -5911,7 +5947,7 @@ export const MappingShortNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('short'),
@@ -6108,7 +6144,7 @@ export const MappingUnsignedLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('unsigned_long'),
@@ -6279,7 +6315,7 @@ export interface IngestProcessorBaseShape {
 }
 export const IngestProcessorBase = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional()
@@ -6301,7 +6337,7 @@ export interface IngestAppendProcessorShape {
 }
 export const IngestAppendProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6324,6 +6360,7 @@ export interface IngestAttachmentProcessorShape {
   ignore_missing?: boolean | undefined
   indexed_chars?: long | undefined
   indexed_chars_field?: Field | undefined
+  max_field_bytes?: ByteSize | undefined
   properties?: string[] | undefined
   target_field?: Field | undefined
   remove_binary?: boolean | undefined
@@ -6331,7 +6368,7 @@ export interface IngestAttachmentProcessorShape {
 }
 export const IngestAttachmentProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6339,6 +6376,7 @@ export const IngestAttachmentProcessor = z.object({
   ignore_missing: z.boolean().describe('If `true` and field does not exist, the processor quietly exits without modifying the document.').optional(),
   indexed_chars: long.describe('The number of chars being used for extraction to prevent huge fields. Use `-1` for no limit.').optional(),
   indexed_chars_field: Field.describe('Field name from which you can overwrite the number of chars being used for extraction.').optional(),
+  max_field_bytes: ByteSize.describe('Maximum allowed size of the attachment `field` value in bytes: length of a string (if base64 in JSON, checked before base64 decoding) or byte array length for binary (for example, CBOR). If set to `-1`, there is no per-processor limit. The node setting `ingest.attachment.max_field_size` also applies.').optional(),
   properties: z.array(z.string()).describe('Array of properties to select to be stored. Can be `content`, `title`, `name`, `author`, `keywords`, `date`, `content_type`, `content_length`, `language`.').optional(),
   target_field: Field.describe('The field that will hold the attachment information.').optional(),
   remove_binary: z.boolean().describe('If true, the binary field will be removed from the document').optional(),
@@ -6358,7 +6396,7 @@ export interface IngestBytesProcessorShape {
 }
 export const IngestBytesProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6382,7 +6420,7 @@ export interface IngestCefProcessorShape {
 }
 export const IngestCefProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6408,7 +6446,7 @@ export interface IngestCircleProcessorShape {
 }
 export const IngestCircleProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6440,7 +6478,7 @@ export interface IngestCommunityIDProcessorShape {
 }
 export const IngestCommunityIDProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6471,7 +6509,7 @@ export interface IngestConvertProcessorShape {
 }
 export const IngestConvertProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6498,7 +6536,7 @@ export interface IngestCsvProcessorShape {
 }
 export const IngestCsvProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6528,7 +6566,7 @@ export interface IngestDateIndexNameProcessorShape {
 }
 export const IngestDateIndexNameProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6557,7 +6595,7 @@ export interface IngestDateProcessorShape {
 }
 export const IngestDateProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6583,7 +6621,7 @@ export interface IngestDissectProcessorShape {
 }
 export const IngestDissectProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6606,7 +6644,7 @@ export interface IngestDotExpanderProcessorShape {
 }
 export const IngestDotExpanderProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6625,7 +6663,7 @@ export interface IngestDropProcessorShape {
 }
 export const IngestDropProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional()
@@ -6648,7 +6686,7 @@ export interface IngestEnrichProcessorShape {
 }
 export const IngestEnrichProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6672,7 +6710,7 @@ export interface IngestFailProcessorShape {
 }
 export const IngestFailProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6694,7 +6732,7 @@ export interface IngestFingerprintProcessorShape {
 }
 export const IngestFingerprintProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6718,7 +6756,7 @@ export interface IngestForeachProcessorShape {
 }
 export const IngestForeachProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6746,7 +6784,7 @@ export interface IngestGeoGridProcessorShape {
 }
 export const IngestGeoGridProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6778,7 +6816,7 @@ export interface IngestGeoIpProcessorShape {
 }
 export const IngestGeoIpProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6808,7 +6846,7 @@ export interface IngestGrokProcessorShape {
 }
 export const IngestGrokProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6836,7 +6874,7 @@ export interface IngestGsubProcessorShape {
 }
 export const IngestGsubProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6860,7 +6898,7 @@ export interface IngestHtmlStripProcessorShape {
 }
 export const IngestHtmlStripProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6885,7 +6923,7 @@ export interface IngestInferenceProcessorShape {
 }
 export const IngestInferenceProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6914,7 +6952,7 @@ export interface IngestIpLocationProcessorShape {
 }
 export const IngestIpLocationProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6940,7 +6978,7 @@ export interface IngestJoinProcessorShape {
 }
 export const IngestJoinProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6964,7 +7002,7 @@ export interface IngestJsonProcessorShape {
 }
 export const IngestJsonProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -6996,7 +7034,7 @@ export interface IngestKeyValueProcessorShape {
 }
 export const IngestKeyValueProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7026,7 +7064,7 @@ export interface IngestLowercaseProcessorShape {
 }
 export const IngestLowercaseProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7051,7 +7089,7 @@ export interface IngestNetworkDirectionProcessorShape {
 }
 export const IngestNetworkDirectionProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7082,7 +7120,7 @@ export interface IngestPipelineProcessorShape {
 }
 export const IngestPipelineProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7108,7 +7146,7 @@ export interface IngestRedactProcessorShape {
 }
 export const IngestRedactProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7135,7 +7173,7 @@ export interface IngestRegisteredDomainProcessorShape {
 }
 export const IngestRegisteredDomainProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7157,7 +7195,7 @@ export interface IngestRemoveProcessorShape {
 }
 export const IngestRemoveProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7179,7 +7217,7 @@ export interface IngestRenameProcessorShape {
 }
 export const IngestRenameProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7201,7 +7239,7 @@ export interface IngestRerouteProcessorShape {
 }
 export const IngestRerouteProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7224,7 +7262,7 @@ export interface IngestScriptProcessorShape {
 }
 export const IngestScriptProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7250,7 +7288,7 @@ export interface IngestSetProcessorShape {
 }
 export const IngestSetProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7274,7 +7312,7 @@ export interface IngestSetSecurityUserProcessorShape {
 }
 export const IngestSetSecurityUserProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7295,7 +7333,7 @@ export interface IngestSortProcessorShape {
 }
 export const IngestSortProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7319,7 +7357,7 @@ export interface IngestSplitProcessorShape {
 }
 export const IngestSplitProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7340,7 +7378,7 @@ export interface IngestTerminateProcessorShape {
 }
 export const IngestTerminateProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional()
@@ -7359,7 +7397,7 @@ export interface IngestTrimProcessorShape {
 }
 export const IngestTrimProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7381,7 +7419,7 @@ export interface IngestUppercaseProcessorShape {
 }
 export const IngestUppercaseProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7405,7 +7443,7 @@ export interface IngestUriPartsProcessorShape {
 }
 export const IngestUriPartsProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7429,7 +7467,7 @@ export interface IngestUrlDecodeProcessorShape {
 }
 export const IngestUrlDecodeProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),
@@ -7454,7 +7492,7 @@ export interface IngestUserAgentProcessorShape {
 }
 export const IngestUserAgentProcessor = z.object({
   description: z.string().describe('Description of the processor. Useful for describing the purpose of the processor or its configuration.').optional(),
-  get if () { return Script.describe('Conditionally execute the processor.').optional() },
+  get if () { return z.union([Script, ScriptSource]).describe('Conditionally execute the processor.').optional() },
   ignore_failure: z.boolean().describe('Ignore failures for the processor.').optional(),
   get on_failure () { return IngestProcessorContainer.array().describe('Handle failures for the processor.').optional() },
   tag: z.string().describe('Identifier for the processor. Useful for debugging and metrics.').optional(),

--- a/packages/es-schemas/src/text_structure_test_grok_pattern.ts
+++ b/packages/es-schemas/src/text_structure_test_grok_pattern.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/transform_delete_transform.ts
+++ b/packages/es-schemas/src/transform_delete_transform.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/transform_get_node_stats.ts
+++ b/packages/es-schemas/src/transform_get_node_stats.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/transform_get_transform.ts
+++ b/packages/es-schemas/src/transform_get_transform.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -299,7 +300,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -310,11 +311,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -330,7 +331,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -343,7 +344,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -357,7 +358,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -403,7 +404,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -419,7 +420,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -433,7 +434,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -498,7 +499,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -598,7 +599,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -613,7 +614,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -625,7 +626,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -698,7 +699,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -716,7 +717,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -735,7 +736,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -773,7 +774,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -857,7 +858,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -940,7 +941,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -992,7 +993,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -1008,7 +1009,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1080,7 +1081,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1095,7 +1096,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1201,7 +1202,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1283,7 +1284,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1304,7 +1305,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1320,7 +1321,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1435,7 +1436,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1512,7 +1513,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1534,7 +1535,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1561,7 +1562,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1593,7 +1594,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1625,12 +1626,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1668,7 +1669,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1765,7 +1766,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1784,7 +1785,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1798,7 +1799,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1839,7 +1840,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1860,7 +1861,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1875,7 +1876,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1899,10 +1900,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1923,7 +1924,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1959,7 +1960,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1975,7 +1976,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1989,7 +1990,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -2002,7 +2003,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2032,7 +2033,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2143,6 +2144,36 @@ export type SearchTrackHits = z.infer<typeof SearchTrackHits>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2157,7 +2188,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2224,7 +2255,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2579,12 +2610,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2637,7 +2668,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2651,7 +2682,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2692,7 +2723,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2870,7 +2901,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3391,7 +3422,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3407,7 +3438,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3570,7 +3601,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3646,7 +3677,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3687,7 +3718,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3928,7 +3959,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3940,13 +3972,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),

--- a/packages/es-schemas/src/transform_get_transform_stats.ts
+++ b/packages/es-schemas/src/transform_get_transform_stats.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/transform_preview_transform.ts
+++ b/packages/es-schemas/src/transform_preview_transform.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4598,7 +4631,7 @@ export const AnalysisConditionTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('condition'),
   filter: z.array(z.string()).describe('Array of token filters. If a token matches the predicate script in the `script` parameter, these filters are applied to the token in the order provided.'),
-  script: z.lazy(() => Script).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
 }).meta({ id: 'AnalysisConditionTokenFilter' })
 export type AnalysisConditionTokenFilter = z.infer<typeof AnalysisConditionTokenFilter>
 
@@ -5079,7 +5112,7 @@ export type AnalysisPorterStemTokenFilter = z.infer<typeof AnalysisPorterStemTok
 export const AnalysisPredicateTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('predicate_token_filter'),
-  script: z.lazy(() => Script).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
 }).meta({ id: 'AnalysisPredicateTokenFilter' })
 export type AnalysisPredicateTokenFilter = z.infer<typeof AnalysisPredicateTokenFilter>
 
@@ -5628,7 +5661,7 @@ export const MappingBooleanProperty = z.object({
   index: z.boolean().optional(),
   null_value: z.boolean().optional(),
   ignore_malformed: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('boolean')
@@ -5669,7 +5702,7 @@ export const MappingNumberPropertyBase = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional()
 }).meta({ id: 'MappingNumberPropertyBase' })
@@ -5711,7 +5744,7 @@ export const MappingByteNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('byte'),
@@ -5840,7 +5873,7 @@ export const MappingDateNanosProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -5885,7 +5918,7 @@ export const MappingDateProperty = z.object({
   format: z.string().optional(),
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   null_value: DateTime.optional(),
   precision_step: integer.optional(),
@@ -6024,7 +6057,7 @@ export const MappingDoubleNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('double'),
@@ -6113,7 +6146,7 @@ export const MappingDynamicProperty = z.object({
   null_value: FieldValue.optional(),
   boost: double.optional(),
   coerce: z.boolean().optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   ignore_malformed: z.boolean().optional(),
   time_series_metric: MappingTimeSeriesMetricType.optional(),
@@ -6277,7 +6310,7 @@ export const MappingFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('float'),
@@ -6351,7 +6384,7 @@ export const MappingGeoPointProperty = z.object({
   null_value: GeoLocation.optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   type: z.literal('geo_point'),
   time_series_metric: MappingGeoPointMetricType.optional()
 }).meta({ id: 'MappingGeoPointProperty' })
@@ -6435,7 +6468,7 @@ export const MappingHalfFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('half_float'),
@@ -6566,7 +6599,7 @@ export const MappingIntegerNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('integer'),
@@ -6640,7 +6673,7 @@ export const MappingIpProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   null_value: z.string().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('ip')
 }).meta({ id: 'MappingIpProperty' })
@@ -6740,7 +6773,7 @@ export const MappingKeywordProperty = z.object({
   eager_global_ordinals: z.boolean().optional(),
   index: z.boolean().optional(),
   index_options: MappingIndexOptions.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   on_script_error: MappingOnScriptError.optional(),
   normalizer: z.string().optional(),
   norms: z.boolean().optional(),
@@ -6788,7 +6821,7 @@ export const MappingLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('long'),
@@ -7105,7 +7138,7 @@ export const MappingScaledFloatNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('scaled_float'),
@@ -7230,7 +7263,7 @@ export const MappingShortNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('short'),
@@ -7427,7 +7460,7 @@ export const MappingUnsignedLongNumberProperty = z.object({
   ignore_malformed: z.boolean().optional(),
   index: z.boolean().optional(),
   on_script_error: MappingOnScriptError.optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_series_metric: MappingTimeSeriesMetricType.describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   time_series_dimension: z.boolean().describe('For internal use by Elastic only. Marks the field as a time series dimension. Defaults to false.').optional(),
   type: z.literal('unsigned_long'),
@@ -7504,6 +7537,9 @@ export const IndicesCacheQueries = z.object({
 }).meta({ id: 'IndicesCacheQueries' })
 export type IndicesCacheQueries = z.infer<typeof IndicesCacheQueries>
 
+export const IndicesRetentionSource = z.enum(['data_stream_configuration', 'default_global_retention', 'max_global_retention', 'default_failures_retention']).meta({ id: 'IndicesRetentionSource' })
+export type IndicesRetentionSource = z.infer<typeof IndicesRetentionSource>
+
 export const IndicesDownsamplingRound = z.object({
   after: Duration.describe('The duration since rollover when this downsampling round should execute'),
   fixed_interval: DurationLarge.describe('The downsample interval.')
@@ -7516,6 +7552,8 @@ export type IndicesSamplingMethod = z.infer<typeof IndicesSamplingMethod>
 /** Data stream lifecycle denotes that a data stream is managed by the data stream lifecycle and contains the configuration. */
 export const IndicesDataStreamLifecycle = z.object({
   data_retention: Duration.describe('If defined, every document added to this data stream will be stored at least for this time frame. Any time after this duration the document could be deleted. When empty, every document in this data stream will be stored indefinitely.').optional(),
+  effective_retention: Duration.describe('The least amount of time data should be kept by elasticsearch.').optional(),
+  retention_determined_by: IndicesRetentionSource.describe('Configuration source that can influence the retention of a data stream.').optional(),
   downsampling: z.array(IndicesDownsamplingRound).describe('The list of downsampling rounds to execute as part of this downsampling configuration').optional(),
   downsampling_method: IndicesSamplingMethod.describe('The method used to downsample the data. There are two options `aggregate` and `last_value`. It requires `downsampling` to be defined. Defaults to `aggregate`.').optional(),
   enabled: z.boolean().describe('If defined, it turns data stream lifecycle on/off (`true`/`false`) for this data stream. A data stream lifecycle that\'s disabled (enabled: `false`) will have no effect on the data stream.').optional(),
@@ -7771,8 +7809,8 @@ export type IndicesSettingsSimilarityLmj = z.infer<typeof IndicesSettingsSimilar
 
 export const IndicesSettingsSimilarityScripted = z.object({
   type: z.literal('scripted'),
-  script: z.lazy(() => Script),
-  weight_script: z.lazy(() => Script).optional()
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]),
+  weight_script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).optional()
 }).meta({ id: 'IndicesSettingsSimilarityScripted' })
 export type IndicesSettingsSimilarityScripted = z.infer<typeof IndicesSettingsSimilarityScripted>
 

--- a/packages/es-schemas/src/transform_put_transform.ts
+++ b/packages/es-schemas/src/transform_put_transform.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),

--- a/packages/es-schemas/src/transform_reset_transform.ts
+++ b/packages/es-schemas/src/transform_reset_transform.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/transform_schedule_now_transform.ts
+++ b/packages/es-schemas/src/transform_schedule_now_transform.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/transform_set_upgrade_mode.ts
+++ b/packages/es-schemas/src/transform_set_upgrade_mode.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/transform_start_transform.ts
+++ b/packages/es-schemas/src/transform_start_transform.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/transform_stop_transform.ts
+++ b/packages/es-schemas/src/transform_stop_transform.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/transform_update_transform.ts
+++ b/packages/es-schemas/src/transform_update_transform.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -309,7 +310,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -320,11 +321,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -340,7 +341,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -353,7 +354,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -367,7 +368,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -413,7 +414,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -429,7 +430,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -443,7 +444,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -508,7 +509,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -608,7 +609,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -623,7 +624,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -635,7 +636,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -708,7 +709,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -726,7 +727,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -745,7 +746,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -776,7 +777,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -860,7 +861,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -943,7 +944,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -995,7 +996,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -1011,7 +1012,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1083,7 +1084,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1098,7 +1099,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1204,7 +1205,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1289,7 +1290,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1310,7 +1311,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1326,7 +1327,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1441,7 +1442,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1518,7 +1519,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1540,7 +1541,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1567,7 +1568,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1599,7 +1600,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1631,12 +1632,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1674,7 +1675,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1771,7 +1772,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1790,7 +1791,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1804,7 +1805,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1845,7 +1846,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -2044,7 +2045,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -2059,7 +2060,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -2083,10 +2084,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -2107,7 +2108,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -2143,7 +2144,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -2159,7 +2160,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -2173,7 +2174,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -2186,7 +2187,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2216,7 +2217,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2326,7 +2327,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -2338,13 +2340,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -2379,6 +2382,36 @@ export type SearchTrackHits = z.infer<typeof SearchTrackHits>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2393,7 +2426,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2460,7 +2493,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2815,12 +2848,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2873,7 +2906,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2887,7 +2920,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2928,7 +2961,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -3106,7 +3139,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3627,7 +3660,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3643,7 +3676,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3806,7 +3839,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3882,7 +3915,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3923,7 +3956,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined

--- a/packages/es-schemas/src/transform_upgrade_transforms.ts
+++ b/packages/es-schemas/src/transform_upgrade_transforms.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/update.ts
+++ b/packages/es-schemas/src/update.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -284,7 +285,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -295,11 +296,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -315,7 +316,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -328,7 +329,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -342,7 +343,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -388,7 +389,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -404,7 +405,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -418,7 +419,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -483,7 +484,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -583,7 +584,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -598,7 +599,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -610,7 +611,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -683,7 +684,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -701,7 +702,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -720,7 +721,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -758,7 +759,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -842,7 +843,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -925,7 +926,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -977,7 +978,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -993,7 +994,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1065,7 +1066,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1080,7 +1081,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1186,7 +1187,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1268,7 +1269,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1289,7 +1290,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1305,7 +1306,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1420,7 +1421,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1497,7 +1498,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1519,7 +1520,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1546,7 +1547,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1578,7 +1579,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1610,12 +1611,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1653,7 +1654,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1750,7 +1751,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1769,7 +1770,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1783,7 +1784,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1824,7 +1825,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1845,7 +1846,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1860,7 +1861,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1884,10 +1885,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1908,7 +1909,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1944,7 +1945,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1960,7 +1961,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1974,7 +1975,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1987,7 +1988,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2017,7 +2018,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2131,6 +2132,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2145,7 +2176,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2212,7 +2243,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2567,12 +2598,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2625,7 +2656,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2639,7 +2670,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2680,7 +2711,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2858,7 +2889,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3382,7 +3413,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3398,7 +3429,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3561,7 +3592,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3637,7 +3668,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3678,7 +3709,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3919,7 +3950,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3931,13 +3963,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4024,7 +4057,7 @@ export const UpdateRequest = z.object({
   detect_noop: z.boolean().describe('If `true`, the `result` in the response is set to `noop` (no operation) when there are no changes to the document.').optional().meta({ found_in: 'body' }),
   doc: z.any().describe('A partial update to an existing document. If both `doc` and `script` are specified, `doc` is ignored.').optional().meta({ found_in: 'body' }),
   doc_as_upsert: z.boolean().describe('If `true`, use the contents of \'doc\' as the value of \'upsert\'. NOTE: Using ingest pipelines with `doc_as_upsert` is not supported.').optional().meta({ found_in: 'body' }),
-  script: z.lazy(() => Script).describe('The script to run to update the document.').optional().meta({ found_in: 'body' }),
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('The script to run to update the document.').optional().meta({ found_in: 'body' }),
   scripted_upsert: z.boolean().describe('If `true`, run the script whether or not the document exists.').optional().meta({ found_in: 'body' }),
   _source: SearchSourceConfig.describe('If `false`, turn off source retrieval. You can also specify a comma-separated list of the fields you want to retrieve.').optional().meta({ found_in: 'body' }),
   upsert: z.any().describe('If the document does not already exist, the contents of \'upsert\' are inserted as a new document. If the document exists, the \'script\' is run.').optional().meta({ found_in: 'body' })

--- a/packages/es-schemas/src/update_by_query.ts
+++ b/packages/es-schemas/src/update_by_query.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4119,7 +4152,7 @@ export const UpdateByQueryRequest = z.object({
   wait_for_completion: z.boolean().describe('If `true`, the request blocks until the operation is complete. If `false`, Elasticsearch performs some preflight checks, launches the request, and returns a task ID that you can use to cancel or get the status of the task. Elasticsearch creates a record of this task as a document at `.tasks/task/{taskId}`.').optional().meta({ found_in: 'query' }),
   max_docs: long.describe('The maximum number of documents to update.').optional().meta({ found_in: 'body' }),
   query: z.lazy(() => QueryDslQueryContainer).describe('The documents to update using the Query DSL.').optional().meta({ found_in: 'body' }),
-  script: z.lazy(() => Script).describe('The script to run to update the document source or metadata when updating.').optional().meta({ found_in: 'body' }),
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('The script to run to update the document source or metadata when updating.').optional().meta({ found_in: 'body' }),
   slice: SlicedScroll.describe('Slice the request manually using the provided slice ID and total number of slices.').optional().meta({ found_in: 'body' }),
   conflicts: Conflicts.describe('The preferred behavior when update by query hits version conflicts: `abort` or `proceed`.').optional().meta({ found_in: 'body' })
 }).meta({ id: 'UpdateByQueryRequest' })

--- a/packages/es-schemas/src/update_by_query_rethrottle.ts
+++ b/packages/es-schemas/src/update_by_query_rethrottle.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/watcher_ack_watch.ts
+++ b/packages/es-schemas/src/watcher_ack_watch.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/watcher_activate_watch.ts
+++ b/packages/es-schemas/src/watcher_activate_watch.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/watcher_deactivate_watch.ts
+++ b/packages/es-schemas/src/watcher_deactivate_watch.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/watcher_delete_watch.ts
+++ b/packages/es-schemas/src/watcher_delete_watch.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/watcher_execute_watch.ts
+++ b/packages/es-schemas/src/watcher_execute_watch.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),

--- a/packages/es-schemas/src/watcher_get_settings.ts
+++ b/packages/es-schemas/src/watcher_get_settings.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),
@@ -4580,7 +4613,7 @@ export const AnalysisConditionTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('condition'),
   filter: z.array(z.string()).describe('Array of token filters. If a token matches the predicate script in the `script` parameter, these filters are applied to the token in the order provided.'),
-  script: z.lazy(() => Script).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Predicate script used to apply token filters. If a token matches this script, the filters in the `filter` parameter are applied to the token.')
 }).meta({ id: 'AnalysisConditionTokenFilter' })
 export type AnalysisConditionTokenFilter = z.infer<typeof AnalysisConditionTokenFilter>
 
@@ -5061,7 +5094,7 @@ export type AnalysisPorterStemTokenFilter = z.infer<typeof AnalysisPorterStemTok
 export const AnalysisPredicateTokenFilter = z.object({
   ...AnalysisTokenFilterBase.shape,
   type: z.literal('predicate_token_filter'),
-  script: z.lazy(() => Script).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).describe('Script containing a condition used to filter incoming tokens. Only tokens that match this script are included in the output.')
 }).meta({ id: 'AnalysisPredicateTokenFilter' })
 export type AnalysisPredicateTokenFilter = z.infer<typeof AnalysisPredicateTokenFilter>
 
@@ -5544,8 +5577,8 @@ export type IndicesSettingsSimilarityLmj = z.infer<typeof IndicesSettingsSimilar
 
 export const IndicesSettingsSimilarityScripted = z.object({
   type: z.literal('scripted'),
-  script: z.lazy(() => Script),
-  weight_script: z.lazy(() => Script).optional()
+  script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]),
+  weight_script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]).optional()
 }).meta({ id: 'IndicesSettingsSimilarityScripted' })
 export type IndicesSettingsSimilarityScripted = z.infer<typeof IndicesSettingsSimilarityScripted>
 

--- a/packages/es-schemas/src/watcher_get_watch.ts
+++ b/packages/es-schemas/src/watcher_get_watch.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),

--- a/packages/es-schemas/src/watcher_put_watch.ts
+++ b/packages/es-schemas/src/watcher_put_watch.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),

--- a/packages/es-schemas/src/watcher_query_watches.ts
+++ b/packages/es-schemas/src/watcher_query_watches.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */
@@ -281,7 +282,7 @@ export interface AggregationsAutoDateHistogramAggregationShape {
   buckets?: integer | undefined
   field?: Field | undefined
   format?: string | undefined
-  minimum_interval?: AggregationsMinimumInterval | undefined
+  minimum_interval?: AggregationsMinimumInterval | null | undefined
   missing?: DateTime | undefined
   offset?: string | undefined
   params?: Record<string, unknown> | undefined
@@ -292,11 +293,11 @@ export const AggregationsAutoDateHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   field: Field.describe('The field on which to run the aggregation.').optional(),
   format: z.string().describe('The date format used to format `key_as_string` in the response. If no `format` is specified, the first date format specified in the field mapping is used.').optional(),
-  minimum_interval: AggregationsMinimumInterval.describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
+  minimum_interval: z.union([AggregationsMinimumInterval, z.null()]).describe('The minimum rounding interval. This can make the collection process more efficient, as the aggregation will not attempt to round at any interval lower than `minimum_interval`.').optional(),
   missing: DateTime.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: z.string().describe('Time zone specified as a ISO 8601 UTC offset.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone ID.').optional()
 }).meta({ id: 'AggregationsAutoDateHistogramAggregation' })
 export type AggregationsAutoDateHistogramAggregation = z.infer<typeof AggregationsAutoDateHistogramAggregation>
@@ -312,7 +313,7 @@ export interface AggregationsMetricAggregationBaseShape {
 export const AggregationsMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsMetricAggregationBase' })
 export type AggregationsMetricAggregationBase = z.infer<typeof AggregationsMetricAggregationBase>
 
@@ -325,7 +326,7 @@ export interface AggregationsFormatMetricAggregationBaseShape {
 export const AggregationsFormatMetricAggregationBase = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormatMetricAggregationBase' })
 export type AggregationsFormatMetricAggregationBase = z.infer<typeof AggregationsFormatMetricAggregationBase>
@@ -339,7 +340,7 @@ export interface AggregationsAverageAggregationShape {
 export const AggregationsAverageAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsAverageAggregation' })
 export type AggregationsAverageAggregation = z.infer<typeof AggregationsAverageAggregation>
@@ -385,7 +386,7 @@ export interface AggregationsBoxplotAggregationShape {
 export const AggregationsBoxplotAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
 }).meta({ id: 'AggregationsBoxplotAggregation' })
@@ -401,7 +402,7 @@ export const AggregationsBucketScriptAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketScriptAggregation' })
 export type AggregationsBucketScriptAggregation = z.infer<typeof AggregationsBucketScriptAggregation>
 
@@ -415,7 +416,7 @@ export const AggregationsBucketSelectorAggregation = z.object({
   buckets_path: AggregationsBucketsPath.describe('Path to the buckets that contain one set of values to correlate.').optional(),
   format: z.string().describe('`DecimalFormat` pattern for the output value. If specified, the formatted value is returned in the aggregation’s `value_as_string` property.').optional(),
   gap_policy: AggregationsGapPolicy.describe('Policy to apply when gaps are found in the data.').optional(),
-  get script () { return Script.describe('The script to run for this aggregation.').optional() }
+  get script () { return z.union([Script, ScriptSource]).describe('The script to run for this aggregation.').optional() }
 }).meta({ id: 'AggregationsBucketSelectorAggregation' })
 export type AggregationsBucketSelectorAggregation = z.infer<typeof AggregationsBucketSelectorAggregation>
 
@@ -480,7 +481,7 @@ export interface ScriptSortShape {
 }
 export const ScriptSort = z.object({
   order: SortOrder.optional(),
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   type: ScriptSortType.optional(),
   mode: SortMode.optional(),
   get nested () { return NestedSortValue.optional() }
@@ -580,7 +581,7 @@ export interface AggregationsCardinalityAggregationShape {
 export const AggregationsCardinalityAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   precision_threshold: integer.describe('A unique count below which counts are expected to be close to accurate. This allows to trade memory for accuracy.').optional(),
   rehash: z.boolean().optional(),
   execution_hint: AggregationsCardinalityExecutionMode.describe('Mechanism by which cardinality aggregations is run.').optional()
@@ -595,7 +596,7 @@ export interface AggregationsCartesianBoundsAggregationShape {
 export const AggregationsCartesianBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianBoundsAggregation' })
 export type AggregationsCartesianBoundsAggregation = z.infer<typeof AggregationsCartesianBoundsAggregation>
 
@@ -607,7 +608,7 @@ export interface AggregationsCartesianCentroidAggregationShape {
 export const AggregationsCartesianCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsCartesianCentroidAggregation' })
 export type AggregationsCartesianCentroidAggregation = z.infer<typeof AggregationsCartesianCentroidAggregation>
 
@@ -680,7 +681,7 @@ export const AggregationsCompositeAggregationBase = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeAggregationBase' })
@@ -698,7 +699,7 @@ export const AggregationsCompositeTermsAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional()
 }).meta({ id: 'AggregationsCompositeTermsAggregation' })
@@ -717,7 +718,7 @@ export const AggregationsCompositeHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   interval: double
@@ -755,7 +756,7 @@ export const AggregationsCompositeDateHistogramAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   format: z.string().optional(),
@@ -839,7 +840,7 @@ export const AggregationsCompositeGeoTileGridAggregation = z.object({
   field: Field.describe('Either `field` or `script` must be present').optional(),
   missing_bucket: z.boolean().optional(),
   missing_order: AggregationsMissingOrder.optional(),
-  get script () { return Script.describe('Either `field` or `script` must be present').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Either `field` or `script` must be present').optional() },
   value_type: AggregationsValueType.optional(),
   order: SortOrder.optional(),
   precision: integer.optional(),
@@ -922,7 +923,7 @@ export const AggregationsDateHistogramAggregation = z.object({
   offset: Duration.describe('Changes the start value of each bucket by the specified positive (`+`) or negative offset (`-`) duration.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets.').optional(),
   params: z.record(z.string(), z.any()).optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   time_zone: TimeZone.describe('Time zone used for bucketing and rounding. Defaults to Coordinated Universal Time (UTC).').optional(),
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional()
 }).meta({ id: 'AggregationsDateHistogramAggregation' })
@@ -974,7 +975,7 @@ export interface AggregationsDiversifiedSamplerAggregationShape {
 export const AggregationsDiversifiedSamplerAggregation = z.object({
   execution_hint: AggregationsSamplerAggregationExecutionHint.describe('The type of value used for de-duplication.').optional(),
   max_docs_per_value: integer.describe('Limits how many documents are permitted per choice of de-duplicating value.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_size: integer.describe('Limits how many top-scoring documents are collected in the sample processed on each shard.').optional(),
   field: Field.describe('The field used to provide values used for de-duplication.').optional()
 }).meta({ id: 'AggregationsDiversifiedSamplerAggregation' })
@@ -990,7 +991,7 @@ export interface AggregationsExtendedStatsAggregationShape {
 export const AggregationsExtendedStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   sigma: double.describe('The number of standard deviations above/below the mean to display.').optional()
 }).meta({ id: 'AggregationsExtendedStatsAggregation' })
@@ -1062,7 +1063,7 @@ export interface AggregationsGeoBoundsAggregationShape {
 export const AggregationsGeoBoundsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   wrap_longitude: z.boolean().describe('Specifies whether the bounding box should be allowed to overlap the international date line.').optional()
 }).meta({ id: 'AggregationsGeoBoundsAggregation' })
 export type AggregationsGeoBoundsAggregation = z.infer<typeof AggregationsGeoBoundsAggregation>
@@ -1077,7 +1078,7 @@ export interface AggregationsGeoCentroidAggregationShape {
 export const AggregationsGeoCentroidAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   count: long.optional(),
   location: GeoLocation.optional()
 }).meta({ id: 'AggregationsGeoCentroidAggregation' })
@@ -1183,7 +1184,7 @@ export const AggregationsHistogramAggregation = z.object({
   missing: double.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   offset: double.describe('By default, the bucket keys start with 0 and then continue in even spaced steps of `interval`. The bucket boundaries can be shifted by using the `offset` option.').optional(),
   order: AggregationsAggregateOrder.describe('The sort order of the returned buckets. By default, the returned buckets are sorted by their key ascending.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('If `true`, returns buckets as a hash instead of an array, keyed by the bucket keys.').optional()
 }).meta({ id: 'AggregationsHistogramAggregation' })
@@ -1265,7 +1266,7 @@ export interface AggregationsMaxAggregationShape {
 export const AggregationsMaxAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMaxAggregation' })
 export type AggregationsMaxAggregation = z.infer<typeof AggregationsMaxAggregation>
@@ -1286,7 +1287,7 @@ export interface AggregationsMedianAbsoluteDeviationAggregationShape {
 export const AggregationsMedianAbsoluteDeviationAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   compression: double.describe('Limits the maximum number of nodes used by the underlying TDigest algorithm to `20 * compression`, enabling control of memory usage and approximation error.').optional(),
   execution_hint: AggregationsTDigestExecutionHint.describe('The default implementation of TDigest is optimized for performance, scaling to millions or even billions of sample values while maintaining acceptable accuracy levels (close to 1% relative error for millions of samples in some cases). To use an implementation optimized for accuracy, set this parameter to high_accuracy instead.').optional()
@@ -1302,7 +1303,7 @@ export interface AggregationsMinAggregationShape {
 export const AggregationsMinAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsMinAggregation' })
 export type AggregationsMinAggregation = z.infer<typeof AggregationsMinAggregation>
@@ -1417,7 +1418,7 @@ const AggregationsMultiTermLookupCommonProps = z.object({
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional()
 })
 
-const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.lazy(() => Script) })])
+const AggregationsMultiTermLookupExclusiveProps = z.union([z.object({ field: Field }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface AggregationsMultiTermLookupShape {
   missing?: AggregationsMissing | undefined
@@ -1494,7 +1495,7 @@ export interface AggregationsPercentileRanksAggregationShape {
 export const AggregationsPercentileRanksAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   values: z.union([z.array(double), z.null()]).describe('An array of values for which to calculate the percentile ranks.').optional(),
@@ -1516,7 +1517,7 @@ export interface AggregationsPercentilesAggregationShape {
 export const AggregationsPercentilesAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   keyed: z.boolean().describe('By default, the aggregation associates a unique string key with each bucket and returns the ranges as a hash rather than an array. Set to `false` to disable this behavior.').optional(),
   percents: z.union([double, z.array(double)]).describe('The percentiles to calculate.').optional(),
@@ -1543,7 +1544,7 @@ export const AggregationsRangeAggregation = z.object({
   field: Field.describe('The date field whose values are use to build ranges.').optional(),
   missing: integer.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
   ranges: z.array(AggregationsAggregationRange).describe('An array of ranges used to bucket documents.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   keyed: z.boolean().describe('Set to `true` to associate a unique string key with each bucket and return the ranges as a hash rather than an array.').optional(),
   format: z.string().optional()
 }).meta({ id: 'AggregationsRangeAggregation' })
@@ -1575,7 +1576,7 @@ export interface AggregationsRateAggregationShape {
 export const AggregationsRateAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional(),
   unit: AggregationsCalendarInterval.describe('The interval used to calculate the rate. By default, the interval of the `date_histogram` is used.').optional(),
   mode: AggregationsRateMode.describe('How the rate is calculated.').optional()
@@ -1607,12 +1608,12 @@ export interface AggregationsScriptedMetricAggregationShape {
 export const AggregationsScriptedMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  get combine_script () { return Script.describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
-  get init_script () { return Script.describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
-  get map_script () { return Script.describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  get combine_script () { return z.union([Script, ScriptSource]).describe('Runs once on each shard after document collection is complete. Allows the aggregation to consolidate the state returned from each shard.').optional() },
+  get init_script () { return z.union([Script, ScriptSource]).describe('Runs prior to any collection of documents. Allows the aggregation to set up any initial state.').optional() },
+  get map_script () { return z.union([Script, ScriptSource]).describe('Run once per document collected. If no `combine_script` is specified, the resulting state needs to be stored in the `state` object.').optional() },
   params: z.record(z.string(), z.any()).describe('A global object with script parameters for `init`, `map` and `combine` scripts. It is shared between the scripts.').optional(),
-  get reduce_script () { return Script.describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
+  get reduce_script () { return z.union([Script, ScriptSource]).describe('Runs once on the coordinating node after all shards have returned their results. The script is provided with access to a variable `states`, which is an array of the result of the `combine_script` on each shard.').optional() }
 }).meta({ id: 'AggregationsScriptedMetricAggregation' })
 export type AggregationsScriptedMetricAggregation = z.infer<typeof AggregationsScriptedMetricAggregation>
 
@@ -1650,7 +1651,7 @@ export interface AggregationsScriptedHeuristicShape {
   script: ScriptShape
 }
 export const AggregationsScriptedHeuristic = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'AggregationsScriptedHeuristic' })
 export type AggregationsScriptedHeuristic = z.infer<typeof AggregationsScriptedHeuristic>
 
@@ -1747,7 +1748,7 @@ export interface AggregationsStatsAggregationShape {
 export const AggregationsStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsStatsAggregation' })
 export type AggregationsStatsAggregation = z.infer<typeof AggregationsStatsAggregation>
@@ -1766,7 +1767,7 @@ export interface AggregationsStringStatsAggregationShape {
 export const AggregationsStringStatsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   show_distribution: z.boolean().describe('Shows the probability distribution for all characters.').optional()
 }).meta({ id: 'AggregationsStringStatsAggregation' })
 export type AggregationsStringStatsAggregation = z.infer<typeof AggregationsStringStatsAggregation>
@@ -1780,7 +1781,7 @@ export interface AggregationsSumAggregationShape {
 export const AggregationsSumAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsSumAggregation' })
 export type AggregationsSumAggregation = z.infer<typeof AggregationsSumAggregation>
@@ -1821,7 +1822,7 @@ export const AggregationsTermsAggregation = z.object({
   missing_bucket: z.boolean().optional(),
   value_type: z.string().describe('Coerced unmapped fields into the specified type.').optional(),
   order: AggregationsAggregateOrder.describe('Specifies the sort order of the buckets. Defaults to sorting by descending document count.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   shard_min_doc_count: long.describe('Regulates the certainty a shard has if the term should actually be added to the candidate list or not with respect to the `min_doc_count`. Terms will only be considered if their local shard frequency within the set is higher than the `shard_min_doc_count`.').optional(),
   shard_size: integer.describe('The number of candidate terms produced by each shard. By default, `shard_size` will be automatically estimated based on the number of shards and the `size` parameter.').optional(),
   show_term_doc_count_error: z.boolean().describe('Set to `true` to return the `doc_count_error_upper_bound`, which is an upper bound to the error on the `doc_count` returned by each shard.').optional(),
@@ -1842,7 +1843,7 @@ export interface ScriptFieldShape {
   ignore_failure?: boolean | undefined
 }
 export const ScriptField = z.object({
-  get script () { return Script },
+  get script () { return z.union([Script, ScriptSource]) },
   ignore_failure: z.boolean().optional()
 }).meta({ id: 'ScriptField' })
 export type ScriptField = z.infer<typeof ScriptField>
@@ -1857,7 +1858,7 @@ export const SearchSourceFilter = z.object({
 export type SearchSourceFilter = z.infer<typeof SearchSourceFilter>
 
 /** Defines how to fetch a source. Fetching can be disabled entirely, or the source can be filtered. */
-export const SearchSourceConfig = z.union([z.boolean(), SearchSourceFilter]).meta({ id: 'SearchSourceConfig' })
+export const SearchSourceConfig = z.union([z.boolean(), z.union([SearchSourceFilter, Fields])]).meta({ id: 'SearchSourceConfig' })
 export type SearchSourceConfig = z.infer<typeof SearchSourceConfig>
 
 export interface AggregationsTopHitsAggregationShape {
@@ -1881,10 +1882,10 @@ export interface AggregationsTopHitsAggregationShape {
 export const AggregationsTopHitsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('Fields for which to return doc values.').optional(),
+  get script () { return z.union([Script, ScriptSource]).optional() },
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Fields for which to return doc values.').optional(),
   explain: z.boolean().describe('If `true`, returns detailed information about score computation as part of a hit.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('Array of wildcard (*) patterns. The request returns values for field names matching these patterns in the hits.fields property of the response.').optional(),
   from: integer.describe('Starting document offset.').optional(),
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in the search results.').optional() },
   get script_fields (): z.ZodOptional<z.ZodRecord<z.ZodString, typeof ScriptField>> { return z.record(z.string(), ScriptField).describe('Returns the result of one or more script evaluations for each hit.').optional() },
@@ -1905,7 +1906,7 @@ export interface AggregationsTestPopulationShape {
 }
 export const AggregationsTestPopulation = z.object({
   field: Field.describe('The field to aggregate.'),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   get filter () { return QueryDslQueryContainer.describe('A filter used to define a set of records to run unpaired t-test on.').optional() }
 }).meta({ id: 'AggregationsTestPopulation' })
 export type AggregationsTestPopulation = z.infer<typeof AggregationsTestPopulation>
@@ -1941,7 +1942,7 @@ export interface AggregationsTopMetricsAggregationShape {
 export const AggregationsTopMetricsAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   metrics: z.union([AggregationsTopMetricsValue, z.array(AggregationsTopMetricsValue)]).describe('The fields of the top document to return.').optional(),
   size: integer.describe('The number of top documents from which to return metrics.').optional(),
   get sort () { return Sort.describe('The sort order of the documents.').optional() }
@@ -1957,7 +1958,7 @@ export interface AggregationsFormattableMetricAggregationShape {
 export const AggregationsFormattableMetricAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsFormattableMetricAggregation' })
 export type AggregationsFormattableMetricAggregation = z.infer<typeof AggregationsFormattableMetricAggregation>
@@ -1971,7 +1972,7 @@ export interface AggregationsValueCountAggregationShape {
 export const AggregationsValueCountAggregation = z.object({
   field: Field.describe('The field on which to run the aggregation.').optional(),
   missing: AggregationsMissing.describe('The value to apply to documents that do not have a value. By default, documents without a value are ignored.').optional(),
-  get script () { return Script.optional() },
+  get script () { return z.union([Script, ScriptSource]).optional() },
   format: z.string().optional()
 }).meta({ id: 'AggregationsValueCountAggregation' })
 export type AggregationsValueCountAggregation = z.infer<typeof AggregationsValueCountAggregation>
@@ -1984,7 +1985,7 @@ export interface AggregationsWeightedAverageValueShape {
 export const AggregationsWeightedAverageValue = z.object({
   field: Field.describe('The field from which to extract the values or weights.').optional(),
   missing: double.describe('A value or weight to use if the field is missing.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsWeightedAverageValue' })
 export type AggregationsWeightedAverageValue = z.infer<typeof AggregationsWeightedAverageValue>
 
@@ -2014,7 +2015,7 @@ export const AggregationsVariableWidthHistogramAggregation = z.object({
   buckets: integer.describe('The target number of buckets.').optional(),
   shard_size: integer.describe('The number of buckets that the coordinating node will request from each shard. Defaults to `buckets * 50`.').optional(),
   initial_buffer: integer.describe('Specifies the number of individual documents that will be stored in memory on a shard before the initial bucketing algorithm is run. Defaults to `min(10 * shard_size, 50000)`.').optional(),
-  get script () { return Script.optional() }
+  get script () { return z.union([Script, ScriptSource]).optional() }
 }).meta({ id: 'AggregationsVariableWidthHistogramAggregation' })
 export type AggregationsVariableWidthHistogramAggregation = z.infer<typeof AggregationsVariableWidthHistogramAggregation>
 
@@ -2128,6 +2129,36 @@ export type IndexName = z.infer<typeof IndexName>
 export const QueryVector = z.array(float).meta({ id: 'QueryVector' })
 export type QueryVector = z.infer<typeof QueryVector>
 
+export const InferenceEmbeddingContentType = z.enum(['text', 'image', 'audio', 'video', 'pdf']).meta({ id: 'InferenceEmbeddingContentType' })
+export type InferenceEmbeddingContentType = z.infer<typeof InferenceEmbeddingContentType>
+
+export const InferenceEmbeddingContentFormat = z.enum(['text', 'base64']).meta({ id: 'InferenceEmbeddingContentFormat' })
+export type InferenceEmbeddingContentFormat = z.infer<typeof InferenceEmbeddingContentFormat>
+
+export const InferenceString = z.object({
+  type: InferenceEmbeddingContentType.describe('The type of data that the value represents.'),
+  format: z.union([InferenceEmbeddingContentFormat, z.null()]).describe('The format of the data. If null, the default data format for the given type is used.').optional(),
+  value: z.string().describe('String which may be raw text, or the string representation of some other data such as an image in base64.')
+}).meta({ id: 'InferenceString' })
+export type InferenceString = z.infer<typeof InferenceString>
+
+export const InferenceStringGroup = z.union([InferenceString, z.array(InferenceString)]).meta({ id: 'InferenceStringGroup' })
+export type InferenceStringGroup = z.infer<typeof InferenceStringGroup>
+
+/**
+ * Knn embedding input.
+ * Either a string, an object or array of objects
+ */
+export const KnnEmbeddingInput = z.union([z.string(), InferenceStringGroup]).meta({ id: 'KnnEmbeddingInput' })
+export type KnnEmbeddingInput = z.infer<typeof KnnEmbeddingInput>
+
+export const Embedding = z.object({
+  inference_id: z.string().optional(),
+  input: KnnEmbeddingInput,
+  timeout: Duration.optional()
+}).meta({ id: 'Embedding' })
+export type Embedding = z.infer<typeof Embedding>
+
 export const TextEmbedding = z.object({
   model_id: z.string().describe('Model ID is required for all dense_vector fields but may be inferred for semantic_text fields').optional(),
   model_text: z.string().describe('The text to be converted into a vector by the specified model')
@@ -2142,7 +2173,7 @@ export const LookupQueryVectorBuilder = z.object({
 }).meta({ id: 'LookupQueryVectorBuilder' })
 export type LookupQueryVectorBuilder = z.infer<typeof LookupQueryVectorBuilder>
 
-const QueryVectorBuilderExclusiveProps = z.union([z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
+const QueryVectorBuilderExclusiveProps = z.union([z.object({ embedding: Embedding }), z.object({ text_embedding: TextEmbedding }), z.object({ lookup: LookupQueryVectorBuilder })])
 
 export const QueryVectorBuilder = QueryVectorBuilderExclusiveProps.meta({ id: 'QueryVectorBuilder' })
 export type QueryVectorBuilder = z.infer<typeof QueryVectorBuilder>
@@ -2209,7 +2240,7 @@ export interface SearchScriptRescoreShape {
   script: ScriptShape
 }
 export const SearchScriptRescore = z.object({
-  get script () { return Script }
+  get script () { return z.union([Script, ScriptSource]) }
 }).meta({ id: 'SearchScriptRescore' })
 export type SearchScriptRescore = z.infer<typeof SearchScriptRescore>
 
@@ -2564,12 +2595,12 @@ export interface MappingRuntimeFieldShape {
 }
 export const MappingRuntimeField = z.object({
   fields: z.record(z.string(), MappingCompositeSubField).describe('For type `composite`').optional(),
-  fetch_fields: z.array(MappingRuntimeFieldFetchFields).describe('For type `lookup`').optional(),
+  fetch_fields: z.array(z.union([MappingRuntimeFieldFetchFields, Field])).describe('For type `lookup`').optional(),
   format: z.string().describe('A custom format for `date` type runtime fields.').optional(),
   input_field: Field.describe('For type `lookup`').optional(),
   target_field: Field.describe('For type `lookup`').optional(),
   target_index: IndexName.describe('For type `lookup`').optional(),
-  get script () { return Script.describe('Painless script executed at query time.').optional() },
+  get script () { return z.union([Script, ScriptSource]).describe('Painless script executed at query time.').optional() },
   type: MappingRuntimeFieldType.describe('Field type, which can be: `boolean`, `composite`, `date`, `double`, `geo_point`, `ip`,`keyword`, `long`, or `lookup`.')
 }).meta({ id: 'MappingRuntimeField' })
 export type MappingRuntimeField = z.infer<typeof MappingRuntimeField>
@@ -2622,7 +2653,7 @@ export const SearchSearchRequestBody = z.object({
   get highlight () { return SearchHighlight.describe('Specifies the highlighter to use for retrieving highlighted snippets from one or more fields in your search results.').optional() },
   track_total_hits: SearchTrackHits.describe('Number of hits matching the query to count accurately. If `true`, the exact number of hits is returned at the cost of some performance. If `false`, the  response does not include the total number of hits matching the query.').optional(),
   indices_boost: z.array(z.record(IndexName, double)).describe('Boost the `_score` of documents from specified indices. The boost value is the factor by which scores are multiplied. A boost value greater than `1.0` increases the score. A boost value between `0` and `1.0` decreases the score.').optional(),
-  docvalue_fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns doc values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   get knn (): z.ZodOptional<z.ZodUnion<readonly [typeof KnnSearch, z.ZodArray<typeof KnnSearch>]>> { return z.union([KnnSearch, KnnSearch.array()]).describe('The approximate kNN search to run.').optional() },
   min_score: double.describe('The minimum `_score` for matching documents. Documents with a lower `_score` are not included in search results or results collected by aggregations.').optional(),
   get post_filter () { return QueryDslQueryContainer.describe('Use the `post_filter` parameter to filter search results. The search hits are filtered after the aggregations are calculated. A post filter has no impact on the aggregation results.').optional() },
@@ -2636,7 +2667,7 @@ export const SearchSearchRequestBody = z.object({
   slice: SlicedScroll.describe('Split a scrolled search into multiple slices that can be consumed independently.').optional(),
   get sort () { return Sort.describe('A comma-separated list of <field>:<direction> pairs.').optional() },
   _source: SearchSourceConfig.describe('The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.').optional(),
-  fields: z.array(QueryDslFieldAndFormat).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).describe('An array of wildcard (`*`) field patterns. The request returns values for field names matching these patterns in the `hits.fields` property of the response.').optional(),
   suggest: SearchSuggester.describe('Defines a suggester that provides similar looking terms based on a provided text.').optional(),
   terminate_after: long.describe('The maximum number of documents to collect for each shard. If a query reaches this limit, Elasticsearch terminates the query early. Elasticsearch collects documents before sorting. IMPORTANT: Use with caution. Elasticsearch applies this property to each shard handling the request. When possible, let Elasticsearch perform early termination automatically. Avoid specifying this property for requests that target data streams with backing indices across multiple data tiers. If set to `0` (default), the query does not terminate early.').optional(),
   timeout: z.string().describe('The period of time to wait for a response from each shard. If no response is received before the timeout expires, the request fails and returns an error. Defaults to no timeout.').optional(),
@@ -2677,7 +2708,7 @@ export interface QueryDslScriptScoreFunctionShape {
   script: ScriptShape
 }
 export const QueryDslScriptScoreFunction = z.object({
-  get script () { return Script.describe('A script that computes a score.') }
+  get script () { return z.union([Script, ScriptSource]).describe('A script that computes a score.') }
 }).meta({ id: 'QueryDslScriptScoreFunction' })
 export type QueryDslScriptScoreFunction = z.infer<typeof QueryDslScriptScoreFunction>
 
@@ -2855,7 +2886,7 @@ export const QueryDslIdsQuery = z.object({
 }).meta({ id: 'QueryDslIdsQuery' })
 export type QueryDslIdsQuery = z.infer<typeof QueryDslIdsQuery>
 
-const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.lazy(() => Script) })])
+const QueryDslIntervalsFilterExclusiveProps = z.union([z.object({ after: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ before: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_contained_by: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_containing: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ not_overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ overlapping: z.lazy(() => QueryDslIntervalsContainer) }), z.object({ script: z.union([z.lazy(() => Script), z.lazy(() => ScriptSource)]) })])
 
 export interface QueryDslIntervalsFilterShape {
   after?: QueryDslIntervalsContainer | undefined
@@ -3379,7 +3410,7 @@ export interface QueryDslScriptQueryShape {
 export const QueryDslScriptQuery = z.object({
   boost: float.describe('Floating point number used to decrease or increase the relevance scores of the query. Boost values are relative to the default value of 1.0. A boost value between 0 and 1.0 decreases the relevance score. A value greater than 1.0 increases the relevance score.').optional(),
   query_name: z.string().optional(),
-  get script () { return Script.describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Contains a script to run as a query. This script must return a boolean value, `true` or `false`.') }
 }).meta({ id: 'QueryDslScriptQuery' })
 export type QueryDslScriptQuery = z.infer<typeof QueryDslScriptQuery>
 
@@ -3395,7 +3426,7 @@ export const QueryDslScriptScoreQuery = z.object({
   query_name: z.string().optional(),
   min_score: float.describe('Documents with a score lower than this floating point number are excluded from the search results.').optional(),
   get query () { return QueryDslQueryContainer.describe('Query used to return documents.') },
-  get script () { return Script.describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
+  get script () { return z.union([Script, ScriptSource]).describe('Script used to compute the score of documents returned by the query. Important: final relevance scores from the `script_score` query cannot be negative.') }
 }).meta({ id: 'QueryDslScriptScoreQuery' })
 export type QueryDslScriptScoreQuery = z.infer<typeof QueryDslScriptScoreQuery>
 
@@ -3558,7 +3589,7 @@ export const QueryDslSpanWithinQuery = z.object({
 }).meta({ id: 'QueryDslSpanWithinQuery' })
 export type QueryDslSpanWithinQuery = z.infer<typeof QueryDslSpanWithinQuery>
 
-const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
+const QueryDslSpanQueryExclusiveProps = z.union([z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_gap: QueryDslSpanGapQuery }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) })])
 
 export interface QueryDslSpanQueryShape {
   span_containing?: QueryDslSpanContainingQuery | undefined
@@ -3634,7 +3665,7 @@ export const QueryDslTermsSetQuery = z.object({
   query_name: z.string().optional(),
   minimum_should_match: MinimumShouldMatch.describe('Specification describing number of matching terms required to return a document.').optional(),
   minimum_should_match_field: Field.describe('Numeric field containing the number of matching terms required to return a document.').optional(),
-  get minimum_should_match_script () { return Script.describe('Custom script containing the number of matching terms required to return a document.').optional() },
+  get minimum_should_match_script () { return z.union([Script, ScriptSource]).describe('Custom script containing the number of matching terms required to return a document.').optional() },
   terms: z.array(FieldValue).describe('Array of terms you wish to find in the provided field.')
 }).meta({ id: 'QueryDslTermsSetQuery' })
 export type QueryDslTermsSetQuery = z.infer<typeof QueryDslTermsSetQuery>
@@ -3675,7 +3706,7 @@ export const QueryDslTypeQuery = z.object({
 }).meta({ id: 'QueryDslTypeQuery' })
 export type QueryDslTypeQuery = z.infer<typeof QueryDslTypeQuery>
 
-const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, QueryDslCommonTermsQuery) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.lazy(() => QueryDslFunctionScoreQuery) }), z.object({ fuzzy: z.record(Field, QueryDslFuzzyQuery) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, QueryDslMatchQuery) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, QueryDslMatchBoolPrefixQuery) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, QueryDslMatchPhraseQuery) }), z.object({ match_phrase_prefix: z.record(Field, QueryDslMatchPhrasePrefixQuery) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, QueryDslPrefixQuery) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, QueryDslRegexpQuery) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, QueryDslSpanTermQuery) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, QueryDslTermQuery) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, QueryDslWildcardQuery) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
+const QueryDslQueryContainerExclusiveProps = z.union([z.object({ bool: z.lazy(() => QueryDslBoolQuery) }), z.object({ boosting: z.lazy(() => QueryDslBoostingQuery) }), z.object({ common: z.record(Field, z.union([QueryDslCommonTermsQuery, z.string()])) }), z.object({ combined_fields: QueryDslCombinedFieldsQuery }), z.object({ constant_score: z.lazy(() => QueryDslConstantScoreQuery) }), z.object({ dis_max: z.lazy(() => QueryDslDisMaxQuery) }), z.object({ distance_feature: QueryDslDistanceFeatureQuery }), z.object({ exists: QueryDslExistsQuery }), z.object({ function_score: z.union([z.lazy(() => QueryDslFunctionScoreQuery), z.array(z.lazy(() => QueryDslFunctionScoreContainer))]) }), z.object({ fuzzy: z.record(Field, z.union([QueryDslFuzzyQuery, z.union([z.string(), double, z.boolean()])])) }), z.object({ geo_bounding_box: QueryDslGeoBoundingBoxQuery }), z.object({ geo_distance: QueryDslGeoDistanceQuery }), z.object({ geo_grid: z.record(Field, QueryDslGeoGridQuery) }), z.object({ geo_polygon: QueryDslGeoPolygonQuery }), z.object({ geo_shape: QueryDslGeoShapeQuery }), z.object({ has_child: z.lazy(() => QueryDslHasChildQuery) }), z.object({ has_parent: z.lazy(() => QueryDslHasParentQuery) }), z.object({ ids: QueryDslIdsQuery }), z.object({ intervals: z.record(Field, z.lazy(() => QueryDslIntervalsQuery)) }), z.object({ knn: z.lazy(() => KnnQuery) }), z.object({ match: z.record(Field, z.union([QueryDslMatchQuery, z.union([z.string(), float, z.boolean()])])) }), z.object({ match_all: QueryDslMatchAllQuery }), z.object({ match_bool_prefix: z.record(Field, z.union([QueryDslMatchBoolPrefixQuery, z.string()])) }), z.object({ match_none: QueryDslMatchNoneQuery }), z.object({ match_phrase: z.record(Field, z.union([QueryDslMatchPhraseQuery, z.string()])) }), z.object({ match_phrase_prefix: z.record(Field, z.union([QueryDslMatchPhrasePrefixQuery, z.string()])) }), z.object({ more_like_this: QueryDslMoreLikeThisQuery }), z.object({ multi_match: QueryDslMultiMatchQuery }), z.object({ nested: z.lazy(() => QueryDslNestedQuery) }), z.object({ parent_id: QueryDslParentIdQuery }), z.object({ percolate: QueryDslPercolateQuery }), z.object({ pinned: z.lazy(() => QueryDslPinnedQuery) }), z.object({ prefix: z.record(Field, z.union([QueryDslPrefixQuery, z.string()])) }), z.object({ query_string: QueryDslQueryStringQuery }), z.object({ range: z.record(Field, QueryDslRangeQuery) }), z.object({ rank_feature: QueryDslRankFeatureQuery }), z.object({ regexp: z.record(Field, z.union([QueryDslRegexpQuery, z.string()])) }), z.object({ rule: z.lazy(() => QueryDslRuleQuery) }), z.object({ script: z.lazy(() => QueryDslScriptQuery) }), z.object({ script_score: z.lazy(() => QueryDslScriptScoreQuery) }), z.object({ semantic: QueryDslSemanticQuery }), z.object({ shape: QueryDslShapeQuery }), z.object({ simple_query_string: QueryDslSimpleQueryStringQuery }), z.object({ span_containing: z.lazy(() => QueryDslSpanContainingQuery) }), z.object({ span_field_masking: z.lazy(() => QueryDslSpanFieldMaskingQuery) }), z.object({ span_first: z.lazy(() => QueryDslSpanFirstQuery) }), z.object({ span_multi: z.lazy(() => QueryDslSpanMultiTermQuery) }), z.object({ span_near: z.lazy(() => QueryDslSpanNearQuery) }), z.object({ span_not: z.lazy(() => QueryDslSpanNotQuery) }), z.object({ span_or: z.lazy(() => QueryDslSpanOrQuery) }), z.object({ span_term: z.record(Field, z.union([QueryDslSpanTermQuery, FieldValue])) }), z.object({ span_within: z.lazy(() => QueryDslSpanWithinQuery) }), z.object({ sparse_vector: QueryDslSparseVectorQuery }), z.object({ term: z.record(Field, z.union([QueryDslTermQuery, FieldValue])) }), z.object({ terms: QueryDslTermsQuery }), z.object({ terms_set: z.record(Field, z.lazy(() => QueryDslTermsSetQuery)) }), z.object({ text_expansion: z.record(Field, QueryDslTextExpansionQuery) }), z.object({ weighted_tokens: z.record(Field, QueryDslWeightedTokensQuery) }), z.object({ wildcard: z.record(Field, z.union([QueryDslWildcardQuery, z.string()])) }), z.object({ wrapper: QueryDslWrapperQuery }), z.object({ type: QueryDslTypeQuery })])
 
 export interface QueryDslQueryContainerShape {
   bool?: QueryDslBoolQuery | undefined
@@ -3916,7 +3947,8 @@ export interface SearchInnerHitsShape {
   ignore_unmapped?: boolean | undefined
   script_fields?: Record<Field, ScriptFieldShape> | undefined
   seq_no_primary_term?: boolean | undefined
-  fields?: Field[] | undefined
+  field?: Field[] | undefined
+  fields?: QueryDslFieldAndFormat[] | undefined
   sort?: SortShape | undefined
   _source?: SearchSourceConfig | undefined
   stored_fields?: Fields | undefined
@@ -3928,13 +3960,14 @@ export const SearchInnerHits = z.object({
   size: integer.describe('The maximum number of hits to return per `inner_hits`.').optional(),
   from: integer.describe('Inner hit starting document offset.').optional(),
   get collapse () { return SearchFieldCollapse.optional() },
-  docvalue_fields: z.array(QueryDslFieldAndFormat).optional(),
+  docvalue_fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   explain: z.boolean().optional(),
   get highlight () { return SearchHighlight.optional() },
   ignore_unmapped: z.boolean().optional(),
   get script_fields (): z.ZodOptional<z.ZodRecord<typeof Field, typeof ScriptField>> { return z.record(Field, ScriptField).optional() },
   seq_no_primary_term: z.boolean().optional(),
-  fields: z.array(Field).optional(),
+  field: z.array(Field).optional(),
+  fields: z.array(z.union([QueryDslFieldAndFormat, Field])).optional(),
   get sort () { return Sort.describe('How the inner hits should be sorted per `inner_hits`. By default, inner hits are sorted by score.').optional() },
   _source: SearchSourceConfig.optional(),
   stored_fields: Fields.optional(),

--- a/packages/es-schemas/src/watcher_start.ts
+++ b/packages/es-schemas/src/watcher_start.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/watcher_stats.ts
+++ b/packages/es-schemas/src/watcher_stats.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/watcher_stop.ts
+++ b/packages/es-schemas/src/watcher_stop.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/watcher_update_settings.ts
+++ b/packages/es-schemas/src/watcher_update_settings.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/xpack_info.ts
+++ b/packages/es-schemas/src/xpack_info.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */

--- a/packages/es-schemas/src/xpack_usage.ts
+++ b/packages/es-schemas/src/xpack_usage.ts
@@ -2,6 +2,7 @@
  * Copyright Elasticsearch B.V. and contributors
  * SPDX-License-Identifier: Apache-2.0
  */
+
 // @ts-nocheck
 
 /* eslint-disable @typescript-eslint/no-use-before-define */


### PR DESCRIPTION
Added support for `@shortcut_property` from the ES specification to Zod schema generator.

Supersedes the manual fix in https://github.com/elastic/cli/pull/370 and covers **A LOT MORE** APIs.
