### PR TITLE
test: isolate store singleton from cross-file bun leaks

### DIFF
--- a/test/config/store.test.ts
+++ b/test/config/store.test.ts
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, afterEach } from 'node:test'
+import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { setResolvedConfig, getResolvedConfig } from '../../src/config/store.ts'
+import { setResolvedConfig, getResolvedConfig, _testResetConfig } from '../../src/config/store.ts'
 import type { ResolvedConfig } from '../../src/config/types.ts'
 
 const sampleConfig: ResolvedConfig = {
@@ -14,9 +14,15 @@ const sampleConfig: ResolvedConfig = {
   },
 }
 
+// The store is a module-level singleton. Under `bun test` all files share one
+// process, so other suites can leave state behind; reset before each test (not
+// just after) so assertions about the initial state are order-independent.
+beforeEach(() => {
+  _testResetConfig()
+})
+
 afterEach(() => {
-  // reset singleton state between tests
-  setResolvedConfig(undefined as unknown as ResolvedConfig)
+  _testResetConfig()
 })
 
 describe('store', () => {


### PR DESCRIPTION
## Summary

- Fixes the `Test Bun` CI failure on `main`, which started at commit 2297c98 (#373) and fails at `test/config/store.test.ts:25` (`store > getResolvedConfig > returns undefined before any config is set`).
- Root cause: `src/config/store.ts` is a module-level singleton. `bun test` runs all test files in a shared process (and distributes them across concurrent workers that share module state), unlike `node --test`, which isolates each file. Sibling suites such as `test/lib/es-client.test.ts` leave `_config` set to `{ context: {} }` in their `afterEach`, so when `store.test.ts`'s first test runs after one of them in the same worker, the initial-state assertion fails. The node runner never sees this because it isolates files.
- Commit 2297c98 added a large batch of tests to `test/cli.test.ts` and `test/factory.test.ts`, which perturbed bun's per-worker file scheduling enough to surface this pre-existing latent leak.
- The fix resets the store singleton via `_testResetConfig()` in a `beforeEach` (in addition to `afterEach`), so the test no longer depends on residual global state and is order-independent under both bun and node.

## Test plan

- [ ] `npx tsc --noEmit` passes
- [ ] `npx tsx --test test/config/store.test.ts` passes (node runner)
- [ ] `bun test test/lib/es-client.test.ts test/config/store.test.ts` passes (bun, polluter ordering)
- [ ] CI `Test Bun` job is green on all three OS runners