### PR TITLE
ci: exclude root-level paths from config-resolver release triggers

### DIFF
--- a/.github/release-please-config.json
+++ b/.github/release-please-config.json
@@ -14,7 +14,8 @@
     },
     "packages/config-resolver": {
         "component": "config-resolver",
-        "release-type": "node"
+        "release-type": "node",
+        "exclude-paths": ["src", "test", "codegen", "scripts", "docs", ".github"]
     }
   },
   "plugins": [


### PR DESCRIPTION
Phantom empty commit f892744 (PR #565) carries fix: messages but has
zero file changes. release-please's includeEmpty:true causes it to be
attributed to all packages including config-resolver, triggering a
spurious 0.1.2 bump.

exclude-paths causes CommitExclude to filter out empty commits from
config-resolver's commit list via vacuous truth: [].every() is always
true, so any non-empty excludePaths array removes empty commits from
that package's release consideration.
