### PR TITLE
chore: upgrade fetch-github-token to v1.5.3

### DIFF
--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -38,7 +38,7 @@ jobs:
       # the generator repo (private) can be cloned.
       - name: Fetch ephemeral Github token
         id: fetch-token
-        uses: elastic/ci-gh-actions/fetch-github-token@2feb1c6f5086cf8e06f61ef35e275abed3456f7b # v1.5.0
+        uses: elastic/ci-gh-actions/fetch-github-token@2feb1c6f5086cf8e06f61ef35e275abed3456f7b # v1.5.3
         with:
           vault-instance: "ci-prod"
 

--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -38,7 +38,7 @@ jobs:
       # the generator repo (private) can be cloned.
       - name: Fetch ephemeral Github token
         id: fetch-token
-        uses: elastic/ci-gh-actions/fetch-github-token@v1.5.3 # v1.5.0
+        uses: elastic/ci-gh-actions/fetch-github-token@2feb1c6f5086cf8e06f61ef35e275abed3456f7b # v1.5.0
         with:
           vault-instance: "ci-prod"
 

--- a/.github/workflows/codegen.yml
+++ b/.github/workflows/codegen.yml
@@ -38,7 +38,7 @@ jobs:
       # the generator repo (private) can be cloned.
       - name: Fetch ephemeral Github token
         id: fetch-token
-        uses: elastic/ci-gh-actions/fetch-github-token@622f9dc1eecdd4af2e81dfb38028aacb1dae03e8 # v1.5.0
+        uses: elastic/ci-gh-actions/fetch-github-token@v1.5.3 # v1.5.0
         with:
           vault-instance: "ci-prod"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Fetch ephemeral Github token
         id: fetch-token
-        uses: elastic/ci-gh-actions/fetch-github-token@2feb1c6f5086cf8e06f61ef35e275abed3456f7b # v1.5.0
+        uses: elastic/ci-gh-actions/fetch-github-token@2feb1c6f5086cf8e06f61ef35e275abed3456f7b # v1.5.3
         with:
           vault-instance: "ci-prod"
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Fetch ephemeral Github token
         id: fetch-token
-        uses: elastic/ci-gh-actions/fetch-github-token@v1.5.3 # v1.5.0
+        uses: elastic/ci-gh-actions/fetch-github-token@2feb1c6f5086cf8e06f61ef35e275abed3456f7b # v1.5.0
         with:
           vault-instance: "ci-prod"
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
     steps:
       - name: Fetch ephemeral Github token
         id: fetch-token
-        uses: elastic/ci-gh-actions/fetch-github-token@622f9dc1eecdd4af2e81dfb38028aacb1dae03e8 # v1.5.0
+        uses: elastic/ci-gh-actions/fetch-github-token@v1.5.3 # v1.5.0
         with:
           vault-instance: "ci-prod"
       - uses: googleapis/release-please-action@45996ed1f6d02564a971a2fa1b5860e934307cf7 # v5


### PR DESCRIPTION
## Summary

Upgrades `elastic/ci-gh-actions/fetch-github-token` to `v1.5.3` across all affected workflow files.

## Reason

Version `v1.5.3` includes a fix for a security concern related to new GitHub token formats. Previous pinned versions (including commit SHAs and older semver tags) do not handle the updated token format correctly.

See: https://github.com/elastic/ci-gh-actions/releases/tag/v1.5.3

## Changes

Bumps `fetch-github-token` references from older versions/SHAs to `v1.5.3`.

---
*This PR was created automatically to address a security concern in CI workflows.*