### PR TITLE
fix: respect --json flag on --help for root and groups

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1133,7 +1133,7 @@ THIS SOFTWARE.
 
 
 ------------------------------------------------------------------------
-yaml@2.8.4
+yaml@2.9.0
 License: ISC
 Repository: https://github.com/eemeli/yaml
 Publisher: Eemeli Aro <eemeli@gmail.com>

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -5,7 +5,7 @@
  */
 
 import { Command } from 'commander'
-import { defineCommand, defineGroup, hideBlockedCommands } from './factory.js'
+import { defineCommand, defineGroup, hideBlockedCommands, configureJsonHelp } from './factory.js'
 import type { OpaqueCommandHandle } from './factory.js'
 import { loadConfig } from './config/loader.ts'
 import { BUILT_IN_PROFILES, type BuiltInProfile } from './config/profiles.ts'
@@ -30,6 +30,8 @@ program
   .option('--json', 'output as JSON')
   .option('--output-fields <list>', 'comma-separated list of fields to include in output (dot-notation supported)')
   .option('--output-template <string>', 'Mustache-like template for custom text output (e.g. "{{id}}: {{name}}")')
+
+configureJsonHelp(program)
 
 // Before every sub-command action, load and resolve the config file.
 // On error, print a structured message and exit -- never let a config failure

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -420,6 +420,75 @@ export function stripTransportMeta (value: JsonValue): JsonValue {
   return value
 }
 
