### PR TITLE
docs: add Elastic docs CI workflows

### DIFF
--- a/.github/workflows/docs-build.yml
+++ b/.github/workflows/docs-build.yml
@@ -1,0 +1,20 @@
+---
+name: docs-build
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+  push:
+    branches:
+      - main
+  merge_group: ~
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  build:
+    uses: elastic/docs-actions/.github/workflows/docs-build.yml@v1
+    with:
+      enable-vale-linting: true

--- a/.github/workflows/docs-deploy.yml
+++ b/.github/workflows/docs-deploy.yml
@@ -1,0 +1,20 @@
+---
+name: docs-deploy
+
+on:
+  workflow_run:
+    workflows: [docs-build]
+    types: [completed]
+
+permissions:
+  contents: read
+  deployments: write
+  id-token: write
+  pull-requests: write
+  actions: read
+
+jobs:
+  deploy:
+    uses: elastic/docs-actions/.github/workflows/docs-deploy.yml@v1
+    with:
+      enable-vale-linting: true

--- a/.github/workflows/docs-preview-cleanup.yml
+++ b/.github/workflows/docs-preview-cleanup.yml
@@ -1,0 +1,15 @@
+---
+name: docs-preview-cleanup
+
+on:
+  pull_request_target:
+    types:
+      - closed
+
+jobs:
+  cleanup:
+    uses: elastic/docs-actions/.github/workflows/docs-preview-cleanup.yml@v1
+    permissions:
+      contents: none
+      id-token: write
+      deployments: write

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,6 @@ megalinter-reports/
 
 # Generated functional test scripts
 test/functional/es/
+
+# docs-builder local build output
+docs/.artifacts


### PR DESCRIPTION
## Summary

- Adds `docs-build.yml`, `docs-deploy.yml`, and `docs-preview-cleanup.yml` reusable workflow callers from `elastic/docs-actions@v1`
- Enables PR preview deployments and Vale linting on `docs/**` changes
- Adds `docs/.artifacts` to `.gitignore` for local builds

## Merge order

Merge **after** [elastic/docs-infra#305](https://github.com/elastic/docs-infra/pull/305) — the OIDC registration must be in place before `docs-deploy` can upload artifacts.

## Follow-up PR (merge after `docs-build` is green on `main`)

- [elastic/docs-builder#3416](https://github.com/elastic/docs-builder/pull/3416): add `cli` to `assembler.yml` + `reference/elastic-cli` in `navigation.yml`

## Test plan

- [ ] Confirm `docs-build / build` check appears on this PR
- [ ] Confirm `docs-deploy` posts a preview deployment link
- [ ] Click through preview: `index.md`, `cli/installation.md`, `cli/configuration.md`
- [ ] After merge: capture green `docs-build` run on `main` — needed as evidence for the docs-builder PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)