### PR TITLE
fix(cli): show banner on --help to match bare `elastic` output

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -64,7 +64,7 @@ released to the public npm registry; depend on it through the workspace.
 
 
 ------------------------------------------------------------------------
-@elastic/es-schemas@1.0.1
+@elastic/es-schemas@1.0.2
 License: UNLICENSED
 Repository: https://github.com/elastic/cli
 Publisher: Elastic Client Library Maintainers
@@ -1133,7 +1133,7 @@ THIS SOFTWARE.
 
 
 ------------------------------------------------------------------------
-yaml@2.9.0
+yaml@2.8.4
 License: ISC
 Repository: https://github.com/eemeli/yaml
 Publisher: Eemeli Aro <eemeli@gmail.com>

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -184,13 +184,14 @@ if (firstArg === 'status') {
 const SKIP_EARLY_CONFIG = new Set<string>([
   'version', 'extension', 'status', ...COMPLETION_COMMAND_NAMES, ...skipConfigNames,
 ])
+let earlyConfig: Awaited<ReturnType<typeof loadConfig>> | undefined
 if (firstArg == null || !SKIP_EARLY_CONFIG.has(firstArg)) {
   // Parse --profile early (before Commander's full parse) so the early config load
   // and hideBlockedCommands can apply the correct profile-based allow-list to --help.
   const profileArgIdx = process.argv.indexOf('--command-profile')
   const earlyProfile = profileArgIdx !== -1 ? process.argv[profileArgIdx + 1] as BuiltInProfile | undefined : undefined
 
-  const earlyConfig = await loadConfig({
+  earlyConfig = await loadConfig({
     ...(earlyProfile != null && { profileName: earlyProfile }),
   })
   if (earlyConfig.ok) {
@@ -199,11 +200,13 @@ if (firstArg == null || !SKIP_EARLY_CONFIG.has(firstArg)) {
   }
 }
 
+// Render the banner before --help output too, not just for bare `elastic` (#390).
+program.addHelpText('before', () =>
+  process.argv.includes('--json') || (earlyConfig?.ok === true && earlyConfig.value.banner === false)
+    ? '' : renderLogo(VERSION).replace(/\n$/, '')
+)
+
 if (process.argv.slice(2).length === 0) {
-  const earlyConfig = await loadConfig()
-  if (!earlyConfig?.ok || earlyConfig.value.banner !== false) {
-    process.stdout.write(renderLogo(VERSION))
-  }
   program.outputHelp()
   process.exit(0)
 }


### PR DESCRIPTION
## Summary

Bare `elastic` printed the ascii banner before the usage; `elastic --help` printed only the usage. They now produce identical output.

The banner-rendering branch was inlined inside the no-args fallback in `src/cli.ts`, so it never ran on Commander's `--help` path. Moved it into a `program.addHelpText('before', ...)` hook on the root command so both invocations go through the same code, and dropped the duplicated banner write in the no-args branch.

`'before'` (not `'beforeAll'`) keeps subcommand `--help` output (e.g. `elastic stack --help`) terse. The callback returns `''` when `--json` is set so `--help --json` stays valid JSON, and when the config has `banner: false`.

Closes #390.

## Test plan

- [x] `npm run build`
- [x] `diff <(env -u NO_COLOR FORCE_COLOR=1 node dist/cli.js) <(env -u NO_COLOR FORCE_COLOR=1 node dist/cli.js --help)` → no diff
- [x] `env -u NO_COLOR FORCE_COLOR=1 node dist/cli.js --help | head -10` shows the colored ascii banner
- [x] `node dist/cli.js --help --json | jq .name` → `"elastic"` (no banner corruption)
- [x] `node dist/cli.js stack --help` → no banner (subcommand help unaffected)
- [x] `npm run test:unit` → 1436/1436 pass


Made with [Cursor](https://cursor.com)