### PR TITLE
chore(deps): upgrade marked to v18

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1289,7 +1289,7 @@ SOFTWARE.
 
 
 ------------------------------------------------------------------------
-marked@14.1.4
+marked@18.0.11
 License: MIT
 Repository: https://github.com/markedjs/marked
 Publisher: Christopher Jeffrey

--- a/package-lock.json
+++ b/package-lock.json
@@ -23,7 +23,7 @@
         "commander": "^15.0.0",
         "cross-spawn": "^7.0.6",
         "csv-parse": "^7.0.0",
-        "marked": "^14.1.4",
+        "marked": "^18.0.0",
         "marked-terminal": "^7.3.0",
         "yaml": "^2.8.3"
       },
@@ -4091,13 +4091,13 @@
       }
     },
     "node_modules/marked": {
-      "version": "14.1.4",
+      "version": "18.0.11",
       "license": "MIT",
       "bin": {
         "marked": "bin/marked.js"
       },
       "engines": {
-        "node": ">= 18"
+        "node": ">= 20"
       }
     },
     "node_modules/marked-terminal": {

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "commander": "^15.0.0",
     "cross-spawn": "^7.0.6",
     "csv-parse": "^7.0.0",
-    "marked": "^14.1.4",
+    "marked": "^18.0.0",
     "marked-terminal": "^7.3.0",
     "yaml": "^2.8.3"
   },
@@ -84,7 +84,10 @@
     "typescript-eslint": "8.62.1"
   },
   "overrides": {
-    "fast-uri": "^3.1.4"
+    "fast-uri": "^3.1.4",
+    "marked-terminal": {
+      "marked": "$marked"
+    }
   },
   "bundleDependencies": [
     "@elastic/config-resolver"


### PR DESCRIPTION
Renovate failed to do this correctly automatically. This should patch that up for the future.
