### PR TITLE
docs: add agent build skills

### DIFF
--- a/.claude/skills/build-failure.md
+++ b/.claude/skills/build-failure.md
@@ -1,0 +1,26 @@
+---
+name: build-failure
+description: Diagnose Elastic CLI CI and local build failures.
+---
+
+# Build failure
+
+Read the failing job log before changing code. Match the symptom, then apply the fix.
+
+JavaScript heap out of memory / `tsc` killed: set `NODE_OPTIONS=--max-old-space-size=8192` (CI already uses 6144). Do not lower memory to make a test pass.
+
+`docs/cli/schema.json` is out of date: `npm run build && npm run build:schema`, commit the file. Same-repo PRs can let CI commit it.
+
+`NOTICE.txt` is out of date: `node scripts/generate-notice.mjs`, commit if it changed.
+
+PR title rejected: conventional commits, lowercase type, no trailing period. Example: `fix: redact cloud credentials`.
+
+Edited generated API files: revert `src/es/apis/`, `src/es/api-manifest.ts`, `src/kb/apis.ts`, `src/kb/api-manifest.ts`. Fix the generator or a hand-maintained file (`src/es/register.ts`, `src/factory.ts`) instead.
+
+MegaLinter / pre-commit: Docker must be running. Fix the flagged files; do not `--no-verify`.
+
+Windows path or spawn failures: use `path.join`, no hard-coded `/`. Tests must pass on Windows, macOS, and Linux.
+
+Functional tests: `ELASTIC_CLI_CONFIG_FILE` must be unset unless pointing at an intentional fixture. Kibana functional tests need `kibana_system`, not `elastic`.
+
+`npm ci` lock mismatch: do not hand-edit `package-lock.json`. Change `package.json` and re-run `npm install`.

--- a/.claude/skills/build.md
+++ b/.claude/skills/build.md
@@ -1,0 +1,27 @@
+---
+name: build
+description: Install, compile, and verify a clean Elastic CLI checkout.
+---
+
+# Build
+
+Node.js 22+. If `tsc` OOMs, set `NODE_OPTIONS=--max-old-space-size=8192`.
+
+```bash
+npm ci
+npm run build
+npm test
+```
+
+`npm test` already runs `npm run build` then unit tests. `npm ci` for CI and clean checkouts; `npm install` is fine locally.
+
+```bash
+npx tsc --noEmit
+npm run test:lint
+node scripts/generate-notice.mjs
+npm run build:schema
+```
+
+Commit `NOTICE.txt` after dependency changes and `docs/cli/schema.json` after command or flag changes.
+
+Do not edit `src/es/apis/*.ts`, `src/es/api-manifest.ts`, `src/kb/apis.ts`, or `src/kb/api-manifest.ts`. Unset `ELASTIC_CLI_CONFIG_FILE` before running the built binary against a real cluster.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,8 +24,23 @@ See [CONTRIBUTING.md](./CONTRIBUTING.md) for the full policy.
 
 Avoid adding new third-party dependencies to reduce supply-chain attack surface.
 
-## Architecture
+## Setup
 
+Node.js 22 or later. `tsc` can peak around 3.7 GB; if the process OOMs, set `NODE_OPTIONS=--max-old-space-size=8192`.
+
+```bash
+npm ci
+npm run build
+npm test
+```
+
+Use `npm ci` in CI and for a clean checkout. `npm install` is fine locally. Unset `ELASTIC_CLI_CONFIG_FILE` before running the built CLI against a real cluster.
+
+After dependency changes, run `node scripts/generate-notice.mjs` and commit `NOTICE.txt` if it changed. After command or flag changes, run `npm run build:schema` and commit `docs/cli/schema.json`.
+
+Do not edit generated files: `src/es/apis/*.ts`, `src/es/api-manifest.ts`, `src/kb/apis.ts`, `src/kb/api-manifest.ts`.
+
+## Architecture
 
 Commands are defined via shared config structures (see `factory.ts`). Custom logic is only permitted for behaviors that cannot be expressed in config.
 


### PR DESCRIPTION
moves the [Build stage](https://cautious-adventure-y876j1o.pages.github.io/#/repo/elastic%2Fcli/stage/build) from documented commands (level 1) to agent-invokable skills (level 2): `AGENTS.md` setup, plus `.claude/skills/build.md` and `.claude/skills/build-failure.md`.