### PR TITLE
fix(ci): switch ai workflows to openrouter

### DIFF
--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -27,7 +27,8 @@ jobs:
 
       - name: Review
         env:
-          LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}
+          OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+          OPENROUTER_BASE_URL: ${{ secrets.OPENROUTER_BASE_URL }}
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_TITLE: ${{ github.event.pull_request.title }}
@@ -50,8 +51,8 @@ jobs:
         run: |
           set -euo pipefail
 
-          if [ -z "${LITELLM_API_KEY:-}" ]; then
-            echo "LITELLM_API_KEY not available, skipping review"
+          if [ -z "${OPENROUTER_API_KEY:-}" ]; then
+            echo "OPENROUTER_API_KEY not available, skipping review"
             exit 0
           fi
 
@@ -62,7 +63,7 @@ jobs:
             --arg diff "$DIFF" \
             --arg system "$SYSTEM_PROMPT" \
             '{
-              model: "llm-gateway/claude-sonnet-4-6",
+              model: "anthropic/claude-sonnet-4.6",
               max_tokens: 1024,
               messages: [
                 {role: "system", content: $system},
@@ -70,10 +71,11 @@ jobs:
               ]
             }' > /tmp/payload.json
 
+          BASE_URL="${OPENROUTER_BASE_URL:-https://openrouter.ai/api/v1}"
           RESPONSE=$(curl -sf \
-            -H "Authorization: Bearer ${LITELLM_API_KEY}" \
+            -H "Authorization: Bearer ${OPENROUTER_API_KEY}" \
             -H "Content-Type: application/json" \
-            "https://elastic.litellm-prod.ai/v1/chat/completions" \
+            "${BASE_URL%/}/chat/completions" \
             -d @/tmp/payload.json)
 
           CONTENT=$(echo "$RESPONSE" | jq -r '.choices[0].message.content // empty')

--- a/.github/workflows/auto-pr.yml
+++ b/.github/workflows/auto-pr.yml
@@ -16,4 +16,5 @@ jobs:
       issue_number: ${{ github.event.issue.number }}
       search_directory: packages
     secrets:
-      LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}
+      OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+      OPENROUTER_BASE_URL: ${{ secrets.OPENROUTER_BASE_URL }}

--- a/.github/workflows/resolve-conflicts.yml
+++ b/.github/workflows/resolve-conflicts.yml
@@ -10,10 +10,15 @@ permissions:
 
 jobs:
   resolve:
+    if: |
+      (github.event.comment.user.login == 'github-actions[bot]' ||
+       github.event.comment.user.login == 'elastic-vault-github-plugin-prod[bot]') &&
+      contains(github.event.comment.body, 'To backport manually, run these commands')
     uses: elastic/clients-team-automations/.github/workflows/ai-backport-resolver.yml@main
     with:
       comment_body: ${{ github.event.comment.body }}
       comment_user: ${{ github.event.comment.user.login }}
       pr_number: ${{ github.event.issue.number }}
     secrets:
-      LITELLM_API_KEY: ${{ secrets.LITELLM_API_KEY }}
+      OPENROUTER_API_KEY: ${{ secrets.OPENROUTER_API_KEY }}
+      OPENROUTER_BASE_URL: ${{ secrets.OPENROUTER_BASE_URL }}


### PR DESCRIPTION
This repo's `LITELLM_API_KEY` secret was replaced with `OPENROUTER_API_KEY`/`OPENROUTER_BASE_URL`, which currently breaks the backport resolver, auto-pr, and AI PR review workflows since they still reference the old secret. Switches all three to OpenRouter, matching `elastic/clients-team-automations#37` and `elastic/clients-team-automations#38`.

`resolve-conflicts.yml` also gets a job-level `if` so it skips non-backport comments before invoking the reusable workflow, instead of spinning up a runner for every comment in the repo.