### PR TITLE
docs: flatten toc to remove duplicate Elastic CLI nav entry

### DIFF
--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -3,9 +3,8 @@ dev_docs: true
 
 toc:
   - file: index.md
-    children:
-      - file: cli/installation.md
-      - file: cli/configuration.md
+  - file: cli/installation.md
+  - file: cli/configuration.md
   - cli: cli/schema.json
     folder: cli
     title: Elastic CLI command reference


### PR DESCRIPTION
## Summary

- Removes the `children` nesting from `index.md` in `docs/docset.yml`
- Lists `cli/installation.md` and `cli/configuration.md` as siblings at the docset toc root instead

## Why

When `index.md` is declared as a group node (with `children`), docs-builder renders it as an inner collapsible "Elastic CLI" section nested inside the docset's own outer "Elastic CLI" nav wrapper — resulting in a duplicated heading visible in the Reference nav.

Flattening the toc makes `index.md` a plain landing page leaf, with installation and configuration listed as direct siblings, so only one "Elastic CLI" entry appears in the nav.

## Related

Companion to [elastic/docs-builder#3416](https://github.com/elastic/docs-builder/pull/3416).

🤖 Generated with [Claude Code](https://claude.com/claude-code)