### PR TITLE
chore(ci): pin config-resolver release-as 0.1.1 to suppress spurious bump

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -15,7 +15,8 @@
     },
     "packages/config-resolver": {
         "component": "config-resolver",
-        "release-type": "node"
+        "release-type": "node",
+        "release-as": "0.1.1"
     }
   },
   "plugins": [


### PR DESCRIPTION
## Problem

Empty commit `f892744` (currently HEAD on `main`) carries two `fix:` lines in its message but changes zero files. Because release-please cannot path-attribute a file-less commit to any specific package, it falls through to every component in the manifest — including `config-resolver`. This caused PR #573 to include a spurious `0.1.1 → 0.1.2` patch bump for `config-resolver` despite nothing in `packages/config-resolver/` actually changing.

## Fix

Add `"release-as": "0.1.1"` to the `packages/config-resolver` entry in `.github/release-please-config.json`. This overrides the computed next version for that component only, keeping it at `0.1.1` while allowing the root `@elastic/cli` package to bump normally.

Merging this PR will trigger the release workflow, which will regenerate PR #573 without the spurious `config-resolver` bump.

## Follow-up

Per the release-please docs, `release-as` is a persistent override and should be removed after the release PR merges, or left in place to act as a permanent parking brake for `config-resolver` auto-bumps. See the commit message for the tradeoffs.