### PR TITLE
fix(docs): correct version command schema and config nav hierarchy

### DIFF
--- a/docs/cli/schema.json
+++ b/docs/cli/schema.json
@@ -59,15 +59,7 @@
     {
       "path": [],
       "name": "version",
-      "parameters": [
-        {
-          "role": "dryRun",
-          "name": "dry-run",
-          "type": "boolean",
-          "required": false,
-          "summary": "validate all inputs and exit without performing any action"
-        }
-      ],
+      "parameters": [],
       "summary": "Print the elastic CLI version",
       "intent": {
         "requiresAuth": false

--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -6,7 +6,7 @@ toc:
   - file: cli/installation.md
   - file: cli/configuration.md
     children:
-      - file: cli/configuration_reference.md
+      - file: configuration_reference.md
   - cli: cli/schema.json
     folder: cli
     title: Elastic CLI command reference

--- a/docs/docset.yml
+++ b/docs/docset.yml
@@ -5,7 +5,8 @@ toc:
   - file: index.md
   - file: cli/installation.md
   - file: cli/configuration.md
-  - file: cli/configuration_reference.md
+    children:
+      - file: cli/configuration_reference.md
   - cli: cli/schema.json
     folder: cli
     title: Elastic CLI command reference

--- a/src/cli-schema.ts
+++ b/src/cli-schema.ts
@@ -526,11 +526,7 @@ export async function registerCliSchemaCommand (
       const schemaRoot = new Command(rootProgram?.name() ?? 'elastic')
       schemaRoot.description(rootProgram?.description() ?? '')
 
-      schemaRoot.addCommand(defineCommand({
-        name: 'version',
-        description: 'Print the elastic CLI version',
-        handler: () => ({ version }),
-      }))
+      schemaRoot.addCommand(new Command('version').description('Print the elastic CLI version'))
 
       const loaded = await Promise.all(namespaces.map((ns) => ns.load({ eager: true })))
       for (const ns of loaded) schemaRoot.addCommand(ns)


### PR DESCRIPTION
## Summary

- Removes `--dry-run` from the `version` command in `docs/cli/schema.json` — the CLI binary rejects the flag at runtime with `error: unknown option '--dry-run'`. Closes #554.
- Nests `configuration_reference.md` under `configuration.md` in `docs/docset.yml` so the config reference appears as a child page in the nav. Addresses the nav nit raised in #100.

## Test plan

- [ ] Verify `elastic version --dry-run` is no longer listed in the rendered reference docs
- [ ] Verify the Configuration reference page appears nested under Configuration in the docs nav

Part of #100.