### PR TITLE
fix: expose --name and --region-id flags on project create

### DIFF
--- a/docs/cli/schema.json
+++ b/docs/cli/schema.json
@@ -1677,9 +1677,7 @@
                   "name": "source",
                   "type": "boolean",
                   "required": false,
-                  "summary": "If `false`, turn off source retrieval. You can also specify a comma-separated list of the fields you want to retrieve.",
-                  "repeatable": true,
-                  "separator": ","
+                  "summary": "If `false`, turn off source retrieval. You can also specify a comma-separated list of the fields you want to retrieve."
                 },
                 {
                   "role": "flag",
@@ -2870,9 +2868,7 @@
                   "name": "source",
                   "type": "boolean",
                   "required": false,
-                  "summary": "The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.",
-                  "repeatable": true,
-                  "separator": ","
+                  "summary": "The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`."
                 },
                 {
                   "role": "flag",
@@ -5268,9 +5264,7 @@
                       "name": "source",
                       "type": "boolean",
                       "required": false,
-                      "summary": "Indicates which source fields are returned for matching documents. These fields are returned in the hits._source property of the search response.",
-                      "repeatable": true,
-                      "separator": ","
+                      "summary": "Indicates which source fields are returned for matching documents. These fields are returned in the hits._source property of the search response."
                     },
                     {
                       "role": "flag",
@@ -11563,8 +11557,7 @@
                       "name": "name",
                       "type": "string",
                       "required": true,
-                      "summary": "The view name to remove.",
-                      "repeatable": true
+                      "summary": "The view name to remove."
                     },
                     {
                       "role": "flag",
@@ -12494,9 +12487,7 @@
                       "name": "source",
                       "type": "boolean",
                       "required": false,
-                      "summary": "Indicates which source fields are returned for matching documents. These fields are returned in the hits._source property of the search response.",
-                      "repeatable": true,
-                      "separator": ","
+                      "summary": "Indicates which source fields are returned for matching documents. These fields are returned in the hits._source property of the search response."
                     },
                     {
                       "role": "flag",
@@ -20501,8 +20492,7 @@
                       "enumValues": [
                         "chat_completion",
                         "completion",
-                        "text_embedding",
-                        "embedding"
+                        "text_embedding"
                       ]
                     },
                     {
@@ -23177,9 +23167,7 @@
                       "name": "analyzed-fields",
                       "type": "string",
                       "required": false,
-                      "summary": "Specify includes and/or excludes patterns to select which fields will be included in the analysis. The patterns specified in excludes are applied last, therefore excludes takes precedence. In other words, if the same field is specified in both includes and excludes, then the field will not be included in the analysis.",
-                      "repeatable": true,
-                      "separator": ","
+                      "summary": "Specify includes and/or excludes patterns to select which fields will be included in the analysis. The patterns specified in excludes are applied last, therefore excludes takes precedence. In other words, if the same field is specified in both includes and excludes, then the field will not be included in the analysis."
                     },
                     {
                       "role": "flag",
@@ -25141,9 +25129,7 @@
                       "name": "analyzed-fields",
                       "type": "string",
                       "required": false,
-                      "summary": "Specifies `includes` and/or `excludes` patterns to select which fields will be included in the analysis. The patterns specified in `excludes` are applied last, therefore `excludes` takes precedence. In other words, if the same field is specified in both `includes` and `excludes`, then the field will not be included in the analysis. If `analyzed_fields` is not set, only the relevant fields will be included. For example, all the numeric fields for outlier detection. The supported fields vary for each type of analysis. Outlier detection requires numeric or `boolean` data to analyze. The algorithms don’t support missing values therefore fields that have data types other than numeric or boolean are ignored. Documents where included fields contain missing values, null values, or an array are also ignored. Therefore the `dest` index may contain documents that don’t have an outlier score. Regression supports fields that are numeric, `boolean`, `text`, `keyword`, and `ip` data types. It is also tolerant of missing values. Fields that are supported are included in the analysis, other fields are ignored. Documents where included fields contain an array with two or more values are also ignored. Documents in the `dest` index that don’t contain a results field are not included in the regression analysis. Classification supports fields that are numeric, `boolean`, `text`, `keyword`, and `ip` data types. It is also tolerant of missing values. Fields that are supported are included in the analysis, other fields are ignored. Documents where included fields contain an array with two or more values are also ignored. Documents in the `dest` index that don’t contain a results field are not included in the classification analysis. Classification analysis can be improved by mapping ordinal variable values to a single number. For example, in case of age ranges, you can model the values as `0-14 = 0`, `15-24 = 1`, `25-34 = 2`, and so on.",
-                      "repeatable": true,
-                      "separator": ","
+                      "summary": "Specifies `includes` and/or `excludes` patterns to select which fields will be included in the analysis. The patterns specified in `excludes` are applied last, therefore `excludes` takes precedence. In other words, if the same field is specified in both `includes` and `excludes`, then the field will not be included in the analysis. If `analyzed_fields` is not set, only the relevant fields will be included. For example, all the numeric fields for outlier detection. The supported fields vary for each type of analysis. Outlier detection requires numeric or `boolean` data to analyze. The algorithms don’t support missing values therefore fields that have data types other than numeric or boolean are ignored. Documents where included fields contain missing values, null values, or an array are also ignored. Therefore the `dest` index may contain documents that don’t have an outlier score. Regression supports fields that are numeric, `boolean`, `text`, `keyword`, and `ip` data types. It is also tolerant of missing values. Fields that are supported are included in the analysis, other fields are ignored. Documents where included fields contain an array with two or more values are also ignored. Documents in the `dest` index that don’t contain a results field are not included in the regression analysis. Classification supports fields that are numeric, `boolean`, `text`, `keyword`, and `ip` data types. It is also tolerant of missing values. Fields that are supported are included in the analysis, other fields are ignored. Documents where included fields contain an array with two or more values are also ignored. Documents in the `dest` index that don’t contain a results field are not included in the classification analysis. Classification analysis can be improved by mapping ordinal variable values to a single number. For example, in case of age ranges, you can model the values as `0-14 = 0`, `15-24 = 1`, `25-34 = 2`, and so on."
                     },
                     {
                       "role": "flag",
@@ -30662,13 +30648,6 @@
                       "required": false,
                       "summary": "The name of the role. You can specify multiple roles as a comma-separated list. If you do not specify this parameter, the API returns information about all roles.",
                       "repeatable": true
-                    },
-                    {
-                      "role": "flag",
-                      "name": "include-implicit",
-                      "type": "boolean",
-                      "required": false,
-                      "summary": "If `true`, include privileges that are implicitly granted by registered `ImplicitPrivilegesProviders` alongside the explicitly configured privileges. Each implicit entry in the response is annotated with `implicitly_granted: true`."
                     },
                     {
                       "role": "flag",
@@ -66828,6 +66807,13 @@
                           "type": "string",
                           "required": false,
                           "summary": "Contains a project ID. If specified, the result will be filtered to only those origin projects that are linked to the specified project ID in a cross-project search configuration."
+                        },
+                        {
+                          "role": "flag",
+                          "name": "tags",
+                          "type": "string",
+                          "required": false,
+                          "summary": "If specified, the result will be filtered to only those projects that have the specified tags and corresponding values."
                         }
                       ],
                       "summary": "Get Elasticsearch projects",
