### PR TITLE
ci: regenerate NOTICE.txt for all PRs, not just bots

### DIFF
--- a/.github/workflows/regenerate-notice.yml
+++ b/.github/workflows/regenerate-notice.yml
@@ -1,9 +1,16 @@
 name: Regenerate NOTICE.txt
-# Runs on PRs opened by bots (Renovate, Dependabot) that update dependencies.
-# Re-generates NOTICE.txt so it reflects the updated dependency tree.
+# Runs on any PR that updates package.json / package-lock.json (human or bot)
+# and on direct pushes to main, so NOTICE.txt is always kept in sync with the
+# dependency tree and the notice-file CI check never fails spuriously.
 on:
   pull_request:
     types: [opened, synchronize]
+    paths:
+      - package.json
+      - package-lock.json
+  push:
+    branches:
+      - main
     paths:
       - package.json
       - package-lock.json
@@ -11,16 +18,18 @@ on:
 jobs:
   regenerate:
     runs-on: ubuntu-latest
-    if: |
-      startsWith(github.event.pull_request.user.login, 'elastic-renovate') ||
-      startsWith(github.event.pull_request.user.login, 'renovate') ||
-      github.event.pull_request.user.login == 'dependabot[bot]'
+    # Skip fork PRs — GITHUB_TOKEN can't push to a fork's branch.
+    if: >
+      github.event_name == 'push' ||
+      github.event.pull_request.head.repo.full_name == github.repository
     permissions:
       contents: write
     steps:
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.head_ref }}
+          # For PRs, check out the head branch so we can push back to it.
+          # For pushes to main, this defaults to the pushed commit.
+          ref: ${{ github.head_ref || github.ref }}
           token: ${{ github.token }}
 
       - uses: actions/setup-node@v4

--- a/test/config/store.test.ts
+++ b/test/config/store.test.ts
@@ -3,9 +3,9 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-import { describe, it, afterEach } from 'node:test'
+import { describe, it, beforeEach, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import { setResolvedConfig, getResolvedConfig } from '../../src/config/store.ts'
+import { setResolvedConfig, getResolvedConfig, _testResetConfig } from '../../src/config/store.ts'
 import type { ResolvedConfig } from '../../src/config/types.ts'
 
 const sampleConfig: ResolvedConfig = {
@@ -14,9 +14,15 @@ const sampleConfig: ResolvedConfig = {
   },
 }
 
+// The store is a module-level singleton. Under `bun test` all files share one
+// process, so other suites can leave state behind; reset before each test (not
+// just after) so assertions about the initial state are order-independent.
+beforeEach(() => {
+  _testResetConfig()
+})
+
 afterEach(() => {
-  // reset singleton state between tests
-  setResolvedConfig(undefined as unknown as ResolvedConfig)
+  _testResetConfig()
 })
 
 describe('store', () => {


### PR DESCRIPTION
## Problem

The `regenerate-notice` workflow had a bot-only guard (`if: startsWith(github.event.pull_request.user.login, 'elastic-renovate') || ...`), so it only auto-committed an updated `NOTICE.txt` for Renovate/Dependabot PRs.

When a human updated `package.json`, `NOTICE.txt` merged without being regenerated. Once stale on `main`, every subsequent PR — even ones that never touched packages — failed the `notice-file` CI check, hence the "random" failures.

## Fix

- Remove the bot-only `if:` guard so the workflow runs for **any same-repo PR** that touches `package.json` or `package-lock.json`.
- Add a `push` trigger on `main` as a second safety net (catches anything that merges with a stale `NOTICE.txt`).
- Fork PRs are explicitly skipped since `GITHUB_TOKEN` cannot push to a fork's branch.

## Result

Any PR that changes dependencies gets `NOTICE.txt` auto-committed before the `notice-file` CI check runs on the follow-up commit, so the check always passes.