### PR TITLE
fix: wire up serverless profile to block stack-only ES namespaces

### DIFF
--- a/src/config/profiles.ts
+++ b/src/config/profiles.ts
@@ -25,10 +25,7 @@ export const BUILT_IN_PROFILES = ['serverless', 'stack', 'default'] as const
 /** Union of valid built-in profile name strings. */
 export type BuiltInProfile = typeof BUILT_IN_PROFILES[number]
 
-/**
- * ES namespaces unavailable on Elasticsearch Serverless.
- * ponytail: namespace-level only; per-endpoint granularity tracked in #283
- */
+/** ES namespaces unavailable on Elasticsearch Serverless. */
 const STACK_ONLY_ES_NAMESPACES = [
   'ccr',
   'dangling-indices',

--- a/src/config/profiles.ts
+++ b/src/config/profiles.ts
@@ -26,12 +26,30 @@ export const BUILT_IN_PROFILES = ['serverless', 'stack', 'default'] as const
 export type BuiltInProfile = typeof BUILT_IN_PROFILES[number]
 
 /**
- * Resolves a built-in profile to an effective allow-list.
+ * ES namespaces unavailable on Elasticsearch Serverless.
+ * ponytail: namespace-level only; per-endpoint granularity tracked in #283
+ */
+const STACK_ONLY_ES_NAMESPACES = [
+  'ccr',
+  'dangling-indices',
+  'ilm',
+  'license',
+  'logstash',
+  'rollup',
+  'searchable-snapshots',
+  'slm',
+  'snapshot',
+  'ssl',
+  'watcher',
+] as const
+
+/**
+ * Resolves a built-in profile to an effective allow/block policy.
  *
  * Returns `null` for `stack`, which means "no restriction" (allow everything).
- * Returns an object with `allowed` patterns for all other profiles.
+ * Returns an object with `allowed` and `blocked` patterns for all other profiles.
  */
-export function resolveBuiltinProfile (name: BuiltInProfile): { allowed: readonly string[] } | null {
+export function resolveBuiltinProfile (name: BuiltInProfile): { allowed: readonly string[]; blocked?: readonly string[] } | null {
   if (name === 'stack') return null
 
   // `default` is an alias for `serverless`
@@ -48,9 +66,6 @@ export function resolveBuiltinProfile (name: BuiltInProfile): { allowed: readonl
       'kb',
 
       // All stack commands (Elasticsearch + Kibana)
-      // Individual serverless-incompatible ES endpoints will be filtered in a
-      // future iteration once per-command availability metadata is added to the
-      // API manifest (see issue #283 for tracking).
       'stack.*',
 
       // Cloud cross-cutting namespaces (apply to both Hosted and Serverless)
@@ -65,5 +80,6 @@ export function resolveBuiltinProfile (name: BuiltInProfile): { allowed: readonl
 
       // cloud.hosted.* is intentionally excluded from serverless/default profiles
     ],
+    blocked: STACK_ONLY_ES_NAMESPACES.map(ns => `stack.es.${ns}.*`),
   }
 }

--- a/src/factory-core.ts
+++ b/src/factory-core.ts
@@ -173,6 +173,7 @@ export function isCommandAllowed (commandDotPath: string, policy: CommandPolicy 
     const profilePolicy = resolveBuiltinProfile(policy.profile)
     if (profilePolicy != null) {
       if (!profilePolicy.allowed.some(matches)) return false
+      if (profilePolicy.blocked?.some(matches)) return false
     }
     if (policy.blocked != null) return !policy.blocked.some(matches)
     return true

--- a/test/factory.test.ts
+++ b/test/factory.test.ts
@@ -2583,6 +2583,18 @@ describe('isCommandAllowed', () => {
     assert.equal(isCommandAllowed('cloud.hosted.traffic-filters.list', { profile: 'serverless' }), false)
   })
 
+  it('profile serverless: blocks stack-only ES namespaces', () => {
+    for (const ns of ['ilm', 'watcher', 'snapshot', 'slm', 'ccr', 'rollup', 'license', 'logstash', 'searchable-snapshots', 'dangling-indices', 'ssl']) {
+      assert.equal(isCommandAllowed(`stack.es.${ns}.get`, { profile: 'serverless' }), false, `expected stack.es.${ns}.* to be blocked under serverless`)
+    }
+  })
+
+  it('profile serverless: still allows non-stack-only ES namespaces', () => {
+    assert.equal(isCommandAllowed('stack.es.indices.create', { profile: 'serverless' }), true)
+    assert.equal(isCommandAllowed('stack.es.ml.get-records', { profile: 'serverless' }), true)
+    assert.equal(isCommandAllowed('stack.es.search', { profile: 'serverless' }), true)
+  })
+
   it('profile serverless: allows version and config commands', () => {
     assert.equal(isCommandAllowed('version', { profile: 'serverless' }), true)
     assert.equal(isCommandAllowed('config.context.list', { profile: 'serverless' }), true)


### PR DESCRIPTION
## Summary

Closes #332.

`--command-profile serverless` was accepted but had no observable effect on the ES command surface. All ES namespaces (including stack-only ones like ILM, watcher, snapshot) were visible and executable under all profiles.

**Root cause**: the `serverless` profile allowed `stack.*` with no exclusions.

**Fix**:
- Added `STACK_ONLY_ES_NAMESPACES` list to `profiles.ts` and extended `resolveBuiltinProfile` to return a `blocked` list alongside `allowed`
- Added one line to `isCommandAllowed` in `factory-core.ts` to honor `profilePolicy.blocked`
- Both help visibility (`hideBlockedCommands`) and runtime enforcement (`defineCommand`) pick this up automatically

Blocked under `serverless`/`default`: `ccr`, `dangling-indices`, `ilm`, `license`, `logstash`, `rollup`, `searchable-snapshots`, `slm`, `snapshot`, `ssl`, `watcher`.

Per-endpoint granularity is still tracked in #283 (this is namespace-level filtering).

## Test plan

- [ ] `elastic --command-profile serverless es help` no longer shows `ilm`, `watcher`, `snapshot`, etc.
- [ ] `elastic --command-profile stack es help` still shows all namespaces
- [ ] `diff <(elastic --command-profile serverless es help) <(elastic --command-profile stack es help)` now produces output
- [ ] New unit tests pass: `profile serverless: blocks stack-only ES namespaces`
