### PR TITLE
fix: add explicit permissions to GitHub Actions workflows

### DIFF
--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -3,6 +3,11 @@ on:
   issues:
     types: [labeled]
 
+permissions:
+  contents: write
+  pull-requests: write
+  issues: read
+
 jobs:
   auto-pr:
     if: startsWith(github.event.label.name, 'auto-pr')

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -6,6 +6,8 @@ on:
   pull_request:
     branches: ["main"]
 
+permissions: {}
+
 jobs:
   analyze:
     name: Analyze (${{ matrix.language }})

--- a/.github/workflows/docs-preview-cleanup.yml
+++ b/.github/workflows/docs-preview-cleanup.yml
@@ -6,6 +6,8 @@ on:
     types:
       - closed
 
+permissions: {}
+
 jobs:
   cleanup:
     uses: elastic/docs-actions/.github/workflows/docs-preview-cleanup.yml@67a2f08b5b237e0f333d23c357b2f6cb6860ecf9 # v1

--- a/.github/workflows/regenerate-notice.yml
+++ b/.github/workflows/regenerate-notice.yml
@@ -8,6 +8,8 @@ on:
       - package.json
       - package-lock.json
 
+permissions: {}
+
 jobs:
   regenerate:
     runs-on: ubuntu-latest

--- a/.github/workflows/resolve-conflicts.yml
+++ b/.github/workflows/resolve-conflicts.yml
@@ -3,6 +3,11 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  contents: write
+  pull-requests: write
+  issues: read
+
 jobs:
   resolve:
     uses: elastic/clients-team-automations/.github/workflows/ai-backport-resolver.yml@main


### PR DESCRIPTION
InfoSec is changing GITHUB_TOKEN default permissions from read/write to read-only on July 15th. This PR adds explicit permissions blocks to workflows that require write access.

## Changes

| Workflow | Fix applied |
|---|---|
| `auto-pr.yml` | Added `contents: write`, `pull-requests: write`, `issues: read` — delegates to reusable workflow that creates PRs |
| `codeql.yml` | Added `permissions: {}` at top level — job-level `security-events: write` already present, top-level deny-all is best practice |
| `docs-preview-cleanup.yml` | Added `permissions: {}` at top level — job-level permissions already scoped correctly |
| `regenerate-notice.yml` | Added `permissions: {}` at top level — job-level `contents: write` already present for `git push` |
| `resolve-conflicts.yml` | Added `contents: write`, `pull-requests: write`, `issues: read` — delegates to reusable workflow that resolves backport conflicts |

## References
- https://docs.github.com/en/actions/reference/workflows-and-actions/workflow-syntax#permissions