### PR TITLE
fix: bump @elastic/schemas to 0.7.1

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -221,7 +221,7 @@ released to the public npm registry; depend on it through the workspace.
 
 
 ------------------------------------------------------------------------
-@elastic/schemas@0.7.0
+@elastic/schemas@0.7.1
 License: Apache-2.0
 Repository: https://github.com/elastic/schemas-js
 Publisher: Elastic Client Library Maintainers

--- a/docs/cli/schema.json
+++ b/docs/cli/schema.json
@@ -58574,6 +58574,62 @@
                     "kb",
                     "agent-builder"
                   ],
+                  "name": "post-agent-builder-conversations",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "access-control",
+                      "type": "string",
+                      "required": false,
+                      "summary": "Optional access control settings. Defaults to private."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "agent-id",
+                      "type": "string",
+                      "required": false,
+                      "summary": "The ID of the agent to associate with the conversation. Defaults to the default Elastic AI agent."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "conversation-id",
+                      "type": "string",
+                      "required": false,
+                      "summary": "Optional client-supplied UUID for the conversation. Server-generated if omitted."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "title",
+                      "type": "string",
+                      "required": false,
+                      "summary": "Title for the conversation. Defaults to \"New conversation\"."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Create conversation",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "agent-builder"
+                  ],
                   "name": "delete-agent-builder-conversations-conversation-id",
                   "parameters": [
                     {
@@ -58644,6 +58700,62 @@
                     }
                   ],
                   "summary": "Get conversation by ID",