@@ -66844,6 +66830,20 @@
                       ],
                       "name": "create",
                       "parameters": [
+                        {
+                          "role": "flag",
+                          "name": "name",
+                          "type": "string",
+                          "required": true,
+                          "summary": "Descriptive name for a project."
+                        },
+                        {
+                          "role": "flag",
+                          "name": "region-id",
+                          "type": "string",
+                          "required": true,
+                          "summary": "Unique human-readable identifier for a region in Elastic Cloud."
+                        },
                         {
                           "role": "flag",
                           "name": "wait",
@@ -67096,6 +67096,13 @@
                           "type": "string",
                           "required": false,
                           "summary": "Contains a project ID. If specified, the result will be filtered to only those origin projects that are linked to the specified project ID in a cross-project search configuration."
+                        },
+                        {
+                          "role": "flag",
+                          "name": "tags",
+                          "type": "string",
+                          "required": false,
+                          "summary": "If specified, the result will be filtered to only those projects that have the specified tags and corresponding values."
                         }
                       ],
                       "summary": "Get Observability projects",
@@ -67112,6 +67119,20 @@
                       ],
                       "name": "create",
                       "parameters": [
+                        {
+                          "role": "flag",
+                          "name": "name",
+                          "type": "string",
+                          "required": true,
+                          "summary": "Descriptive name for a project."
+                        },
+                        {
+                          "role": "flag",
+                          "name": "region-id",
+                          "type": "string",
+                          "required": true,
+                          "summary": "Unique human-readable identifier for a region in Elastic Cloud."
+                        },
                         {
                           "role": "flag",
                           "name": "wait",
@@ -67364,6 +67385,13 @@
                           "type": "string",
                           "required": false,
                           "summary": "Contains a project ID. If specified, the result will be filtered to only those origin projects that are linked to the specified project ID in a cross-project search configuration."
+                        },
+                        {
+                          "role": "flag",
+                          "name": "tags",
+                          "type": "string",
+                          "required": false,
+                          "summary": "If specified, the result will be filtered to only those projects that have the specified tags and corresponding values."
                         }
                       ],
                       "summary": "Get Security projects",
