### PR TITLE
ci: add CodeQL for static analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,40 @@
+name: "CodeQL"
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [actions, javascript-typescript]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: none
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file.
+          # Prefix the list here with "+" to use these queries and those in the config file.
+
+          # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+          # queries: security-extended,security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v4
+        with:
+          category: "/language:${{matrix.language}}"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -21,18 +21,12 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
 
-      # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v4
         with:
           languages: ${{ matrix.language }}
           build-mode: none
-          # If you wish to specify custom queries, you can do so here or in a config file.
-          # By default, queries listed here will override any specified in a config file.
-          # Prefix the list here with "+" to use these queries and those in the config file.
-
-          # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-          # queries: security-extended,security-and-quality
+          queries: +./test/codeql/
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v4

--- a/test/codeql/codeql-pack.lock.yml
+++ b/test/codeql/codeql-pack.lock.yml
@@ -1,0 +1,30 @@
+---
+lockVersion: 1.0.0
+dependencies:
+  codeql/concepts:
+    version: 0.0.25
+  codeql/controlflow:
+    version: 2.0.35
+  codeql/dataflow:
+    version: 2.1.7
+  codeql/javascript-all:
+    version: 2.7.2
+  codeql/mad:
+    version: 1.0.51
+  codeql/regex:
+    version: 1.0.51
+  codeql/ssa:
+    version: 2.0.27
+  codeql/threat-models:
+    version: 1.0.51
+  codeql/tutorial:
+    version: 1.0.51
+  codeql/typetracking:
+    version: 2.0.35
+  codeql/util:
+    version: 2.0.38
+  codeql/xml:
+    version: 1.0.51
+  codeql/yaml:
+    version: 1.0.51
+compiled: false

--- a/test/codeql/no-custom.ql
+++ b/test/codeql/no-custom.ql
@@ -1,0 +1,58 @@
+/**
+ * @name Custom Command instead of factory
+ * @description Finds commands created with `new Command()` that register options or actions directly instead of using the factory.
+ * @kind problem
+ * @problem.severity warning
+ * @id js/no-custom-command
+ */
+
+import javascript
+
+/**
+ * Command names that are permitted to bypass the factory.
+ */
+predicate isAllowlisted(string name) {
+  name = ["version", "completion", "elastic", "__complete"]
+}
+
+/**
+ * A `new Command('name')` expression.
+ */
+class NewCommandExpr extends NewExpr {
+  NewCommandExpr() {
+    this.getCalleeName() = "Command" and
+    this.getNumArgument() >= 1
+  }
+
+  string getCommandName() {
+    result = this.getArgument(0).getStringValue()
+  }
+}
+
+/**
+ * A method call on a variable that was assigned from `new Command(...)`.
+ */
+predicate isMethodOnCommand(NewCommandExpr cmd, MethodCallExpr methodCall) {
+  exists(VarDef def, VarAccess access |
+    def.getSource() = cmd and
+    access.getVariable() = def.getTarget().(VarRef).getVariable() and
+    methodCall.getReceiver() = access
+  )
+  or
+  // Chained: new Command('...').option(...) / new Command('...').action(...)
+  methodCall.getReceiver() = cmd
+  or
+  // Chained off another method on the same command: new Command('...').option(...).action(...)
+  exists(MethodCallExpr prior |
+    isMethodOnCommand(cmd, prior) and
+    methodCall.getReceiver() = prior
+  )
+}
+
+from NewCommandExpr cmd, MethodCallExpr methodCall
+where
+  isMethodOnCommand(cmd, methodCall) and
+  methodCall.getMethodName() = ["option", "action"] and
+  not isAllowlisted(cmd.getCommandName()) and
+  not cmd.getFile().getRelativePath().matches("test/%")
+select cmd, "Custom command '" + cmd.getCommandName() + "' should use the factory instead of manual Command construction."

--- a/test/codeql/no-printing.ql
+++ b/test/codeql/no-printing.ql
@@ -1,0 +1,37 @@
+/**
+ * @name Console.log in Command action handler
+ * @description Finds undesired prints to stdout/stderr inside command .action() callbacks.
+ * @kind problem
+ * @problem.severity warning
+ * @id js/console-log-in-command-action
+ */
+
+import javascript
+
+predicate isActionHandler(Function f) {
+  exists(CallExpr actionCall |
+    actionCall.getCalleeName() = "action" and
+    f = actionCall.getArgument(0).(Function)
+  )
+}
+
+predicate isConsoleCall(CallExpr call) {
+  call.getReceiver().(VarAccess).getName() = "console"
+}
+
+predicate isProcessStreamWrite(CallExpr call) {
+  exists(DotExpr recv |
+    recv = call.getReceiver() and
+    call.getCalleeName() = "write" and
+    recv.getPropertyName() = ["stdout", "stderr"] and
+    recv.getBase().(VarAccess).getName() = "process"
+  )
+}
+
+from Function actionHandler, CallExpr printCall
+where
+  isActionHandler(actionHandler) and
+  printCall.getEnclosingFunction+() = actionHandler and
+  (isConsoleCall(printCall) or isProcessStreamWrite(printCall)) and
+  not printCall.getFile().getBaseName() = ["factory.ts", "factory-core.ts"]
+select printCall, "Direct printing should not be used inside a Command .action() handler."

--- a/test/codeql/qlpack.yml
+++ b/test/codeql/qlpack.yml
@@ -1,0 +1,4 @@
+name: elastic-cli/codeql-queries
+version: 0.0.1
+dependencies:
+  codeql/javascript-all: "*"


### PR DESCRIPTION
Adds CodeQL static analysis of code to help enforce some of our command guidelines, namely:

- always use a factory
- never print to stdout from a handler

With room to expand into more rules later.

This also adds GitHub's default rule bundles for validating security best practices for various languages, in our case TypeScript and GitHub actions.