### PR TITLE
fix: tolerate sigpipe truncating large ai review diffs

### DIFF
--- a/.github/workflows/ai-pr-review-external.yml
+++ b/.github/workflows/ai-pr-review-external.yml
@@ -22,7 +22,7 @@ jobs:
           GH_REPO: ${{ github.repository }}
           PR_NUMBER: ${{ github.event.issue.number }}
         run: |
-          gh pr diff "$PR_NUMBER" | head -c 32000 > /tmp/diff.txt
+          gh pr diff "$PR_NUMBER" | head -c 32000 > /tmp/diff.txt || true
 
       - name: Review
         env:

--- a/.github/workflows/ai-pr-review.yml
+++ b/.github/workflows/ai-pr-review.yml
@@ -30,11 +30,11 @@ jobs:
             echo "Reviewing changes since previous review ($PREV_SHA)"
             echo "incremental" > /tmp/review_mode.txt
             gh api "repos/${GH_REPO}/compare/${PREV_SHA}...${HEAD_SHA}" \
-              -H "Accept: application/vnd.github.v3.diff" | head -c 32000 > /tmp/diff.txt
+              -H "Accept: application/vnd.github.v3.diff" | head -c 32000 > /tmp/diff.txt || true
           else
             echo "No prior review found, reviewing full PR diff"
             echo "full" > /tmp/review_mode.txt
-            gh pr diff "$PR_NUMBER" | head -c 32000 > /tmp/diff.txt
+            gh pr diff "$PR_NUMBER" | head -c 32000 > /tmp/diff.txt || true
           fi
 
       - name: Review


### PR DESCRIPTION
The diff-fetching step pipes to \`head -c 32000\` under \`pipefail\` (explicit in \`ai-pr-review.yml\`, implicit via GitHub Actions' default bash invocation in \`ai-pr-review-external.yml\`). Once \`head\` has its 32000 bytes it closes the pipe, the upstream \`gh pr diff\`/\`gh api compare\` gets SIGPIPE on its next write, and \`pipefail\` turns that into a step failure (exit 141), even though the truncated file is exactly what's wanted. Happens on any PR whose diff exceeds 32000 bytes, e.g. elastic/cli#537.