@@ -67380,6 +67408,20 @@
                       ],
                       "name": "create",
                       "parameters": [
+                        {
+                          "role": "flag",
+                          "name": "name",
+                          "type": "string",
+                          "required": true,
+                          "summary": "Descriptive name for a project."
+                        },
+                        {
+                          "role": "flag",
+                          "name": "region-id",
+                          "type": "string",
+                          "required": true,
+                          "summary": "Unique human-readable identifier for a region in Elastic Cloud."
+                        },
                         {
                           "role": "flag",
                           "name": "wait",
@@ -67662,6 +67704,13 @@
                       "type": "string",
                       "required": false,
                       "summary": "The project alias to filter the link candidates by."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "tags",
+                      "type": "string",
+                      "required": false,
+                      "summary": "If specified, the result will be filtered to only those projects that have the specified tags and corresponding values."
                     }
                   ],
                   "summary": "Get Elasticsearch project link candidates",
@@ -67718,6 +67767,13 @@
                       "type": "string",
                       "required": false,
                       "summary": "The project alias to filter the link candidates by."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "tags",
+                      "type": "string",
+                      "required": false,
+                      "summary": "If specified, the result will be filtered to only those projects that have the specified tags and corresponding values."
                     }
                   ],
                   "summary": "Get Observability project link candidates",
@@ -67774,6 +67830,13 @@
                       "type": "string",
                       "required": false,
                       "summary": "The project alias to filter the link candidates by."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "tags",
+                      "type": "string",
+                      "required": false,
+                      "summary": "If specified, the result will be filtered to only those projects that have the specified tags and corresponding values."
                     }
                   ],
                   "summary": "Get Security project link candidates",
@@ -67927,7 +67990,29 @@
                     "traffic-filters"
                   ],
                   "name": "create-traffic-filter",
