### PR TITLE
docs: improve elastic-cli overview page

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -8,4 +8,13 @@ type: overview
 
 # Elastic CLI
 
-Interact with the Elastic Stack and Elastic Cloud from the command line.
+The Elastic CLI (`elastic`) is the command-line interface for Elasticsearch, Kibana, and Elastic Cloud resources. It supports self-managed Elastic Stack deployments, Elastic Cloud Hosted, and Elastic Serverless projects.
+
+:::{note}
+The Elastic CLI is a technical preview and is under active development. Not all features and APIs are supported yet.
+:::
+
+To get started, visit [Install the Elastic CLI](./cli/installation.md) and [Configure the Elastic CLI](./cli/configuration.md). 
+
+For a full list of available commands, refer to the [Elastic CLI command reference](./cli/index.md).
+


### PR DESCRIPTION
Expands the top-level docs/index.md from a one-liner into a proper overview page, following the pattern of sibling reference sections 

Adds a preview note, links to installation, configuration, and command reference child pages.