+/**
+ * Returns true when `--json` is set on the root program. Walks up the parent
+ * chain so it works regardless of whether `cmd` is the root, a group, or a leaf.
+ */
+function hasGlobalJsonFlag (cmd: OpaqueCommandHandle): boolean {
+  let current: OpaqueCommandHandle = cmd
+  while (current.parent != null) current = current.parent
+  return (current.opts() as { json?: boolean }).json === true
+}
+
+/**
+ * Serialises a command's help structure as JSON: name, description, usage,
+ * visible options, and visible sub-commands. Used by {@link configureJsonHelp}
+ * so `--help --json` returns machine-readable output for groups and the root
+ * program (leaf commands with an input schema continue to return that schema).
+ */
+function formatHelpAsJson (cmd: OpaqueCommandHandle): string {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const isOptionHidden = (o: any): boolean => o.hidden === true
+  const options = cmd.options.filter(o => !isOptionHidden(o)).map(o => {
+    const entry: Record<string, JsonValue> = {
+      flags: o.flags,
+      description: o.description ?? '',
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const dv = (o as any).defaultValue
+    if (dv !== undefined && (typeof dv === 'string' || typeof dv === 'number' || typeof dv === 'boolean')) {
+      entry['defaultValue'] = dv
+    }
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    if ((o as any).mandatory === true) entry['mandatory'] = true
+    return entry
+  })
+  const commands = (cmd.commands as OpaqueCommandHandle[])
+    .filter(c => !isHidden(c) && c.name() !== 'help')
+    .map(c => {
+      const entry: Record<string, JsonValue> = {
+        name: c.name(),
+        description: c.description() ?? '',
+      }
+      const aliases = c.aliases()
+      if (aliases.length > 0) entry['aliases'] = aliases
+      return entry
+    })
+  const data: JsonValue = {
+    name: cmd.name(),
+    description: cmd.description() ?? '',
+    usage: cmd.usage(),
+    options,
+    commands,
+  }
+  return JSON.stringify(data) + '\n'
+}
+
+/**
+ * Hooks into Commander's help formatter so `--help --json` emits structured
+ * JSON describing the command tree (name, description, options, sub-commands)
+ * instead of the text help. Apply to the root program and to command groups.
+ */
+export function configureJsonHelp (cmd: OpaqueCommandHandle): void {
+  const origHelp = cmd.createHelp()
+  cmd.configureHelp({
+    formatHelp: (thisCmd, helper) => {
+      if (hasGlobalJsonFlag(thisCmd)) return formatHelpAsJson(thisCmd)
+      return origHelp.formatHelp(thisCmd, helper)
+    }
+  })
+}
+
 function configureHelpWithSchema (
   cmd: OpaqueCommandHandle,
   inputSchema: z.ZodType | undefined,
@@ -427,8 +496,7 @@ function configureHelpWithSchema (
   const origHelp = cmd.createHelp()
   cmd.configureHelp({
     formatHelp: (thisCmd, helper) => {
-      const globalOpts = thisCmd.parent?.optsWithGlobals()
-      if (globalOpts?.json === true) {
+      if (hasGlobalJsonFlag(thisCmd)) {
         const jsonSchema = inputSchema != null
           ? stripTransportMeta(z.toJSONSchema(inputSchema, { reused: 'ref' }) as JsonValue)
           : undefined
@@ -889,6 +957,7 @@ export function defineGroup (config: GroupConfig, ...commands: OpaqueCommandHand
   group.description(config.description)
   group.allowExcessArguments(true)
   configureErrorOutput(group)
+  configureJsonHelp(group)
   // Mark as a group so hideBlockedCommands can distinguish groups from leaf commands.
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   ;(group as unknown as any)._isGroup = true

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -437,36 +437,31 @@ function hasGlobalJsonFlag (cmd: OpaqueCommandHandle): boolean {
  * program (leaf commands with an input schema continue to return that schema).
  */
 function formatHelpAsJson (cmd: OpaqueCommandHandle): string {
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  const isOptionHidden = (o: any): boolean => o.hidden === true
-  const options = cmd.options.filter(o => !isOptionHidden(o)).map(o => {
-    const entry: Record<string, JsonValue> = {
-      flags: o.flags,
-      description: o.description ?? '',
-    }
+  const options = cmd.options
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    const dv = (o as any).defaultValue
-    if (dv !== undefined && (typeof dv === 'string' || typeof dv === 'number' || typeof dv === 'boolean')) {
-      entry['defaultValue'] = dv
-    }
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    if ((o as any).mandatory === true) entry['mandatory'] = true
-    return entry
-  })
+    .filter(o => (o as any).hidden !== true)
+    .map(o => {
+      const entry: Record<string, JsonValue> = { flags: o.flags, description: o.description }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const dv = (o as any).defaultValue
+      if (typeof dv === 'string' || typeof dv === 'number' || typeof dv === 'boolean') {
+        entry['defaultValue'] = dv
+      }
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      if ((o as any).mandatory === true) entry['mandatory'] = true
+      return entry
+    })
   const commands = (cmd.commands as OpaqueCommandHandle[])
     .filter(c => !isHidden(c) && c.name() !== 'help')
     .map(c => {
-      const entry: Record<string, JsonValue> = {
-        name: c.name(),
-        description: c.description() ?? '',
-      }
+      const entry: Record<string, JsonValue> = { name: c.name(), description: c.description() }
       const aliases = c.aliases()
       if (aliases.length > 0) entry['aliases'] = aliases
       return entry
     })
   const data: JsonValue = {
     name: cmd.name(),
-    description: cmd.description() ?? '',
+    description: cmd.description(),
     usage: cmd.usage(),
     options,
     commands,

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -323,6 +323,66 @@ describe('elastic CLI -- stack command tree', () => {
   })
 })
 
+describe('elastic CLI -- --help --json', () => {
+  it('`elastic --help --json` emits structured JSON help', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'elastic-cli-help-json-'))
+    try {
+      const { code, stdout } = await runCli(['--help', '--json'], { cwd: dir, env: { HOME: dir } })
+      assert.equal(code, 0, `expected exit code 0, got ${code}`)
+      const parsed = JSON.parse(stdout) as {
+        name: string
+        description: string
+        usage: string
+        options: Array<{ flags: string }>
+        commands: Array<{ name: string }>
+      }
+      assert.equal(parsed.name, 'elastic')
+      assert.ok(parsed.options.some((o) => o.flags.includes('--json')), 'expected --json option in JSON help')
+      assert.ok(parsed.commands.some((c) => c.name === 'stack'), 'expected stack command in JSON help')
+      assert.ok(parsed.commands.some((c) => c.name === 'version'), 'expected version command in JSON help')
+    } finally {
+      await rm(dir, { recursive: true })
+    }
+  })
+
+  it('`elastic --json --help` works regardless of flag order', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'elastic-cli-help-json-order-'))
+    try {
+      const { code, stdout } = await runCli(['--json', '--help'], { cwd: dir, env: { HOME: dir } })
+      assert.equal(code, 0, `expected exit code 0, got ${code}`)
+      const parsed = JSON.parse(stdout) as { name: string }
+      assert.equal(parsed.name, 'elastic')
+    } finally {
+      await rm(dir, { recursive: true })
+    }
+  })
+
+  it('`elastic --help` (without --json) still emits plain text', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'elastic-cli-help-text-'))
+    try {
+      const { code, stdout } = await runCli(['--help'], { cwd: dir, env: { HOME: dir } })
+      assert.equal(code, 0, `expected exit code 0, got ${code}`)
+      assert.match(stdout, /^Usage: elastic/m, 'expected text help format')
+      assert.throws(() => JSON.parse(stdout), 'text help should not be valid JSON')
+    } finally {
+      await rm(dir, { recursive: true })
+    }
+  })
+
+  it('`elastic <group> --help --json` emits JSON help for groups', async () => {
+    const dir = await mkdtemp(join(tmpdir(), 'elastic-cli-group-help-json-'))
+    try {
+      const { code, stdout } = await runCli(['sanitize', '--help', '--json'], { cwd: dir, env: { HOME: dir } })
+      assert.equal(code, 0, `expected exit code 0, got ${code}`)
+      const parsed = JSON.parse(stdout) as { name: string; commands: Array<{ name: string }> }
+      assert.equal(parsed.name, 'sanitize')
+      assert.ok(parsed.commands.length > 0, 'expected sanitize sub-commands in JSON help')
+    } finally {
+      await rm(dir, { recursive: true })
+    }
+  })
+})
+
 describe('elastic CLI -- alias rewriting with option values', () => {
   it('correctly rewrites es alias when --command-profile value is also "es"', async () => {
     const dir = await mkdtemp(join(tmpdir(), 'elastic-cli-alias-'))

--- a/test/factory.test.ts
+++ b/test/factory.test.ts
@@ -15,7 +15,7 @@ import type {
   GroupConfig,
   OpaqueCommandHandle,
 } from '../src/factory.ts'
-import { defineCommand, defineGroup, _testSetStdinReader, isCommandAllowed, hideBlockedCommands } from '../src/factory.ts'
+import { defineCommand, defineGroup, _testSetStdinReader, isCommandAllowed, hideBlockedCommands, configureJsonHelp } from '../src/factory.ts'
 import { setResolvedConfig, _testResetConfig } from '../src/config/store.ts'
 import { Command } from 'commander'
 import { z } from 'zod'
@@ -3812,5 +3812,138 @@ describe('error result detection', () => {
     })
     await invokeCapturingStreams(cmd, [], [])
     assert.equal(formatCalled, false)
+  })
+})
+
+describe('configureJsonHelp', () => {
+  async function captureHelp (prog: InstanceType<typeof Command>, argv: string[]): Promise<string> {
+    prog.exitOverride()
+    let out = ''
+    prog.configureOutput({ writeOut: (s) => { out += s } })
+    try {
+      await prog.parseAsync(argv, { from: 'user' })
+    } catch { /* exitOverride throws on --help */ }
+    return out
+  }
+
+  it('returns JSON when --json is set on the root program', async () => {
+    const prog = new Command('elastic')
+    prog.description('CLI')
+    prog.option('--json', 'output as JSON')
+    configureJsonHelp(prog)
+    const out = await captureHelp(prog, ['--help', '--json'])
+    const parsed = JSON.parse(out) as Record<string, unknown>
+    assert.equal(parsed['name'], 'elastic')
+    assert.equal(parsed['description'], 'CLI')
+  })
+
+  it('returns text help when --json is absent', async () => {
+    const prog = new Command('elastic')
+    prog.description('CLI')
+    prog.option('--json', 'output as JSON')
+    configureJsonHelp(prog)
+    const out = await captureHelp(prog, ['--help'])
+    assert.match(out, /^Usage: elastic/m)
+  })
+
+  it('serialises options including mandatory and primitive defaults', async () => {
+    const prog = new Command('elastic')
+    prog.description('CLI')
+    prog.option('--json', 'output as JSON')
+    prog.option('--retries <n>', 'retry count', '3')
+    prog.requiredOption('--token <value>', 'auth token')
+    configureJsonHelp(prog)
+    const out = await captureHelp(prog, ['--help', '--json', '--token', 'x'])
+    const parsed = JSON.parse(out) as { options: Array<Record<string, unknown>> }
+    const retries = parsed.options.find((o) => (o['flags'] as string).includes('--retries'))
+    assert.ok(retries != null)
+    assert.equal(retries['defaultValue'], '3')
+    const token = parsed.options.find((o) => (o['flags'] as string).includes('--token'))
+    assert.ok(token != null)
+    assert.equal(token['mandatory'], true)
+  })
+
+  it('omits hidden options and hidden commands from JSON help', async () => {
+    const prog = new Command('elastic')
+    prog.description('CLI')
+    prog.option('--json', 'output as JSON')
+    prog.option('--secret <s>', 'hidden')
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    const secretOpt = prog.options.find((o) => o.long === '--secret') as any
+    secretOpt.hidden = true
+    const visible = defineCommand({ name: 'ping', description: 'Ping', handler: () => ({}) })
+    const hidden = defineCommand({ name: 'internal', description: 'Internal', handler: () => ({}) })
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    ;(hidden as unknown as any)._hidden = true
+    prog.addCommand(visible)
+    prog.addCommand(hidden)
+    configureJsonHelp(prog)
+    const out = await captureHelp(prog, ['--help', '--json'])
+    const parsed = JSON.parse(out) as {
+      options: Array<{ flags: string }>
+      commands: Array<{ name: string }>
+    }
+    assert.ok(!parsed.options.some((o) => o.flags.includes('--secret')), 'hidden option leaked')
+    assert.ok(!parsed.commands.some((c) => c.name === 'internal'), 'hidden command leaked')
+    assert.ok(parsed.commands.some((c) => c.name === 'ping'), 'expected visible command')
+  })
+
+  it('includes aliases on sub-commands that have them', async () => {
+    const prog = new Command('elastic')
+    prog.description('CLI')
+    prog.option('--json', 'output as JSON')
+    const child = defineGroup({ name: 'stack', description: 'Stack' })
+    child.alias('es')
+    prog.addCommand(child)
+    configureJsonHelp(prog)
+    const out = await captureHelp(prog, ['--help', '--json'])
+    const parsed = JSON.parse(out) as { commands: Array<{ name: string; aliases?: string[] }> }
+    const stack = parsed.commands.find((c) => c.name === 'stack')
+    assert.deepEqual(stack?.aliases, ['es'])
+  })
+
+  it('preserves numeric and boolean defaults from Commander options', async () => {
+    const prog = new Command('elastic')
+    prog.option('--json', 'output as JSON')
+    prog.option('--count <n>', 'count', 5)
+    prog.option('--enabled', 'enabled flag', false)
+    configureJsonHelp(prog)
+    const out = await captureHelp(prog, ['--help', '--json'])
+    const parsed = JSON.parse(out) as { options: Array<Record<string, unknown>> }
+    const count = parsed.options.find((o) => (o['flags'] as string).includes('--count'))
+    assert.equal(count?.['defaultValue'], 5)
+    const enabled = parsed.options.find((o) => (o['flags'] as string).includes('--enabled'))
+    assert.equal(enabled?.['defaultValue'], false)
+  })
+
+  it('omits the auto-added `help` sub-command from JSON help', async () => {
+    const prog = new Command('elastic')
+    prog.option('--json', 'output as JSON')
+    const child = defineCommand({ name: 'ping', description: 'Ping', handler: () => ({}) })
+    prog.addCommand(child)
+    // Commander adds a synthetic `help` command on commands with sub-commands;
+    // force-add one to mirror that.
+    prog.addCommand(new Command('help'))
+    configureJsonHelp(prog)
+    const out = await captureHelp(prog, ['--help', '--json'])
+    const parsed = JSON.parse(out) as { commands: Array<{ name: string }> }
+    assert.ok(!parsed.commands.some((c) => c.name === 'help'), 'auto-help command leaked')
+    assert.ok(parsed.commands.some((c) => c.name === 'ping'))
+  })
+
+  it('groups respect --json from the root via parent walk', async () => {
+    const prog = new Command('elastic')
+    prog.option('--json', 'output as JSON')
+    const group = defineGroup({ name: 'sanitize', description: 'Sanitize' })
+    prog.addCommand(group)
+    prog.exitOverride()
+    group.exitOverride()
+    let out = ''
+    group.configureOutput({ writeOut: (s) => { out += s } })
+    try {
+      await prog.parseAsync(['--json', 'sanitize', '--help'], { from: 'user' })
+    } catch { /* exitOverride on --help */ }
+    const parsed = JSON.parse(out) as { name: string }
+    assert.equal(parsed.name, 'sanitize')
   })
 })

--- a/test/factory.test.ts
+++ b/test/factory.test.ts
@@ -2791,7 +2791,7 @@ describe('no Commander API leaks', () => {
   it('factory module exports only public API and test seam at runtime', async () => {
     const factory = await import('../src/factory.ts')
     const exported = Object.keys(factory)
-    assert.deepEqual(exported.sort(), ['RawJsonValue', '_testSetStdinReader', 'defineCommand', 'defineGroup', 'hideBlockedCommands', 'isCommandAllowed', 'stripTransportMeta'])
+    assert.deepEqual(exported.sort(), ['RawJsonValue', '_testSetStdinReader', 'configureJsonHelp', 'defineCommand', 'defineGroup', 'hideBlockedCommands', 'isCommandAllowed', 'stripTransportMeta'])
   })
 
   it('defineCommand return value requires no Commander import to use', () => {


### PR DESCRIPTION
## Summary

`elastic --help --json` (and `elastic <group> --help --json`) was printing plain text help instead of respecting the `--json` flag. Only leaf commands ran their help through the JSON-aware formatter, and even there the detection used `thisCmd.parent?.optsWithGlobals()`, which returns `undefined` for the root program.

## What changed

- New helpers in [`src/factory.ts`](https://github.com/elastic/cli/blob/claude/hardcore-jepsen-85c4e4/src/factory.ts):
  - `hasGlobalJsonFlag(cmd)` walks up to the root and reads its `--json` opt, so detection works uniformly for root, groups, and leaves.
  - `formatHelpAsJson(cmd)` serialises name, description, usage, visible options, and visible sub-commands.
  - Exported `configureJsonHelp(cmd)` hooks Commander's help formatter and falls back to text help when `--json` is not set.
- `defineGroup` now calls `configureJsonHelp` so every group inherits the behaviour.
- `src/cli.ts` calls `configureJsonHelp(program)` on the root program.
- Existing leaf-command behaviour is preserved: commands with an `input` Zod schema continue to emit that schema; commands without one still emit empty output (existing contract covered by `test/factory.test.ts`).

## Tests

Added a new `elastic CLI -- --help --json` suite in `test/cli.test.ts`:

- `elastic --help --json` returns structured JSON with `name`, `options`, and `commands`.
- Flag order (`--json --help`) also works.
- `elastic --help` (no `--json`) still emits plain text.
- `elastic sanitize --help --json` returns JSON for a group.

Updated the export-surface assertion in `test/factory.test.ts` to include the new `configureJsonHelp` export.

## Test plan

- [x] `npm run build`
- [x] `node --import tsx/esm --test test/cli.test.ts` (30 pass, including 4 new)
- [x] `node --import tsx/esm --test test/factory.test.ts` (268 pass)
- [x] `npm run test:lint`
- [x] Manual verification:
  - `elastic --help --json` → JSON
  - `elastic --json --help` → JSON
  - `elastic --help` → text (unchanged)
  - `elastic sanitize --help --json` → JSON
  - `elastic cli-schema --help --json` → empty (unchanged leaf-without-input-schema contract)
