### PR TITLE
fix(secret-store): pass secrets via stdin instead of argv on macOS and Windows

### DIFF
--- a/src/config/secret-store.ts
+++ b/src/config/secret-store.ts
@@ -146,12 +146,11 @@ class MacOSKeychainStore extends ShellSecretStore {
     validateServiceAccount(service, account, this.kind)
     try {
       // -U updates an existing entry in-place instead of failing.
-      // Use -w with the value as an argument; `security` supports reading from
-      // stdin via `-w` with no value, but argv is simpler and the value is
-      // ASCII-safe after validation.
+      // -w with no argument reads the password from stdin, keeping the secret
+      // out of the process argument list.
       _execSync(
-        `security add-generic-password -U -s ${shellEscape(service)} -a ${shellEscape(account)} -w ${shellEscape(secret)}`,
-        execOpts(5_000)
+        `security add-generic-password -U -s ${shellEscape(service)} -a ${shellEscape(account)} -w`,
+        execOpts(5_000, secret)
       )
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
@@ -275,12 +274,11 @@ class WindowsCredentialManagerStore extends ShellSecretStore {
     validateServiceAccount(service, account, this.kind)
     const target = this.target(service, account).replace(/'/g, "''")
     const user = account.replace(/'/g, "''")
-    const pass = secret.replace(/'/g, "''")
     const expression =
-      `$secure = ConvertTo-SecureString -String '${pass}' -AsPlainText -Force; ` +
+      `$secure = ConvertTo-SecureString -String ([Console]::In.ReadToEnd().Trim()) -AsPlainText -Force; ` +
       `New-StoredCredential -Target '${target}' -UserName '${user}' -SecurePassword $secure -Persist LocalMachine | Out-Null`
     try {
-      _execSync(psEncodedCommand(expression), execOpts(10_000))
+      _execSync(psEncodedCommand(expression), execOpts(10_000, secret))
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
       throw new Error(`Credential Manager write failed for service="${service}", account="${account}": ${message}`, { cause: err })

--- a/src/config/secret-store.ts
+++ b/src/config/secret-store.ts
@@ -275,7 +275,7 @@ class WindowsCredentialManagerStore extends ShellSecretStore {
     const target = this.target(service, account).replace(/'/g, "''")
     const user = account.replace(/'/g, "''")
     const expression =
-      `$secure = ConvertTo-SecureString -String ([Console]::In.ReadToEnd().Trim()) -AsPlainText -Force; ` +
+      `$secure = ConvertTo-SecureString -String ([Console]::In.ReadToEnd().TrimEnd(@([char]"\`n", [char]"\`r"))) -AsPlainText -Force; ` +
       `New-StoredCredential -Target '${target}' -UserName '${user}' -SecurePassword $secure -Persist LocalMachine | Out-Null`
     try {
       _execSync(psEncodedCommand(expression), execOpts(10_000, secret))

--- a/test/config/secret-store.test.ts
+++ b/test/config/secret-store.test.ts
@@ -92,7 +92,7 @@ describe('MacOSKeychainStore', () => {
     while (restores.length > 0) restores.pop()!()
   })
 
-  it('put invokes `security add-generic-password -U` with shell-escaped values', async () => {
+  it('put invokes `security add-generic-password -U` with shell-escaped values and passes secret via stdin', async () => {
     const { fn, calls } = makeExec([{ match: 'security ', result: '' }])
     restores.push(_testSetExecSync(fn))
     const store = new _testStores.MacOSKeychainStore()
@@ -102,7 +102,10 @@ describe('MacOSKeychainStore', () => {
     assert.match(put.cmd, /-U /)
     assert.match(put.cmd, /-s 'elastic-cli'/)
     assert.match(put.cmd, /-a 'prod:es.api_key'/)
-    assert.match(put.cmd, /-w 'it'\\''s secret'/)
+    // Secret must NOT appear in the command string (would be visible in `ps`)
+    assert.ok(!put.cmd.includes("it's secret"), 'secret must not be in argv')
+    // Secret IS passed via stdin
+    assert.equal((put.options as { input?: string }).input, "it's secret")
   })
 
   it('delete swallows errors (idempotent)', async () => {
@@ -215,14 +218,20 @@ describe('WindowsCredentialManagerStore', () => {
     while (restores.length > 0) restores.pop()!()
   })
 
-  it('put invokes powershell with an EncodedCommand', async () => {
+  it('put invokes powershell with an EncodedCommand and passes secret via stdin', async () => {
     const { fn, calls } = makeExec([{ match: 'powershell ', result: '' }])
     restores.push(_testSetExecSync(fn))
     const store = new _testStores.WindowsCredentialManagerStore()
-    await store.put('elastic-cli', 'prod:k', 'secret')
+    await store.put('elastic-cli', 'prod:k', 's3cr3t!')
     const put = calls.find(c => c.cmd.startsWith('powershell '))!
     assert.ok(put)
     assert.match(put.cmd, /EncodedCommand /)
+    // Decode the EncodedCommand base64 and confirm the secret is not embedded in it
+    const b64 = put.cmd.replace(/^.*EncodedCommand /, '')
+    const decoded = Buffer.from(b64, 'base64').toString('utf16le')
+    assert.ok(!decoded.includes('s3cr3t!'), 'secret must not be in the EncodedCommand')
+    // Secret IS passed via stdin
+    assert.equal((put.options as { input?: string }).input, 's3cr3t!')
   })
 
   it('resolverExpr produces a credential_manager: expression', () => {


### PR DESCRIPTION
Closes #515.