-                  "parameters": [],
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "name",
+                      "type": "string",
+                      "required": true,
+                      "summary": "Name of the traffic filter"
+                    },
+                    {
+                      "role": "flag",
+                      "name": "type",
+                      "type": "string",
+                      "required": true,
+                      "summary": "Type of the traffic filter"
+                    },
+                    {
+                      "role": "flag",
+                      "name": "region",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The traffic filter can be attached only to projects in the specific region"
+                    }
+                  ],
                   "summary": "Create a traffic filter",
                   "intent": {
                     "requiresAuth": true

--- a/docs/cli/schema.json
+++ b/docs/cli/schema.json
@@ -1677,7 +1677,9 @@
                   "name": "source",
                   "type": "boolean",
                   "required": false,
-                  "summary": "If `false`, turn off source retrieval. You can also specify a comma-separated list of the fields you want to retrieve."
+                  "summary": "If `false`, turn off source retrieval. You can also specify a comma-separated list of the fields you want to retrieve.",
+                  "repeatable": true,
+                  "separator": ","
                 },
                 {
                   "role": "flag",
@@ -2868,7 +2870,9 @@
                   "name": "source",
                   "type": "boolean",
                   "required": false,
-                  "summary": "The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`."
+                  "summary": "The source fields that are returned for matching documents. These fields are returned in the `hits._source` property of the search response. If the `stored_fields` property is specified, the `_source` property defaults to `false`. Otherwise, it defaults to `true`.",
+                  "repeatable": true,
+                  "separator": ","
                 },
                 {
                   "role": "flag",
@@ -5264,7 +5268,9 @@
                       "name": "source",
                       "type": "boolean",
                       "required": false,
-                      "summary": "Indicates which source fields are returned for matching documents. These fields are returned in the hits._source property of the search response."
+                      "summary": "Indicates which source fields are returned for matching documents. These fields are returned in the hits._source property of the search response.",
+                      "repeatable": true,
+                      "separator": ","
                     },
                     {
                       "role": "flag",
@@ -11557,7 +11563,8 @@
                       "name": "name",
                       "type": "string",
                       "required": true,
-                      "summary": "The view name to remove."
+                      "summary": "The view name to remove.",
+                      "repeatable": true
                     },
                     {
                       "role": "flag",
@@ -12487,7 +12494,9 @@
                       "name": "source",
                       "type": "boolean",
                       "required": false,
-                      "summary": "Indicates which source fields are returned for matching documents. These fields are returned in the hits._source property of the search response."
+                      "summary": "Indicates which source fields are returned for matching documents. These fields are returned in the hits._source property of the search response.",
+                      "repeatable": true,
+                      "separator": ","
                     },
                     {
                       "role": "flag",
@@ -20492,7 +20501,8 @@
                       "enumValues": [
                         "chat_completion",
                         "completion",
-                        "text_embedding"
+                        "text_embedding",
+                        "embedding"
                       ]
                     },
                     {
@@ -23167,7 +23177,9 @@
                       "name": "analyzed-fields",
                       "type": "string",
                       "required": false,
-                      "summary": "Specify includes and/or excludes patterns to select which fields will be included in the analysis. The patterns specified in excludes are applied last, therefore excludes takes precedence. In other words, if the same field is specified in both includes and excludes, then the field will not be included in the analysis."
+                      "summary": "Specify includes and/or excludes patterns to select which fields will be included in the analysis. The patterns specified in excludes are applied last, therefore excludes takes precedence. In other words, if the same field is specified in both includes and excludes, then the field will not be included in the analysis.",
+                      "repeatable": true,
+                      "separator": ","
                     },
                     {
                       "role": "flag",
@@ -25129,7 +25141,9 @@
                       "name": "analyzed-fields",
                       "type": "string",
                       "required": false,
-                      "summary": "Specifies `includes` and/or `excludes` patterns to select which fields will be included in the analysis. The patterns specified in `excludes` are applied last, therefore `excludes` takes precedence. In other words, if the same field is specified in both `includes` and `excludes`, then the field will not be included in the analysis. If `analyzed_fields` is not set, only the relevant fields will be included. For example, all the numeric fields for outlier detection. The supported fields vary for each type of analysis. Outlier detection requires numeric or `boolean` data to analyze. The algorithms don’t support missing values therefore fields that have data types other than numeric or boolean are ignored. Documents where included fields contain missing values, null values, or an array are also ignored. Therefore the `dest` index may contain documents that don’t have an outlier score. Regression supports fields that are numeric, `boolean`, `text`, `keyword`, and `ip` data types. It is also tolerant of missing values. Fields that are supported are included in the analysis, other fields are ignored. Documents where included fields contain an array with two or more values are also ignored. Documents in the `dest` index that don’t contain a results field are not included in the regression analysis. Classification supports fields that are numeric, `boolean`, `text`, `keyword`, and `ip` data types. It is also tolerant of missing values. Fields that are supported are included in the analysis, other fields are ignored. Documents where included fields contain an array with two or more values are also ignored. Documents in the `dest` index that don’t contain a results field are not included in the classification analysis. Classification analysis can be improved by mapping ordinal variable values to a single number. For example, in case of age ranges, you can model the values as `0-14 = 0`, `15-24 = 1`, `25-34 = 2`, and so on."
+                      "summary": "Specifies `includes` and/or `excludes` patterns to select which fields will be included in the analysis. The patterns specified in `excludes` are applied last, therefore `excludes` takes precedence. In other words, if the same field is specified in both `includes` and `excludes`, then the field will not be included in the analysis. If `analyzed_fields` is not set, only the relevant fields will be included. For example, all the numeric fields for outlier detection. The supported fields vary for each type of analysis. Outlier detection requires numeric or `boolean` data to analyze. The algorithms don’t support missing values therefore fields that have data types other than numeric or boolean are ignored. Documents where included fields contain missing values, null values, or an array are also ignored. Therefore the `dest` index may contain documents that don’t have an outlier score. Regression supports fields that are numeric, `boolean`, `text`, `keyword`, and `ip` data types. It is also tolerant of missing values. Fields that are supported are included in the analysis, other fields are ignored. Documents where included fields contain an array with two or more values are also ignored. Documents in the `dest` index that don’t contain a results field are not included in the regression analysis. Classification supports fields that are numeric, `boolean`, `text`, `keyword`, and `ip` data types. It is also tolerant of missing values. Fields that are supported are included in the analysis, other fields are ignored. Documents where included fields contain an array with two or more values are also ignored. Documents in the `dest` index that don’t contain a results field are not included in the classification analysis. Classification analysis can be improved by mapping ordinal variable values to a single number. For example, in case of age ranges, you can model the values as `0-14 = 0`, `15-24 = 1`, `25-34 = 2`, and so on.",
+                      "repeatable": true,
+                      "separator": ","
                     },
                     {
                       "role": "flag",
@@ -30648,6 +30662,13 @@
                       "required": false,
                       "summary": "The name of the role. You can specify multiple roles as a comma-separated list. If you do not specify this parameter, the API returns information about all roles.",
                       "repeatable": true
+                    },
+                    {
+                      "role": "flag",
+                      "name": "include-implicit",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "If `true`, include privileges that are implicitly granted by registered `ImplicitPrivilegesProviders` alongside the explicitly configured privileges. Each implicit entry in the response is annotated with `implicitly_granted: true`."
                     },
                     {
                       "role": "flag",

--- a/src/cloud/apis/elasticsearch-projects.ts
+++ b/src/cloud/apis/elasticsearch-projects.ts
@@ -22,6 +22,7 @@ export const elasticsearchProjectsApis: CloudApiDefinition[] = [
     queryParams: [
     { name: "traffic_filter", type: "string", description: "Filters the returned list of projects. Only projects associated with the provided traffic_filter will be returned." },
     { name: "linked", type: "string", description: "Contains a project ID. If specified, the result will be filtered to only those origin projects that are linked to the specified project ID in a cross-project search configuration." },
+    { name: "tags", type: "string", description: "If specified, the result will be filtered to only those projects that have the specified tags and corresponding values." },
     ],
   },
   {
@@ -31,8 +32,8 @@ export const elasticsearchProjectsApis: CloudApiDefinition[] = [
     method: "POST",
     path: "/api/v1/serverless/projects/elasticsearch",
     body: z.object({
-      name: z.string().describe('Project name'),
-      region_id: z.string().describe('Region for the project (e.g. aws-us-east-1)'),
+      name: z.string().describe("Descriptive name for a project."),
+      region_id: z.string().describe("Unique human-readable identifier for a region in Elastic Cloud."),
     }),
   },
   {

--- a/src/cloud/apis/elasticsearch-projects.ts
+++ b/src/cloud/apis/elasticsearch-projects.ts
@@ -9,6 +9,7 @@
  * and elastic/elastic-client-generator-js to regenerate this file again.
  */
 
+import { z } from 'zod'
 import type { CloudApiDefinition } from '../types.ts'
 
 export const elasticsearchProjectsApis: CloudApiDefinition[] = [
@@ -29,6 +30,10 @@ export const elasticsearchProjectsApis: CloudApiDefinition[] = [
     description: "Create an Elasticsearch project",
     method: "POST",
     path: "/api/v1/serverless/projects/elasticsearch",
+    body: z.object({
+      name: z.string().describe('Project name'),
+      region_id: z.string().describe('Region for the project (e.g. aws-us-east-1)'),
+    }),
   },
   {
     name: "get-elasticsearch-project",

--- a/src/cloud/apis/linked-candidate-projects.ts
+++ b/src/cloud/apis/linked-candidate-projects.ts
@@ -27,6 +27,7 @@ export const linkedCandidateProjectsApis: CloudApiDefinition[] = [
     { name: "region", type: "string", description: "The region to filter the link candidate projects by." },
     { name: "name", type: "string", description: "The project name to filter the link candidates by." },
     { name: "alias", type: "string", description: "The project alias to filter the link candidates by." },
+    { name: "tags", type: "string", description: "If specified, the result will be filtered to only those projects that have the specified tags and corresponding values." },
     ],
   },
   {
@@ -44,6 +45,7 @@ export const linkedCandidateProjectsApis: CloudApiDefinition[] = [
     { name: "region", type: "string", description: "The region to filter the link candidate projects by." },
     { name: "name", type: "string", description: "The project name to filter the link candidates by." },
     { name: "alias", type: "string", description: "The project alias to filter the link candidates by." },
+    { name: "tags", type: "string", description: "If specified, the result will be filtered to only those projects that have the specified tags and corresponding values." },
     ],
   },
   {
@@ -61,6 +63,7 @@ export const linkedCandidateProjectsApis: CloudApiDefinition[] = [
     { name: "region", type: "string", description: "The region to filter the link candidate projects by." },
     { name: "name", type: "string", description: "The project name to filter the link candidates by." },
     { name: "alias", type: "string", description: "The project alias to filter the link candidates by." },
+    { name: "tags", type: "string", description: "If specified, the result will be filtered to only those projects that have the specified tags and corresponding values." },
     ],
   },
 ]

--- a/src/cloud/apis/observability-projects.ts
+++ b/src/cloud/apis/observability-projects.ts
@@ -9,6 +9,7 @@
  * and elastic/elastic-client-generator-js to regenerate this file again.
  */
 
+import { z } from 'zod'
 import type { CloudApiDefinition } from '../types.ts'
 
 export const observabilityProjectsApis: CloudApiDefinition[] = [
@@ -29,6 +30,10 @@ export const observabilityProjectsApis: CloudApiDefinition[] = [
     description: "Create an observability project",
     method: "POST",
     path: "/api/v1/serverless/projects/observability",
+    body: z.object({
+      name: z.string().describe('Project name'),
+      region_id: z.string().describe('Region for the project (e.g. aws-us-east-1)'),
+    }),
   },
   {
     name: "get-observability-project",

--- a/src/cloud/apis/observability-projects.ts
+++ b/src/cloud/apis/observability-projects.ts
@@ -22,6 +22,7 @@ export const observabilityProjectsApis: CloudApiDefinition[] = [
     queryParams: [
     { name: "traffic_filter", type: "string", description: "traffic filters associated with this project" },
     { name: "linked", type: "string", description: "Contains a project ID. If specified, the result will be filtered to only those origin projects that are linked to the specified project ID in a cross-project search configuration." },
+    { name: "tags", type: "string", description: "If specified, the result will be filtered to only those projects that have the specified tags and corresponding values." },
     ],
   },
   {
@@ -31,8 +32,8 @@ export const observabilityProjectsApis: CloudApiDefinition[] = [
     method: "POST",
     path: "/api/v1/serverless/projects/observability",
     body: z.object({
-      name: z.string().describe('Project name'),
-      region_id: z.string().describe('Region for the project (e.g. aws-us-east-1)'),
+      name: z.string().describe("Descriptive name for a project."),
+      region_id: z.string().describe("Unique human-readable identifier for a region in Elastic Cloud."),
     }),
   },
   {

--- a/src/cloud/apis/security-projects.ts
+++ b/src/cloud/apis/security-projects.ts
@@ -9,6 +9,7 @@
  * and elastic/elastic-client-generator-js to regenerate this file again.
  */
 
+import { z } from 'zod'
 import type { CloudApiDefinition } from '../types.ts'
 
 export const securityProjectsApis: CloudApiDefinition[] = [
@@ -29,6 +30,10 @@ export const securityProjectsApis: CloudApiDefinition[] = [
     description: "Create a security project",
     method: "POST",
     path: "/api/v1/serverless/projects/security",
+    body: z.object({
+      name: z.string().describe('Project name'),
+      region_id: z.string().describe('Region for the project (e.g. aws-us-east-1)'),
+    }),
   },
   {
     name: "get-security-project",

--- a/src/cloud/apis/security-projects.ts
+++ b/src/cloud/apis/security-projects.ts
@@ -22,6 +22,7 @@ export const securityProjectsApis: CloudApiDefinition[] = [
     queryParams: [
     { name: "traffic_filter", type: "string", description: "traffic filters associated with this project" },
     { name: "linked", type: "string", description: "Contains a project ID. If specified, the result will be filtered to only those origin projects that are linked to the specified project ID in a cross-project search configuration." },
+    { name: "tags", type: "string", description: "If specified, the result will be filtered to only those projects that have the specified tags and corresponding values." },
     ],
   },
   {
@@ -31,8 +32,8 @@ export const securityProjectsApis: CloudApiDefinition[] = [
     method: "POST",
     path: "/api/v1/serverless/projects/security",
     body: z.object({
-      name: z.string().describe('Project name'),
-      region_id: z.string().describe('Region for the project (e.g. aws-us-east-1)'),
+      name: z.string().describe("Descriptive name for a project."),
+      region_id: z.string().describe("Unique human-readable identifier for a region in Elastic Cloud."),
     }),
   },
   {

--- a/src/cloud/apis/traffic-filters.ts
+++ b/src/cloud/apis/traffic-filters.ts
@@ -9,6 +9,7 @@
  * and elastic/elastic-client-generator-js to regenerate this file again.
  */
 
+import { z } from 'zod'
 import type { CloudApiDefinition } from '../types.ts'
 
 export const trafficFiltersApis: CloudApiDefinition[] = [
@@ -29,6 +30,11 @@ export const trafficFiltersApis: CloudApiDefinition[] = [
     description: "Create a traffic filter",
     method: "POST",
     path: "/api/v1/serverless/traffic-filters",
+    body: z.object({
+      name: z.string().describe("Name of the traffic filter"),
+      type: z.string().describe("Type of the traffic filter"),
+      region: z.string().describe("The traffic filter can be attached only to projects in the specific region"),
+    }),
   },
   {
     name: "get-traffic-filter-metadata",

--- a/src/config/profiles.ts
+++ b/src/config/profiles.ts
@@ -48,9 +48,6 @@ export function resolveBuiltinProfile (name: BuiltInProfile): { allowed: readonl
       'kb',
 
       // All stack commands (Elasticsearch + Kibana)
-      // Individual serverless-incompatible ES endpoints will be filtered in a
-      // future iteration once per-command availability metadata is added to the
-      // API manifest (see issue #283 for tracking).
       'stack.*',
 
       // Cloud cross-cutting namespaces (apply to both Hosted and Serverless)

--- a/test/cloud/register.test.ts
+++ b/test/cloud/register.test.ts
@@ -5,6 +5,7 @@
 
 import { describe, it } from 'node:test'
 import assert from 'node:assert/strict'
+import { z } from 'zod'
 import { registerCloudCommands, simplifyProjectCommandName } from '../../src/cloud/register.ts'
 import type { CloudApiDefinition } from '../../src/cloud/types.ts'
 
@@ -217,6 +218,21 @@ describe('registerCloudCommands', () => {
       const regions = group.commands.find((c) => c.name() === 'serverless')!
         .commands.find((c) => c.name() === 'regions')!
       assert.deepEqual(regions.commands.map((c) => c.name()), ['list-regions', 'get-region'])
+    })
+
+    it('exposes --name and --region-id flags on create project commands', () => {
+      const defs: CloudApiDefinition[] = [
+        { name: 'create-elasticsearch-project', namespace: 'elasticsearch-projects', description: 'Create', method: 'POST', path: '/api/v1/serverless/projects/elasticsearch',
+          body: z.object({ name: z.string(), region_id: z.string() }) },
+      ]
+      const group = registerCloudCommands(defs)
+      const createCmd = group.commands.find((c) => c.name() === 'serverless')!
+        .commands.find((c) => c.name() === 'projects')!
+        .commands.find((c) => c.name() === 'search')!
+        .commands.find((c) => c.name() === 'create')!
+      const flags = createCmd.options.map((o) => o.long)
+      assert.ok(flags.includes('--name'), '--name flag should be registered')
+      assert.ok(flags.includes('--region-id'), '--region-id flag should be registered')
     })
 
     it('adds --wait flag to create project commands only', () => {


### PR DESCRIPTION
## Summary

Closes #328.

`cloud serverless projects {search,observability,security} create` only showed generic flags (`--input-file`, `--wait`, etc.). The required body fields `name` and `region_id` had no flag equivalents, forcing users to write a JSON file just to set two scalars.

**Root cause**: the codegen API definitions for the three create commands had no `body` schema, so `buildCommandSchema` produced an empty `z.looseObject({})` with no derived flags.

**Fix**: add a `body: z.object({ name, region_id })` to each create definition. The existing `buildCommandSchema` -> `extractSchemaArgs` -> `defineCommand` pipeline handles the rest automatically, registering `--name` and `--region-id` flags and routing them into the POST body.

Before:
```
elastic cloud serverless projects search create --input-file /tmp/body.json --wait
```

After:
```
elastic cloud serverless projects search create --name cli-demo --region-id aws-us-east-1 --wait
```

Applies to all three project types: search, observability, security.

## Test plan

- [ ] `elastic cloud serverless projects search create --help` shows `--name` and `--region-id`
- [ ] `elastic cloud serverless projects observability create --help` shows `--name` and `--region-id`
- [ ] `elastic cloud serverless projects security create --help` shows `--name` and `--region-id`
- [ ] `--input-file` still works (flags merge on top of JSON input)
- [ ] New unit test passes: exposes --name and --region-id flags on create project commands
