### PR TITLE
docs: add ARCHITECTURE.md and link from AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,7 +16,10 @@ Avoid adding new third-party dependencies to reduce supply-chain attack surface.
 
 ## Architecture
 
+
 Commands are defined via shared config structures (see `factory.ts`). Custom logic is only permitted for behaviors that cannot be expressed in config.
+
+**Read [`ARCHITECTURE.md`](./ARCHITECTURE.md) before proposing structural changes.** It documents performance-critical design decisions (factory core split, per-endpoint API files, lazy loading, manifest format) that must not be refactored unless benchmarks prove the change is neutral.
 
 ## Command Authoring Requirements
 

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -1,0 +1,53 @@
+# Architecture Decisions
+
+Read this before proposing structural changes. Each section documents a deliberate choice made for startup performance or memory efficiency, validated by `scripts/perf-check`. Do not refactor these unless benchmarks prove the change is neutral.
+
+## Factory Core Split (`factory-core.ts` / `factory.ts`)
+
+`factory-core.ts` contains types and lightweight functions needed to build command groups and render `--help`. It deliberately avoids importing Zod, schema-args, output formatters, and the config store.
+
+`factory.ts` re-exports everything from `factory-core.ts` and adds the heavy command-definition logic.
+
+**Why**: Callers that only need group structure (e.g. lazy namespace registration) import `factory-core.ts` and skip the transitive cost of Zod and friends. Merging the two files would regress `--help` latency for every namespace.
+
+**Consumers**: `cli.ts`, `cloud/register-lazy.ts`, `namespaces.ts`, `es/register.ts` all import from `factory-core.ts` directly.
+
+## Per-Endpoint API Files (`src/es/apis/*.ts`)
+
+560 generated files, one per Elasticsearch endpoint. Each file exports a single `EsApiDefinition` array with its Zod input schema.
+
+**Why**: Loading all 560 schemas at once allocates several gigabytes of heap (see `elastic/cli#171`). The lazy barrel in `src/es/apis.ts` loads only the namespace file for the endpoint actually invoked, via `loadEsApi()` / `loadEsApisInFile()` with a per-file module cache.
+
+**Do not**: Collapse into a single file, eagerly import, or remove the per-file isolation.
+
+## API Manifests as TypeScript (`src/es/api-manifest.ts`, `src/kb/api-manifest.ts`)
+
+~6,400 lines of static metadata (names, HTTP methods, paths, descriptions) compiled as TypeScript rather than loaded from JSON at runtime.
+
+**Why**: V8 compiles TS/JS source into bytecode that is cached across runs. `JSON.parse(readFileSync(...))` on a 6K-line file is measurably slower at startup than importing a pre-compiled module, and it cannot benefit from V8's code cache.
+
+## `cli-schema.ts` — JSON Schema Emitter
+
+594-line module that derives JSON Schema from command configs for `--help --json` output.
+
+**Why**: Project requirement — every command must emit its full JSON Schema so agents can introspect valid inputs. Not redundant with Zod; it is the Zod-to-JSON-Schema bridge.
+
+## Lazy Loading in `es/register.ts`
+
+`defineCommand`, `handler`, `types`, and Zod are all loaded lazily via `createRequire` and dynamic `import()`. The top-level import graph for `elastic es --help` touches only Commander and the manifest.
+
+**Why**: `elastic es --help` must render in ~59 ms. Eagerly importing Zod or the handler module adds measurable latency.
+
+## Dependencies
+
+| Dependency | Used by | Why it stays |
+|---|---|---|
+| `cli-table3` | `src/output.ts` | Table rendering for human-readable output. `console.table` lacks formatting control. |
+| `csv-parse` | `src/es/helpers/shared.ts` | Full RFC 4180 CSV parsing for bulk ingest. A naive `split()` breaks on quoted fields, escapes, and multi-line values. |
+| `marked` + `marked-terminal` | `src/docs/renderer.ts` (4 consumers) | Terminal markdown rendering for `elastic docs` commands. |
+| `@elastic/config-resolver` | Config subsystem | Internal Elastic package. |
+| `@elastic/es-schemas` | Codegen source for API definitions | Internal Elastic package. |
+
+## `cli-schema-intent.ts`
+
+30-line helper that infers `CommandIntent` from HTTP methods. Used by `es/register.ts` and `kb/register.ts`. Small enough to inline, but kept as a separate module for clarity. No performance implications either way.


### PR DESCRIPTION
I did a full audit of the codebase using [ponytail](https://github.com/DietrichGebert/ponytail), and all the recommendations it suggested were simplifications of the code that would introduce performance regressions. Fixing those regressions is why the code complexity was introduced in the first place.

So, I've added an ARCHITECTURE.md file, linked from AGENTS.md, that explains each architectural choice, why it exists, and why it should not be removed, unless the improvement can avoid a perf regression.
