### PR TITLE
chore: adjust renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,7 +1,13 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "local>elastic/renovate-config"
+    "local>elastic/renovate-config",
+    "schedule:automergeMonthly",
+    "security:minimumReleaseAgeNpm",
+    "mergeConfidence:all-badges"
   ],
-  "schedule": ["on monday"]
+  "schedule": [
+    "* 0-3 1 * *"
+  ],
+  "prConcurrentLimit": 10
 }


### PR DESCRIPTION
Getting endless PRs on a daily basis is too noisy. This adjusts it to work more like elasticsearch-js: ~10 max PRs weekly every Monday.