+                  "intent": {
+                    "destructive": false,
+                    "idempotent": true,
+                    "scope": "global",
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "agent-builder"
+                  ],
+                  "name": "put-agent-builder-conversations-conversation-id-access-control",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "conversation-id",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The unique identifier of the conversation whose access control to update."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "access-mode",
+                      "type": "enum",
+                      "required": true,
+                      "summary": "Access-control mode: `private` (only the owner and the listed members can read and continue the conversation), `public` (any user with access to the conversation's agent can read and continue it).",
+                      "enumValues": [
+                        "private",
+                        "public"
+                      ]
+                    },
+                    {
+                      "role": "flag",
+                      "name": "entries",
+                      "type": "array",
+                      "required": true,
+                      "summary": "Members to share the conversation with. The list replaces the stored one; submit an empty list to unshare. Entries naming the owner are ignored. Must be empty when `access_mode` is `public`; repeated ids are rejected."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Update a conversation's access control",
                   "intent": {
                     "destructive": false,
                     "idempotent": true,
@@ -59131,13 +59243,6 @@
                     },
                     {
                       "role": "flag",
-                      "name": "capabilities",
-                      "type": "string",
-                      "required": false,
-                      "summary": "Controls agent capabilities during conversation. Currently supports visualization rendering for tabular tool results."
-                    },
-                    {
-                      "role": "flag",
                       "name": "configuration-overrides",
                       "type": "string",
                       "required": false,
@@ -59177,6 +59282,13 @@
                       "type": "string",
                       "required": false,
                       "summary": "The user input message to send to the agent."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "project-routing",
+                      "type": "string",
+                      "required": false,
+                      "summary": "Cross-project search routing expression resolved from the header project picker, applied to the run's searches. Serverless (CPS) only; ignored elsewhere."
                     },
                     {
                       "role": "flag",
@@ -59271,13 +59383,6 @@
                     },
                     {
                       "role": "flag",
-                      "name": "capabilities",
-                      "type": "string",
-                      "required": false,
-                      "summary": "Controls agent capabilities during conversation. Currently supports visualization rendering for tabular tool results."
-                    },
-                    {
-                      "role": "flag",
                       "name": "configuration-overrides",
                       "type": "string",
                       "required": false,
@@ -59317,6 +59422,13 @@
                       "type": "string",
                       "required": false,
                       "summary": "The user input message to send to the agent."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "project-routing",
+                      "type": "string",
+                      "required": false,
+                      "summary": "Cross-project search routing expression resolved from the header project picker, applied to the run's searches. Serverless (CPS) only; ignored elsewhere."
                     },
                     {
                       "role": "flag",
@@ -61323,6 +61435,2650 @@
               "summary": "Kibana alerting API commands"
             },
             {
+              "segment": "alerting-v2",
+              "commands": [
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "get-alerting-v2-action-policies",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "page",
+                      "type": "number",
+                      "required": false,
+                      "summary": "The page number to return. Defaults to 1."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "per-page",
+                      "type": "number",
+                      "required": false,
+                      "summary": "The number of action policies to return per page. Defaults to 20."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "search",
+                      "type": "string",
+                      "required": false,
+                      "summary": "A text string to search across action policy fields."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "tags",
+                      "type": "array",
+                      "required": false,
+                      "summary": "Filter by tags. Accepts a single string or an array.",
+                      "elementType": "string"
+                    },
+                    {
+                      "role": "flag",
+                      "name": "enabled",
+                      "type": "enum",
+                      "required": false,
+                      "summary": "Filter by enabled status. Accepts the strings true or false.",
+                      "enumValues": [
+                        "true",
+                        "false"
+                      ]
+                    },
+                    {
+                      "role": "flag",
+                      "name": "sort-field",
+                      "type": "enum",
+                      "required": false,
+                      "summary": "The field to sort action policies by.",
+                      "enumValues": [
+                        "name",
+                        "created_at",
+                        "updated_at"
+                      ]
+                    },
+                    {
+                      "role": "flag",
+                      "name": "sort-order",
+                      "type": "enum",
+                      "required": false,
+                      "summary": "The sort direction.",
+                      "enumValues": [
+                        "asc",
+                        "desc"
+                      ]
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "List action policies",
+                  "intent": {
+                    "destructive": false,
+                    "idempotent": true,
+                    "scope": "global",
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "post-alerting-v2-action-policies",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "description",
+                      "type": "string",
+                      "required": true,
+                      "summary": "A description of the action policy."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "destinations",
+                      "type": "array",
+                      "required": true,
+                      "summary": "The list of destinations. At least one is required."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "group-by",
+                      "type": "array",
+                      "required": false,
+                      "summary": "The fields used to group alerts.",
+                      "elementType": "string"
+                    },
+                    {
+                      "role": "flag",
+                      "name": "grouping-mode",
+                      "type": "string",
+                      "required": false,
+                      "summary": "The grouping mode for alert notifications."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "matcher",
+                      "type": "string",
+                      "required": false,
+                      "summary": "A KQL query string to match alerts."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "name",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The name of the action policy."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "tags",
+                      "type": "array",
+                      "required": false,
+                      "summary": "Tags for categorizing the action policy.",
+                      "elementType": "string"
+                    },
+                    {
+                      "role": "flag",
+                      "name": "throttle",
+                      "type": "string",
+                      "required": false,
+                      "summary": "The throttle configuration for notifications."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Create an action policy",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "post-alerting-v2-action-policies-bulk-delete",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "ids",
+                      "type": "array",
+                      "required": true,
+                      "summary": "Explicit list of IDs to operate on.",
+                      "elementType": "string"
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Delete action policies in bulk by ID",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "post-alerting-v2-action-policies-bulk-disable",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "ids",
+                      "type": "array",
+                      "required": true,
+                      "summary": "Explicit list of IDs to operate on.",
+                      "elementType": "string"
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Disable action policies in bulk by ID",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "post-alerting-v2-action-policies-bulk-enable",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "ids",
+                      "type": "array",
+                      "required": true,
+                      "summary": "Explicit list of IDs to operate on.",
+                      "elementType": "string"
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Enable action policies in bulk by ID",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "post-alerting-v2-action-policies-bulk-snooze",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "ids",
+                      "type": "array",
+                      "required": true,
+                      "summary": "Explicit list of IDs to operate on.",
+                      "elementType": "string"
+                    },
+                    {
+                      "role": "flag",
+                      "name": "snoozed-until",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The ISO datetime until which the targeted action policies should be snoozed."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Snooze action policies in bulk by ID",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "post-alerting-v2-action-policies-bulk-unsnooze",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "ids",
+                      "type": "array",
+                      "required": true,
+                      "summary": "Explicit list of IDs to operate on.",
+                      "elementType": "string"
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Cancel snooze for action policies in bulk by ID",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "post-alerting-v2-action-policies-bulk-update-api-key",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "ids",
+                      "type": "array",
+                      "required": true,
+                      "summary": "Explicit list of IDs to operate on.",
+                      "elementType": "string"
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Rotate API keys for action policies in bulk by ID",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "post-alerting-v2-action-policies-match-for-rule",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "rule",
+                      "type": "string",
+                      "required": false
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Match action policies for a rule",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "delete-alerting-v2-action-policies-id",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "id",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The action policy identifier."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    },
+                    {
+                      "role": "flag",
+                      "name": "yes",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "confirm destructive action without prompting"
+                    }
+                  ],
+                  "summary": "Delete an action policy",
+                  "intent": {
+                    "destructive": true,
+                    "idempotent": true,
+                    "scope": "global",
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "get-alerting-v2-action-policies-id",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "id",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The action policy identifier."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Get an action policy",
+                  "intent": {
+                    "destructive": false,
+                    "idempotent": true,
+                    "scope": "global",
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "patch-alerting-v2-action-policies-id",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "id",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The action policy identifier."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "description",
+                      "type": "string",
+                      "required": false,
+                      "summary": "A description of the action policy."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "destinations",
+                      "type": "array",
+                      "required": false,
+                      "summary": "The list of destinations. At least one is required."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "group-by",
+                      "type": "string",
+                      "required": false,
+                      "summary": "The fields used to group alerts.",
+                      "repeatable": true,
+                      "separator": ","
+                    },
+                    {
+                      "role": "flag",
+                      "name": "grouping-mode",
+                      "type": "string",
+                      "required": false,
+                      "summary": "The grouping mode for alert notifications."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "matcher",
+                      "type": "string",
+                      "required": false,
+                      "summary": "A KQL query string to match alerts."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "name",
+                      "type": "string",
+                      "required": false,
+                      "summary": "The name of the action policy."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "tags",
+                      "type": "string",
+                      "required": false,
+                      "summary": "Tags for categorizing the action policy.",
+                      "repeatable": true,
+                      "separator": ","
+                    },
+                    {
+                      "role": "flag",
+                      "name": "throttle",
+                      "type": "string",
+                      "required": false,
+                      "summary": "The throttle configuration for notifications."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "version",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The current version of the action policy, used for optimistic concurrency control."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Partially update an action policy.",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "put-alerting-v2-action-policies-id",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "id",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The identifier for the action policy."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "description",
+                      "type": "string",
+                      "required": true,
+                      "summary": "A description of the action policy."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "destinations",
+                      "type": "array",
+                      "required": true,
+                      "summary": "The list of destinations. At least one is required."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "group-by",
+                      "type": "array",
+                      "required": false,
+                      "summary": "The fields used to group alerts.",
+                      "elementType": "string"
+                    },
+                    {
+                      "role": "flag",
+                      "name": "grouping-mode",
+                      "type": "string",
+                      "required": false,
+                      "summary": "The grouping mode for alert notifications."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "matcher",
+                      "type": "string",
+                      "required": false,
+                      "summary": "A KQL query string to match alerts."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "name",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The name of the action policy."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "tags",
+                      "type": "array",
+                      "required": false,
+                      "summary": "Tags for categorizing the action policy.",
+                      "elementType": "string"
+                    },
+                    {
+                      "role": "flag",
+                      "name": "throttle",
+                      "type": "string",
+                      "required": false,
+                      "summary": "The throttle configuration for notifications."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Create or replace an action policy",
+                  "intent": {
+                    "destructive": false,
+                    "idempotent": true,
+                    "scope": "global",
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "post-alerting-v2-action-policies-id-disable",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "id",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The action policy identifier."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Disable an action policy",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "post-alerting-v2-action-policies-id-enable",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "id",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The action policy identifier."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Enable an action policy",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "post-alerting-v2-action-policies-id-snooze",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "id",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The action policy identifier."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "snoozed-until",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The ISO datetime until which the action policy should be snoozed."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Snooze an action policy",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "post-alerting-v2-action-policies-id-unsnooze",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "id",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The action policy identifier."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Unsnooze an action policy",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "post-alerting-v2-action-policies-id-update-api-key",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "id",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The action policy identifier."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Update an action policy API key",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "get-alerting-v2-action-policies-tags",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "search",
+                      "type": "string",
+                      "required": false,
+                      "summary": "Prefix to filter tags by. Returns all most-used tags when omitted."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Get action policy tags",
+                  "intent": {
+                    "destructive": false,
+                    "idempotent": true,
+                    "scope": "global",
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "post-alerting-v2-alerts-bulk-action",
+                  "parameters": [
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Bulk create alert actions",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "post-alerting-v2-alerts-group-hash-ack",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "group-hash",
+                      "type": "string",
+                      "required": true,
+                      "summary": "Hash identifying the alert group to apply the action to."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "episode-id",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The episode identifier for the alert to acknowledge."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Acknowledge an alert",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "post-alerting-v2-alerts-group-hash-activate",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "group-hash",
+                      "type": "string",
+                      "required": true,
+                      "summary": "Hash identifying the alert group to apply the action to."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "reason",
+                      "type": "string",
+                      "required": true,
+                      "summary": "Reason for activating the alert."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Activate an alert",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "post-alerting-v2-alerts-group-hash-assign",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "group-hash",
+                      "type": "string",
+                      "required": true,
+                      "summary": "Hash identifying the alert group to apply the action to."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "assignee-uid",
+                      "type": "string",
+                      "required": true,
+                      "summary": "User profile UID of the assignee, or null to remove the assignee from the episode."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "episode-id",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The episode identifier to assign."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Assign an alert to a user",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "post-alerting-v2-alerts-group-hash-deactivate",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "group-hash",
+                      "type": "string",
+                      "required": true,
+                      "summary": "Hash identifying the alert group to apply the action to."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "reason",
+                      "type": "string",
+                      "required": true,
+                      "summary": "Reason for deactivating the alert."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Deactivate an alert",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "post-alerting-v2-alerts-group-hash-snooze",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "group-hash",
+                      "type": "string",
+                      "required": true,
+                      "summary": "Hash identifying the alert group to apply the action to."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "expiry",
+                      "type": "string",
+                      "required": false,
+                      "summary": "ISO datetime when snooze should expire."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Snooze an alert",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "post-alerting-v2-alerts-group-hash-tag",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "group-hash",
+                      "type": "string",
+                      "required": true,
+                      "summary": "Hash identifying the alert group to apply the action to."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "tags",
+                      "type": "array",
+                      "required": true,
+                      "summary": "List of tags to add to the alert.",
+                      "elementType": "string"
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Add tags to an alert",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "post-alerting-v2-alerts-group-hash-unack",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "group-hash",
+                      "type": "string",
+                      "required": true,
+                      "summary": "Hash identifying the alert group to apply the action to."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "episode-id",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The episode identifier for the alert to unacknowledge."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Unacknowledge an alert",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "post-alerting-v2-alerts-group-hash-unsnooze",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "group-hash",
+                      "type": "string",
+                      "required": true,
+                      "summary": "Hash identifying the alert group to apply the action to."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Unsnooze an alert",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "get-alerting-v2-execution-history-action-policies",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "page",
+                      "type": "number",
+                      "required": false,
+                      "summary": "Page number (1-indexed). Defaults to 1."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "per-page",
+                      "type": "number",
+                      "required": false,
+                      "summary": "Number of events per page. Defaults to 20. Pass 0 for a count-only read."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "start-date",
+                      "type": "string",
+                      "required": false,
+                      "summary": "Inclusive ISO datetime lower bound on the event timestamp; overrides the default 24-hour window. Independent of episode_ids — e.g. set it to an episode’s start time to scope results to that episode’s lifetime."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "episode-ids",
+                      "type": "array",
+                      "required": false,
+                      "summary": "Episode filter. Narrows events to those referencing at least one of the provided episode ids.",
+                      "elementType": "string"
+                    },
+                    {
+                      "role": "flag",
+                      "name": "search",
+                      "type": "string",
+                      "required": false,
+                      "summary": "Free-text search. Matches policy name, rule name, policy/rule ID (case-insensitive)."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "rule-ids",
+                      "type": "array",
+                      "required": false,
+                      "summary": "Explicit rule filter. Narrows events to those referencing at least one of the provided rule ids. Also unions with the search filter if both are provided.",
+                      "elementType": "string"
+                    },
+                    {
+                      "role": "flag",
+                      "name": "outcome",
+                      "type": "array",
+                      "required": false,
+                      "summary": "Outcome filter. When omitted matches all outcomes. Pass one or more of \"dispatched\", \"throttled\", \"dispatch_failed\" to narrow."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "List action policy executions",
+                  "intent": {
+                    "destructive": false,
+                    "idempotent": true,
+                    "scope": "global",
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "get-alerting-v2-execution-history-rules",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "rule-ids",
+                      "type": "array",
+                      "required": false,
+                      "summary": "Rule id filter. ",
+                      "elementType": "string"
+                    },
+                    {
+                      "role": "flag",
+                      "name": "outcome",
+                      "type": "array",
+                      "required": false,
+                      "summary": "Outcome filter. "
+                    },
+                    {
+                      "role": "flag",
+                      "name": "from",
+                      "type": "string",
+                      "required": false,
+                      "summary": "Inclusive ISO datetime lower bound on event.start."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "to",
+                      "type": "string",
+                      "required": false,
+                      "summary": "Inclusive ISO datetime upper bound on event.start."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "sort",
+                      "type": "enum",
+                      "required": true,
+                      "summary": "Sort field. Defaults to started_at.",
+                      "enumValues": [
+                        "started_at",
+                        "duration"
+                      ]
+                    },
+                    {
+                      "role": "flag",
+                      "name": "sort-order",
+                      "type": "enum",
+                      "required": true,
+                      "summary": "Sort direction.",
+                      "enumValues": [
+                        "asc",
+                        "desc"
+                      ]
+                    },
+                    {
+                      "role": "flag",
+                      "name": "page",
+                      "type": "number",
+                      "required": true,
+                      "summary": "Page number."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "per-page",
+                      "type": "number",
+                      "required": true,
+                      "summary": "Number of results per page."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "List rule executions",
+                  "intent": {
+                    "destructive": false,
+                    "idempotent": true,
+                    "scope": "global",
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "get-alerting-v2-rules",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "page",
+                      "type": "number",
+                      "required": false,
+                      "summary": "The page number to return. Defaults to 1."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "per-page",
+                      "type": "number",
+                      "required": false,
+                      "summary": "The number of rules to return per page. Defaults to 20."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "filter",
+                      "type": "string",
+                      "required": false,
+                      "summary": "The filter to apply to the rules."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "sort-field",
+                      "type": "enum",
+                      "required": false,
+                      "summary": "The field to sort rules by.",
+                      "enumValues": [
+                        "kind",
+                        "enabled",
+                        "name"
+                      ]
+                    },
+                    {
+                      "role": "flag",
+                      "name": "sort-order",
+                      "type": "enum",
+                      "required": false,
+                      "summary": "The direction to sort rules.",
+                      "enumValues": [
+                        "asc",
+                        "desc"
+                      ]
+                    },
+                    {
+                      "role": "flag",
+                      "name": "search",
+                      "type": "string",
+                      "required": false,
+                      "summary": "A text string to search across rule fields."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "List rules",
+                  "intent": {
+                    "destructive": false,
+                    "idempotent": true,
+                    "scope": "global",
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "post-alerting-v2-rules",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "artifacts",
+                      "type": "array",
+                      "required": false,
+                      "summary": "Artifacts attached to the rule, each shaped as `{ id, type, data }`. `data` is a type-specific object (for example a `runbook` may carry `content`, a `dashboard` may carry `dashboardId`). Per-type shape is validated by the artifact-type registry when the type is registered; unregistered types pass through with envelope bounds only."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "grouping",
+                      "type": "string",
+                      "required": false
+                    },
+                    {
+                      "role": "flag",
+                      "name": "kind",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The kind of the rule."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "metadata",
+                      "type": "string",
+                      "required": true
+                    },
+                    {
+                      "role": "flag",
+                      "name": "no-data-strategy",
+                      "type": "string",
+                      "required": false,
+                      "summary": "How to handle no-data situations. \"last_known_status\" holds the last known status; \"recover\" forces recovery; \"none\" disables no-data detection. \"emit\" is not currently accepted by the create/update API. Standalone-format rules must provide a `no_data` query block when this is not \"none\"; composed-format rules use `base` as the data-presence query."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "query",
+                      "type": "string",
+                      "required": true
+                    },
+                    {
+                      "role": "flag",
+                      "name": "recovery-strategy",
+                      "type": "string",
+                      "required": false,
+                      "summary": "How recovery is detected. \"no_breach\" recovers groups that stop breaching; \"query\" uses a custom recovery query; \"none\" disables recovery."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "schedule",
+                      "type": "string",
+                      "required": true
+                    },
+                    {
+                      "role": "flag",
+                      "name": "state-transition",
+                      "type": "string",
+                      "required": false,
+                      "summary": "Episode state transition thresholds (alert-only)."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "time-field",
+                      "type": "string",
+                      "required": false,
+                      "summary": "Time field used for the lookback window range filter."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Create a rule",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "post-alerting-v2-rules-bulk-delete",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "ids",
+                      "type": "array",
+                      "required": true,
+                      "summary": "Explicit list of IDs to operate on.",
+                      "elementType": "string"
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Delete rules in bulk by ID",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "post-alerting-v2-rules-bulk-disable",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "ids",
+                      "type": "array",
+                      "required": true,
+                      "summary": "Explicit list of IDs to operate on.",
+                      "elementType": "string"
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Disable rules in bulk by ID",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "post-alerting-v2-rules-bulk-enable",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "ids",
+                      "type": "array",
+                      "required": true,
+                      "summary": "Explicit list of IDs to operate on.",
+                      "elementType": "string"
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Enable rules in bulk by ID",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "post-alerting-v2-rules-bulk-get",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "ids",
+                      "type": "array",
+                      "required": true,
+                      "summary": "Rule identifiers to retrieve. The response preserved this order.",
+                      "elementType": "string"
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Get rules in bulk",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "post-alerting-v2-rules-bulk-update-api-key",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "ids",
+                      "type": "array",
+                      "required": true,
+                      "summary": "Explicit list of IDs to operate on.",
+                      "elementType": "string"
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Update the API key of rules in bulk by ID",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "post-alerting-v2-rules-delete-by-query",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "filter",
+                      "type": "string",
+                      "required": false,
+                      "summary": "KQL filter string to match target resources. At most 10000 matching resources are processed per request. Cannot be empty; to target every resource use `match_all: true`."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "force",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "When true, executes the operation. When false (default), returns a dry-run preview with `match_count` and a `sample` of matching resource IDs so the client can verify before committing."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "match-all",
+                      "type": "enum",
+                      "required": false,
+                      "summary": "When true, targets every resource. Requires an explicit opt-in. Omitted by default.",
+                      "enumValues": [
+                        "true"
+                      ]
+                    },
+                    {
+                      "role": "flag",
+                      "name": "search",
+                      "type": "string",
+                      "required": false,
+                      "summary": "Free-text search string matched against the resource-defined searchable fields. Cannot be empty; to target every resource use `match_all: true`."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Delete rules matching a query (dry-run by default)",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "post-alerting-v2-rules-disable-by-query",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "filter",
+                      "type": "string",
+                      "required": false,
+                      "summary": "KQL filter string to match target resources. At most 10000 matching resources are processed per request. Cannot be empty; to target every resource use `match_all: true`."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "force",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "When true, executes the operation. When false (default), returns a dry-run preview with `match_count` and a `sample` of matching resource IDs so the client can verify before committing."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "match-all",
+                      "type": "enum",
+                      "required": false,
+                      "summary": "When true, targets every resource. Requires an explicit opt-in. Omitted by default.",
+                      "enumValues": [
+                        "true"
+                      ]
+                    },
+                    {
+                      "role": "flag",
+                      "name": "search",
+                      "type": "string",
+                      "required": false,
+                      "summary": "Free-text search string matched against the resource-defined searchable fields. Cannot be empty; to target every resource use `match_all: true`."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Disable rules matching a query (dry-run by default)",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "post-alerting-v2-rules-enable-by-query",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "filter",
+                      "type": "string",
+                      "required": false,
+                      "summary": "KQL filter string to match target resources. At most 10000 matching resources are processed per request. Cannot be empty; to target every resource use `match_all: true`."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "force",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "When true, executes the operation. When false (default), returns a dry-run preview with `match_count` and a `sample` of matching resource IDs so the client can verify before committing."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "match-all",
+                      "type": "enum",
+                      "required": false,
+                      "summary": "When true, targets every resource. Requires an explicit opt-in. Omitted by default.",
+                      "enumValues": [
+                        "true"
+                      ]
+                    },
+                    {
+                      "role": "flag",
+                      "name": "search",
+                      "type": "string",
+                      "required": false,
+                      "summary": "Free-text search string matched against the resource-defined searchable fields. Cannot be empty; to target every resource use `match_all: true`."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Enable rules matching a query (dry-run by default)",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "post-alerting-v2-rules-update-api-key-by-query",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "filter",
+                      "type": "string",
+                      "required": false,
+                      "summary": "KQL filter string to match target resources. At most 10000 matching resources are processed per request. Cannot be empty; to target every resource use `match_all: true`."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "force",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "When true, executes the operation. When false (default), returns a dry-run preview with `match_count` and a `sample` of matching resource IDs so the client can verify before committing."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "match-all",
+                      "type": "enum",
+                      "required": false,
+                      "summary": "When true, targets every resource. Requires an explicit opt-in. Omitted by default.",
+                      "enumValues": [
+                        "true"
+                      ]
+                    },
+                    {
+                      "role": "flag",
+                      "name": "search",
+                      "type": "string",
+                      "required": false,
+                      "summary": "Free-text search string matched against the resource-defined searchable fields. Cannot be empty; to target every resource use `match_all: true`."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Update the API key of rules matching a query (dry-run by default)",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "delete-alerting-v2-rules-id",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "id",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The identifier for the rule."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    },
+                    {
+                      "role": "flag",
+                      "name": "yes",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "confirm destructive action without prompting"
+                    }
+                  ],
+                  "summary": "Delete a rule",
+                  "intent": {
+                    "destructive": true,
+                    "idempotent": true,
+                    "scope": "global",
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "get-alerting-v2-rules-id",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "id",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The identifier for the rule."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Get a rule",
+                  "intent": {
+                    "destructive": false,
+                    "idempotent": true,
+                    "scope": "global",
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "patch-alerting-v2-rules-id",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "id",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The identifier for the rule."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "artifacts",
+                      "type": "string",
+                      "required": false,
+                      "summary": "Artifacts attached to the rule, each shaped as `{ id, type, data }`. `data` is a type-specific object (for example a `runbook` may carry `content`, a `dashboard` may carry `dashboardId`). Per-type shape is validated by the artifact-type registry when the type is registered; unregistered types pass through with envelope bounds only.",
+                      "repeatable": true,
+                      "separator": ","
+                    },
+                    {
+                      "role": "flag",
+                      "name": "grouping",
+                      "type": "string",
+                      "required": false
+                    },
+                    {
+                      "role": "flag",
+                      "name": "metadata",
+                      "type": "string",
+                      "required": false
+                    },
+                    {
+                      "role": "flag",
+                      "name": "no-data-strategy",
+                      "type": "string",
+                      "required": false
+                    },
+                    {
+                      "role": "flag",
+                      "name": "query",
+                      "type": "string",
+                      "required": false
+                    },
+                    {
+                      "role": "flag",
+                      "name": "recovery-strategy",
+                      "type": "string",
+                      "required": false
+                    },
+                    {
+                      "role": "flag",
+                      "name": "schedule",
+                      "type": "string",
+                      "required": false
+                    },
+                    {
+                      "role": "flag",
+                      "name": "state-transition",
+                      "type": "string",
+                      "required": false
+                    },
+                    {
+                      "role": "flag",
+                      "name": "time-field",
+                      "type": "string",
+                      "required": false
+                    },
+                    {
+                      "role": "flag",
+                      "name": "version",
+                      "type": "string",
+                      "required": false,
+                      "summary": "The current version of the rule, used for optimistic concurrency control."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Update a rule",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "put-alerting-v2-rules-id",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "id",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The identifier for the rule."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "artifacts",
+                      "type": "array",
+                      "required": false,
+                      "summary": "Artifacts attached to the rule, each shaped as `{ id, type, data }`. `data` is a type-specific object (for example a `runbook` may carry `content`, a `dashboard` may carry `dashboardId`). Per-type shape is validated by the artifact-type registry when the type is registered; unregistered types pass through with envelope bounds only."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "grouping",
+                      "type": "string",
+                      "required": false
+                    },
+                    {
+                      "role": "flag",
+                      "name": "kind",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The kind of the rule."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "metadata",
+                      "type": "string",
+                      "required": true
+                    },
+                    {
+                      "role": "flag",
+                      "name": "no-data-strategy",
+                      "type": "string",
+                      "required": false,
+                      "summary": "How to handle no-data situations. \"last_known_status\" holds the last known status; \"recover\" forces recovery; \"none\" disables no-data detection. \"emit\" is not currently accepted by the create/update API. Standalone-format rules must provide a `no_data` query block when this is not \"none\"; composed-format rules use `base` as the data-presence query."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "query",
+                      "type": "string",
+                      "required": true
+                    },
+                    {
+                      "role": "flag",
+                      "name": "recovery-strategy",
+                      "type": "string",
+                      "required": false,
+                      "summary": "How recovery is detected. \"no_breach\" recovers groups that stop breaching; \"query\" uses a custom recovery query; \"none\" disables recovery."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "schedule",
+                      "type": "string",
+                      "required": true
+                    },
+                    {
+                      "role": "flag",
+                      "name": "state-transition",
+                      "type": "string",
+                      "required": false,
+                      "summary": "Episode state transition thresholds (alert-only)."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "time-field",
+                      "type": "string",
+                      "required": false,
+                      "summary": "Time field used for the lookback window range filter."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Create or replace a rule",
+                  "intent": {
+                    "destructive": false,
+                    "idempotent": true,
+                    "scope": "global",
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "post-alerting-v2-rules-id-disable",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "id",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The identifier for the rule."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Disable a rule",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "post-alerting-v2-rules-id-enable",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "id",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The identifier for the rule."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Enable a rule",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "post-alerting-v2-rules-id-run",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "id",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The identifier for the rule."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Run a rule now",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "get-alerting-v2-rules-id-history",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "id",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The identifier for the rule."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "page",
+                      "type": "number",
+                      "required": true,
+                      "summary": "Page number (1-based)."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "per-page",
+                      "type": "number",
+                      "required": true,
+                      "summary": "Number of results per page."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "List rule change history",
+                  "intent": {
+                    "destructive": false,
+                    "idempotent": true,
+                    "scope": "global",
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "get-alerting-v2-rules-id-history-eventid",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "id",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The identifier for the rule."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "event-id",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The change-history event identifier (`event.id`)."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Get a rule change-history event",
+                  "intent": {
+                    "destructive": false,
+                    "idempotent": true,
+                    "scope": "global",
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "get-alerting-v2-rules-tags",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "search",
+                      "type": "string",
+                      "required": false,
+                      "summary": "Prefix to filter tags by. Returns all most-used tags when omitted."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "kind",
+                      "type": "string",
+                      "required": false,
+                      "summary": "Restrict tags to rules of the given kind."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Get rule tags",
+                  "intent": {
+                    "destructive": false,
+                    "idempotent": true,
+                    "scope": "global",
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "alerting-v2"
+                  ],
+                  "name": "get-alerting-v2-suggestions-rule-event-fields",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "matcher",
+                      "type": "string",
+                      "required": false,
+                      "summary": "Optional matcher expression used to scope suggested data field names."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Get matcher data fields suggestions",
+                  "intent": {
+                    "destructive": false,
+                    "idempotent": true,
+                    "scope": "global",
+                    "requiresAuth": true
+                  }
+                }
+              ],
+              "namespaces": [],
+              "summary": "Kibana alerting-v2 API commands"
+            },
+            {
               "segment": "apm-agent-configuration",
               "commands": [
                 {
@@ -61852,6 +64608,1381 @@
               "summary": "Kibana apm-server-schema API commands"
             },
             {
+              "segment": "cases",
+              "commands": [
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "cases"
+                  ],
+                  "name": "delete-case-default-space",
+                  "parameters": [
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    },
+                    {
+                      "role": "flag",
+                      "name": "yes",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "confirm destructive action without prompting"
+                    }
+                  ],
+                  "summary": "Delete cases",
+                  "intent": {
+                    "destructive": true,
+                    "idempotent": true,
+                    "scope": "global",
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "cases"
+                  ],
+                  "name": "update-case-default-space",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "cases",
+                      "type": "array",
+                      "required": true,
+                      "summary": "An array containing one or more case objects."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Update cases",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "cases"
+                  ],
+                  "name": "create-case-default-space",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "assignees",
+                      "type": "string",
+                      "required": false,
+                      "repeatable": true,
+                      "separator": ","
+                    },
+                    {
+                      "role": "flag",
+                      "name": "category",
+                      "type": "string",
+                      "required": false
+                    },
+                    {
+                      "role": "flag",
+                      "name": "connector",
+                      "type": "string",
+                      "required": true
+                    },
+                    {
+                      "role": "flag",
+                      "name": "custom-fields",
+                      "type": "array",
+                      "required": false,
+                      "summary": "Custom field values for a case. Any optional custom fields that are not specified in the request are set to null.\n"
+                    },
+                    {
+                      "role": "flag",
+                      "name": "description",
+                      "type": "string",
+                      "required": true
+                    },
+                    {
+                      "role": "flag",
+                      "name": "owner",
+                      "type": "enum",
+                      "required": true,
+                      "enumValues": [
+                        "cases",
+                        "observability",
+                        "securitySolution"
+                      ]
+                    },
+                    {
+                      "role": "flag",
+                      "name": "settings",
+                      "type": "string",
+                      "required": true
+                    },
+                    {
+                      "role": "flag",
+                      "name": "severity",
+                      "type": "enum",
+                      "required": false,
+                      "enumValues": [
+                        "critical",
+                        "high",
+                        "low",
+                        "medium"
+                      ]
+                    },
+                    {
+                      "role": "flag",
+                      "name": "tags",
+                      "type": "array",
+                      "required": true,
+                      "elementType": "string"
+                    },
+                    {
+                      "role": "flag",
+                      "name": "template",
+                      "type": "string",
+                      "required": false,
+                      "summary": "A case template to create the case from. Requires the `xpack.cases.templates.enabled` setting. The server applies the template's case defaults (severity, category, tags, assignees, settings, connector) and its field defaults into `extended_fields`; any value explicitly provided in the request wins over the template default. When `version` is omitted, the latest version of the template is resolved and pinned on the case. To discover a template's fields before creating a case, use the get case fields API (`GET /api/cases/fields`).\n"
+                    },
+                    {
+                      "role": "flag",
+                      "name": "title",
+                      "type": "string",
+                      "required": true
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Create a case",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "cases"
+                  ],
+                  "name": "find-cases-default-space",
+                  "parameters": [
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Search cases",
+                  "intent": {
+                    "destructive": false,
+                    "idempotent": true,
+                    "scope": "global",
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "cases"
+                  ],
+                  "name": "get-case-default-space",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "case-id",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The identifier for the case. To retrieve case IDs, use the search cases (`_find)` API. All non-ASCII characters must be URL encoded."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Get case information",
+                  "intent": {
+                    "destructive": false,
+                    "idempotent": true,
+                    "scope": "global",
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "cases"
+                  ],
+                  "name": "get-case-alerts-default-space",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "case-id",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The identifier for the case. To retrieve case IDs, use the search cases (`_find)` API. All non-ASCII characters must be URL encoded."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Get all alerts for a case",
+                  "intent": {
+                    "destructive": false,
+                    "idempotent": true,
+                    "scope": "global",
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "cases"
+                  ],
+                  "name": "delete-case-comments-default-space",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "case-id",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The identifier for the case. To retrieve case IDs, use the search cases (`_find)` API. All non-ASCII characters must be URL encoded."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    },
+                    {
+                      "role": "flag",
+                      "name": "yes",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "confirm destructive action without prompting"
+                    }
+                  ],
+                  "summary": "Delete all case comments and alerts",
+                  "intent": {
+                    "destructive": true,
+                    "idempotent": true,
+                    "scope": "global",
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "cases"
+                  ],
+                  "name": "update-case-comment-default-space",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "case-id",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The identifier for the case. To retrieve case IDs, use the search cases (`_find)` API. All non-ASCII characters must be URL encoded."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "body",
+                      "type": "string",
+                      "required": false
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Update a case comment or alert",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "cases"
+                  ],
+                  "name": "add-case-comment-default-space",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "case-id",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The identifier for the case. To retrieve case IDs, use the search cases (`_find)` API. All non-ASCII characters must be URL encoded."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "body",
+                      "type": "string",
+                      "required": false
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Add a case comment or alert",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "cases"
+                  ],
+                  "name": "find-case-comments-default-space",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "case-id",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The identifier for the case. To retrieve case IDs, use the search cases (`_find)` API. All non-ASCII characters must be URL encoded."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "page",
+                      "type": "number",
+                      "required": false,
+                      "summary": "The page number to return."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "per-page",
+                      "type": "number",
+                      "required": false,
+                      "summary": "The number of items to return. Limited to 100 items."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "sort-order",
+                      "type": "enum",
+                      "required": false,
+                      "summary": "Determines the sort order.",
+                      "enumValues": [
+                        "asc",
+                        "desc"
+                      ]
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Find case comments",
+                  "intent": {
+                    "destructive": false,
+                    "idempotent": true,
+                    "scope": "global",
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "cases"
+                  ],
+                  "name": "delete-case-comment-default-space",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "case-id",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The identifier for the case. To retrieve case IDs, use the search cases (`_find)` API. All non-ASCII characters must be URL encoded."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "comment-id",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The identifier for the comment. To retrieve comment IDs, use the get case or search cases (`_find`) APIs.\n"
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    },
+                    {
+                      "role": "flag",
+                      "name": "yes",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "confirm destructive action without prompting"
+                    }
+                  ],
+                  "summary": "Delete a case comment or alert",
+                  "intent": {
+                    "destructive": true,
+                    "idempotent": true,
+                    "scope": "global",
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "cases"
+                  ],
+                  "name": "get-case-comment-default-space",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "case-id",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The identifier for the case. To retrieve case IDs, use the search cases (`_find)` API. All non-ASCII characters must be URL encoded."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "comment-id",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The identifier for the comment. To retrieve comment IDs, use the get case or search cases (`_find`) APIs.\n"
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Get a case comment or alert",
+                  "intent": {
+                    "destructive": false,
+                    "idempotent": true,
+                    "scope": "global",
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "cases"
+                  ],
+                  "name": "push-case-default-space",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "case-id",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The identifier for the case. To retrieve case IDs, use the search cases (`_find)` API. All non-ASCII characters must be URL encoded."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "connector-id",
+                      "type": "string",
+                      "required": true,
+                      "summary": "An identifier for the connector. To retrieve connector IDs, use the find connectors API."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "body",
+                      "type": "string",
+                      "required": false
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Push a case to an external service",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "cases"
+                  ],
+                  "name": "get-case-applicable-fields-default-space",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "case-id",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The identifier for the case. To retrieve case IDs, use the search cases (`_find)` API. All non-ASCII characters must be URL encoded."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Get the fields applicable to an existing case",
+                  "intent": {
+                    "destructive": false,
+                    "idempotent": true,
+                    "scope": "global",
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "cases"
+                  ],
+                  "name": "add-case-file-default-space",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "case-id",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The caseId parameter"
+                    },
+                    {
+                      "role": "flag",
+                      "name": "file",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The file being attached to the case."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "filename",
+                      "type": "string",
+                      "required": false,
+                      "summary": "The desired name of the file being attached to the case, it can be different than the name of the file in the filesystem. **This should not include the file extension.**"
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Attach a file to a case",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "cases"
+                  ],
+                  "name": "find-case-activity-default-space",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "case-id",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The identifier for the case. To retrieve case IDs, use the search cases (`_find)` API. All non-ASCII characters must be URL encoded."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "page",
+                      "type": "number",
+                      "required": false,
+                      "summary": "The page number to return."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "per-page",
+                      "type": "number",
+                      "required": false,
+                      "summary": "The number of items to return. Limited to 100 items."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "sort-order",
+                      "type": "enum",
+                      "required": false,
+                      "summary": "Determines the sort order.",
+                      "enumValues": [
+                        "asc",
+                        "desc"
+                      ]
+                    },
+                    {
+                      "role": "flag",
+                      "name": "types",
+                      "type": "array",
+                      "required": false,
+                      "summary": "Determines the types of user actions to return."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Find case activity",
+                  "intent": {
+                    "destructive": false,
+                    "idempotent": true,
+                    "scope": "global",
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "cases"
+                  ],
+                  "name": "get-cases-by-alert-default-space",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "alert-id",
+                      "type": "string",
+                      "required": true,
+                      "summary": "An identifier for the alert."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "owner",
+                      "type": "string",
+                      "required": false,
+                      "summary": "A filter to limit the response to a specific set of applications. If this parameter is omitted, the response contains information about all the cases that the user has access to read.\n",
+                      "repeatable": true
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Get cases for an alert",
+                  "intent": {
+                    "destructive": false,
+                    "idempotent": true,
+                    "scope": "global",
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "cases"
+                  ],
+                  "name": "get-case-configuration-default-space",
+                  "parameters": [
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Get case settings",
+                  "intent": {
+                    "destructive": false,
+                    "idempotent": true,
+                    "scope": "global",
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "cases"
+                  ],
+                  "name": "set-case-configuration-default-space",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "closure-type",
+                      "type": "enum",
+                      "required": true,
+                      "enumValues": [
+                        "close-by-pushing",
+                        "close-by-user"
+                      ]
+                    },
+                    {
+                      "role": "flag",
+                      "name": "connector",
+                      "type": "string",
+                      "required": true,
+                      "summary": "An object that contains the connector configuration."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "custom-fields",
+                      "type": "array",
+                      "required": false,
+                      "summary": "Custom fields case configuration."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "owner",
+                      "type": "enum",
+                      "required": true,
+                      "enumValues": [
+                        "cases",
+                        "observability",
+                        "securitySolution"
+                      ]
+                    },
+                    {
+                      "role": "flag",
+                      "name": "templates",
+                      "type": "array",
+                      "required": false
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Add case settings",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "cases"
+                  ],
+                  "name": "update-case-configuration-default-space",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "configuration-id",
+                      "type": "string",
+                      "required": true,
+                      "summary": "An identifier for the configuration."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "closure-type",
+                      "type": "enum",
+                      "required": false,
+                      "enumValues": [
+                        "close-by-pushing",
+                        "close-by-user"
+                      ]
+                    },
+                    {
+                      "role": "flag",
+                      "name": "connector",
+                      "type": "string",
+                      "required": false,
+                      "summary": "An object that contains the connector configuration."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "custom-fields",
+                      "type": "array",
+                      "required": false,
+                      "summary": "Custom fields case configuration."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "templates",
+                      "type": "array",
+                      "required": false
+                    },
+                    {
+                      "role": "flag",
+                      "name": "version",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The version of the connector. To retrieve the version value, use the get configuration API.\n"
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Update case settings",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "cases"
+                  ],
+                  "name": "find-case-connectors-default-space",
+                  "parameters": [
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Get case connectors",
+                  "intent": {
+                    "destructive": false,
+                    "idempotent": true,
+                    "scope": "global",
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "cases"
+                  ],
+                  "name": "get-applicable-fields-default-space",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "owner",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The application that owns the cases (for example `cases`, `observability`, or `securitySolution`)."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "template-id",
+                      "type": "string",
+                      "required": false,
+                      "summary": "The identifier of a template to include the template's fields in the response."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Get the fields applicable to a case",
+                  "intent": {
+                    "destructive": false,
+                    "idempotent": true,
+                    "scope": "global",
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "cases"
+                  ],
+                  "name": "get-case-reporters-default-space",
+                  "parameters": [
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Get case creators",
+                  "intent": {
+                    "destructive": false,
+                    "idempotent": true,
+                    "scope": "global",
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "cases"
+                  ],
+                  "name": "get-case-tags-default-space",
+                  "parameters": [
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Get case tags",
+                  "intent": {
+                    "destructive": false,
+                    "idempotent": true,
+                    "scope": "global",
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "cases"
+                  ],
+                  "name": "get-case-templates-default-space",
+                  "parameters": [
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Get all case templates",
+                  "intent": {
+                    "destructive": false,
+                    "idempotent": true,
+                    "scope": "global",
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "cases"
+                  ],
+                  "name": "create-case-template-default-space",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "When true, validates the request without creating the template and returns `{\"valid\": true}`."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "definition",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The template definition as a YAML string: case defaults (name, severity, category, tags, assignees, connector, settings) and a `fields` array of inline field definitions or `$ref` entries pointing into the owner's field library. Stored field values appear on cases under `extended_fields` keys shaped `<field_name>_as_<storage_type>`.\n"
+                    },
+                    {
+                      "role": "flag",
+                      "name": "description",
+                      "type": "string",
+                      "required": false,
+                      "summary": "A description of the template."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "is-enabled",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "Disabled templates are hidden from the case creation flow."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "name",
+                      "type": "string",
+                      "required": false,
+                      "summary": "The template identity name, unique per owner (case-insensitive). May be omitted when the YAML definition provides a case-default title (`name:`), which is then used as the identity name.\n"
+                    },
+                    {
+                      "role": "flag",
+                      "name": "owner",
+                      "type": "enum",
+                      "required": true,
+                      "enumValues": [
+                        "cases",
+                        "observability",
+                        "securitySolution"
+                      ]
+                    },
+                    {
+                      "role": "flag",
+                      "name": "tags",
+                      "type": "array",
+                      "required": false,
+                      "elementType": "string"
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    }
+                  ],
+                  "summary": "Create a case template",
+                  "intent": {
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "cases"
+                  ],
+                  "name": "delete-case-template-default-space",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "template-id",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The identifier for the template."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    },
+                    {
+                      "role": "flag",
+                      "name": "yes",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "confirm destructive action without prompting"
+                    }
+                  ],
+                  "summary": "Delete a case template",
+                  "intent": {
+                    "destructive": true,
+                    "idempotent": true,
+                    "scope": "global",
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "cases"
+                  ],
+                  "name": "get-case-template-default-space",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "template-id",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The identifier for the template."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "version",
+                      "type": "number",
+                      "required": false,
+                      "summary": "The version number of the template to retrieve. If omitted, the latest version is returned."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
+                      "role": "dryRun",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "validate all inputs and exit without performing any action"
+                    }
+                  ],
+                  "summary": "Get a case template by ID",
+                  "intent": {
+                    "destructive": false,
+                    "idempotent": true,
+                    "scope": "global",
+                    "requiresAuth": true
+                  }
+                },
+                {
+                  "path": [
+                    "stack",
+                    "kb",
+                    "cases"
+                  ],
+                  "name": "update-case-template-default-space",
+                  "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "template-id",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The identifier for the template."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "dry-run",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "When true, validates the request without updating the template and returns `{\"valid\": true}`."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "definition",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The template definition as a YAML string: case defaults (name, severity, category, tags, assignees, connector, settings) and a `fields` array of inline field definitions or `$ref` entries pointing into the owner's field library. Stored field values appear on cases under `extended_fields` keys shaped `<field_name>_as_<storage_type>`.\n"
+                    },
+                    {
+                      "role": "flag",
+                      "name": "description",
+                      "type": "string",
+                      "required": false,
+                      "summary": "A description of the template."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "is-enabled",
+                      "type": "boolean",
+                      "required": false,
+                      "summary": "Disabled templates are hidden from the case creation flow."
+                    },
+                    {
+                      "role": "flag",
+                      "name": "name",
+                      "type": "string",
+                      "required": false,
+                      "summary": "The template identity name, unique per owner (case-insensitive). May be omitted when the YAML definition provides a case-default title (`name:`), which is then used as the identity name.\n"
+                    },
+                    {
+                      "role": "flag",
+                      "name": "owner",
+                      "type": "enum",
+                      "required": true,
+                      "enumValues": [
+                        "cases",
+                        "observability",
+                        "securitySolution"
+                      ]
+                    },
+                    {
+                      "role": "flag",
+                      "name": "tags",
+                      "type": "array",
+                      "required": false,
+                      "elementType": "string"
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    }
+                  ],
+                  "summary": "Update a case template",
+                  "intent": {
+                    "destructive": false,
+                    "idempotent": true,
+                    "scope": "global",
+                    "requiresAuth": true
+                  }
+                }
+              ],
+              "namespaces": [],
+              "summary": "Kibana cases API commands"
+            },
+            {
               "segment": "connectors",
               "commands": [
                 {
@@ -62304,6 +66435,19 @@
                   "name": "create-dashboard",
                   "parameters": [
                     {
+                      "role": "flag",
+                      "name": "body",
+                      "type": "string",
+                      "required": false
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
                       "role": "dryRun",
                       "name": "dry-run",
                       "type": "boolean",
@@ -62368,6 +66512,12 @@
                       "type": "string",
                       "required": true,
                       "summary": "The id parameter"
+                    },
+                    {
+                      "role": "flag",
+                      "name": "body",
+                      "type": "string",
+                      "required": false
                     },
                     {
                       "role": "flag",
@@ -63629,6 +67779,12 @@
                       "type": "string",
                       "required": true,
                       "summary": "The ID of the action to cancel"
+                    },
+                    {
+                      "role": "flag",
+                      "name": "body",
+                      "type": "string",
+                      "required": false
                     },
                     {
                       "role": "flag",
@@ -73599,6 +77755,19 @@
                   "name": "ml-update-jobs-spaces",
                   "parameters": [
                     {
+                      "role": "flag",
+                      "name": "body",
+                      "type": "string",
+                      "required": false
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
                       "role": "dryRun",
                       "name": "dry-run",
                       "type": "boolean",
@@ -73619,6 +77788,19 @@
                   ],
                   "name": "ml-update-trained-models-spaces",
                   "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "body",
+                      "type": "string",
+                      "required": false
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
                     {
                       "role": "dryRun",
                       "name": "dry-run",
@@ -89219,6 +93401,19 @@
                   "name": "create-visualization",
                   "parameters": [
                     {
+                      "role": "flag",
+                      "name": "body",
+                      "type": "string",
+                      "required": false
+                    },
+                    {
+                      "role": "flag",
+                      "name": "input-file",
+                      "type": "string",
+                      "required": false,
+                      "summary": "path to a JSON file to use as command input"
+                    },
+                    {
                       "role": "dryRun",
                       "name": "dry-run",
                       "type": "boolean",
@@ -89283,6 +93478,12 @@
                       "type": "string",
                       "required": true,
                       "summary": "The id parameter"
+                    },
+                    {
+                      "role": "flag",
+                      "name": "body",
+                      "type": "string",
+                      "required": false
                     },
                     {
                       "role": "flag",
@@ -91841,48 +96042,6 @@
                 "cloud",
                 "orgs"
               ],
-              "name": "accept-organization-invitation",
-              "parameters": [
-                {
-                  "role": "flag",
-                  "name": "invitation-token",
-                  "type": "string",
-                  "required": true,
-                  "summary": "Organization invitation token"
-                },
-                {
-                  "role": "flag",
-                  "name": "input-file",
-                  "type": "string",
-                  "required": false,
-                  "summary": "path to a JSON file to use as command input"
-                },
-                {
-                  "role": "dryRun",
-                  "name": "dry-run",
-                  "type": "boolean",
-                  "required": false,
-                  "summary": "validate all inputs and exit without performing any action"
-                },
-                {
-                  "role": "flag",
-                  "name": "yes",
-                  "type": "boolean",
-                  "required": false,
-                  "summary": "confirm destructive action without prompting"
-                }
-              ],
-              "summary": "Accept an organization invitation",
-              "intent": {
-                "destructive": true,
-                "requiresAuth": true
-              }
-            },
-            {
-              "path": [
-                "cloud",
-                "orgs"
-              ],
               "name": "get-organization",
               "parameters": [
                 {
@@ -91932,6 +96091,15 @@
                   "name": "name",
                   "type": "string",
                   "required": false
+                },
+                {
+                  "role": "flag",
+                  "name": "enforce-authentication-method",
+                  "type": "enum",
+                  "required": false,
+                  "enumValues": [
+                    "sso"
+                  ]
                 },
                 {
                   "role": "flag",
@@ -92608,6 +96776,54 @@
                 "cloud",
                 "orgs"
               ],
+              "name": "add-role-mappings-individually",
+              "parameters": [
+                {
+                  "role": "flag",
+                  "name": "organization-id",
+                  "type": "string",
+                  "required": true,
+                  "summary": "Identifier for the Organization"
+                },
+                {
+                  "role": "flag",
+                  "name": "mappings",
+                  "type": "array",
+                  "required": true
+                },
+                {
+                  "role": "flag",
+                  "name": "input-file",
+                  "type": "string",
+                  "required": false,
+                  "summary": "path to a JSON file to use as command input"
+                },
+                {
+                  "role": "dryRun",
+                  "name": "dry-run",
+                  "type": "boolean",
+                  "required": false,
+                  "summary": "validate all inputs and exit without performing any action"
+                },
+                {
+                  "role": "flag",
+                  "name": "yes",
+                  "type": "boolean",
+                  "required": false,
+                  "summary": "confirm destructive action without prompting"
+                }
+              ],
+              "summary": "Adds role mapping",
+              "intent": {
+                "destructive": true,
+                "requiresAuth": true
+              }
+            },
+            {
+              "path": [
+                "cloud",
+                "orgs"
+              ],
               "name": "update-role-mappings",
               "parameters": [
                 {
@@ -92688,6 +96904,110 @@
                 }
               ],
               "summary": "Delete role mappings",
+              "intent": {
+                "destructive": true,
+                "requiresAuth": true
+              }
+            },
+            {
+              "path": [
+                "cloud",
+                "orgs"
+              ],
+              "name": "delete-role-mappings-individually",
+              "parameters": [
+                {
+                  "role": "flag",
+                  "name": "organization-id",
+                  "type": "string",
+                  "required": true,
+                  "summary": "Identifier for the Organization"
+                },
+                {
+                  "role": "flag",
+                  "name": "role-names",
+                  "type": "string",
+                  "required": true,
+                  "summary": "Comma separated list of role names"
+                },
+                {
+                  "role": "flag",
+                  "name": "input-file",
+                  "type": "string",
+                  "required": false,
+                  "summary": "path to a JSON file to use as command input"
+                },
+                {
+                  "role": "dryRun",
+                  "name": "dry-run",
+                  "type": "boolean",
+                  "required": false,
+                  "summary": "validate all inputs and exit without performing any action"
+                },
+                {
+                  "role": "flag",
+                  "name": "yes",
+                  "type": "boolean",
+                  "required": false,
+                  "summary": "confirm destructive action without prompting"
+                }
+              ],
+              "summary": "Delete role mapping",
+              "intent": {
+                "destructive": true,
+                "requiresAuth": true
+              }
+            },
+            {
+              "path": [
+                "cloud",
+                "orgs"
+              ],
+              "name": "update-role-mapping",
+              "parameters": [
+                {
+                  "role": "flag",
+                  "name": "organization-id",
+                  "type": "string",
+                  "required": true,
+                  "summary": "Identifier for the Organization"
+                },
+                {
+                  "role": "flag",
+                  "name": "role-name",
+                  "type": "string",
+                  "required": true,
+                  "summary": "Role name"
+                },
+                {
+                  "role": "flag",
+                  "name": "mapping",
+                  "type": "string",
+                  "required": true
+                },
+                {
+                  "role": "flag",
+                  "name": "input-file",
+                  "type": "string",
+                  "required": false,
+                  "summary": "path to a JSON file to use as command input"
+                },
+                {
+                  "role": "dryRun",
+                  "name": "dry-run",
+                  "type": "boolean",
+                  "required": false,
+                  "summary": "validate all inputs and exit without performing any action"
+                },
+                {
+                  "role": "flag",
+                  "name": "yes",
+                  "type": "boolean",
+                  "required": false,
+                  "summary": "confirm destructive action without prompting"
+                }
+              ],
+              "summary": "Update role mapping",
               "intent": {
                 "destructive": true,
                 "requiresAuth": true
@@ -97513,6 +101833,13 @@
                       "parameters": [
                         {
                           "role": "flag",
+                          "name": "exclude-credentials",
+                          "type": "boolean",
+                          "required": false,
+                          "summary": "If true, the username and password fields in the response credentials are set to empty strings and no usable credentials are returned. Credentials can be retrieved later using the _reset-credentials endpoint."
+                        },
+                        {
+                          "role": "flag",
                           "name": "name",
                           "type": "string",
                           "required": true
@@ -98061,6 +102388,13 @@
                       "parameters": [
                         {
                           "role": "flag",
+                          "name": "exclude-credentials",
+                          "type": "boolean",
+                          "required": false,
+                          "summary": "If true, the username and password fields in the response credentials are set to empty strings and no usable credentials are returned. Credentials can be retrieved later using the _reset-credentials endpoint."
+                        },
+                        {
+                          "role": "flag",
                           "name": "name",
                           "type": "string",
                           "required": true
@@ -98605,6 +102939,13 @@
                       ],
                       "name": "create",
                       "parameters": [
+                        {
+                          "role": "flag",
+                          "name": "exclude-credentials",
+                          "type": "boolean",
+                          "required": false,
+                          "summary": "If true, the username and password fields in the response credentials are set to empty strings and no usable credentials are returned. Credentials can be retrieved later using the _reset-credentials endpoint."
+                        },
                         {
                           "role": "flag",
                           "name": "name",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
       "dependencies": {
         "@cli-schema/spec": "^0.2.0",
         "@elastic/config-resolver": "0.1.1",
-        "@elastic/schemas": "^0.7.0",
+        "@elastic/schemas": "^0.7.1",
         "ajv": "^6.14.0",
         "cli-table3": "^0.6.5",
         "commander": "^15.0.0",
@@ -108,9 +108,9 @@
       "link": true
     },
     "node_modules/@elastic/schemas": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/@elastic/schemas/-/schemas-0.7.0.tgz",
-      "integrity": "sha512-9EvDe/2SvGCQJOYGwrHSsWEAgBa4RemGu+U0odHaYITIDZx7El6ALJLvkZ2SpFGELJ20iRZF6IpflcXSf+0FtA==",
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@elastic/schemas/-/schemas-0.7.1.tgz",
+      "integrity": "sha512-4EH67jQsPV84dPAp6+caJ4lZweH7sgFp2CjOMUIfgZya7SruSB7dmmRfNo3YB1yMQlgut/sVdPnLgbkjfszc3g==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"
@@ -5121,7 +5121,9 @@
       }
     },
     "node_modules/pacote": {
-      "version": "21.5.0",
+      "version": "21.5.1",
+      "resolved": "https://registry.npmjs.org/pacote/-/pacote-21.5.1.tgz",
+      "integrity": "sha512-KvcJ9iy3crysCsgqc4+PknH/w6jkrp8JN36mpZBPwNaDRwTfMZD37YzRazNstiZUOhuF5pno9f78n9mEJBavwg==",
       "dev": true,
       "license": "ISC",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -58,7 +58,7 @@
   "dependencies": {
     "@cli-schema/spec": "^0.2.0",
     "@elastic/config-resolver": "0.1.1",
-    "@elastic/schemas": "^0.7.0",
+    "@elastic/schemas": "^0.7.1",
     "ajv": "^6.14.0",
     "cli-table3": "^0.6.5",
     "commander": "^15.0.0",

--- a/test/lib/manifest-drift.test.ts
+++ b/test/lib/manifest-drift.test.ts
@@ -90,7 +90,7 @@ describe('manifest/definition parity (upstream drift guard)', () => {
     })
 
     it('pins the kb command count', () => {
-      const expected = 583
+      const expected = 666
       assert.equal(kbApiManifest.length, expected, countDriftMessage('kb', expected, kbApiManifest.length))
     })
 
@@ -118,7 +118,7 @@ describe('manifest/definition parity (upstream drift guard)', () => {
   // loaded count still catches an upstream add/remove going unnoticed.
   describe('cloud', () => {
     it('pins the cloud command count', async () => {
-      const expected = 112
+      const expected = 114
       const actual = (await loadCloudApis()).length
       assert.equal(actual, expected, countDriftMessage('cloud', expected, actual))
     })


### PR DESCRIPTION
Upgrade of `@elastic/schemas` provides fixes and improved support for several APIs that were absent or incorrect, including:

- Kibana `alerting-v2` APIs
- Kibana `cases` APIs
- Cloud `role-mapping` APIs

See https://github.com/elastic/schemas-js/pull/79 for the full list.

Fixes https://github.com/elastic/cli/issues/528.
