### PR TITLE
fix: decode yaml and ndjson kb responses

### DIFF
--- a/codegen/functional/kb.ts
+++ b/codegen/functional/kb.ts
@@ -381,9 +381,6 @@ const skippedFilesServerless = new Set<string>([
   "fleet_uninstall_tokens_post_fleet_uninstall_tokens_agentpolicyid_rotate.yml",
   "message_signing_service_post_fleet_message_signing_service_rotate_key_pair.yml",
 
-  // CLI (de)serialization defects: a non-JSON response the client cannot parse.
-  "elastic_agent_policies_get_fleet_kubernetes_download.yml",
-
   // Not fixed by empty-body normalisation: mcp_post needs a JSON-RPC payload and
   // returns an event-stream (-32700 Parse error); consumption 404s (route absent);
   // security_role_query returns total 0 (no queryable roles in this env).
@@ -616,11 +613,9 @@ const skippedFilesStack = new Set<string>([
   // Assertions fail or the response is unparseable: required objects were never
   // provisioned in the stack env, or the body isn't the JSON/YAML the check expects.
   "agent_builder_converse_async.yml",
-  "elastic_agent_policies_get_fleet_kubernetes_download.yml",
   "elastic_agents_get_fleet_agents_setup.yml",
   "security_attack_discovery_api_get_attack_discovery_generations.yml",
   "security_entity_analytics_api_bulk_upsert_asset_criticality_records.yml",
-  "security_lists_api_export_list_items.yml",
   "security_timeline_api_resolve_timeline.yml",
   "apm_agent_configuration_search_single_configuration.yml",
   "security_exceptions_api_create_shared_exception_list.yml",

--- a/src/factory.ts
+++ b/src/factory.ts
@@ -768,7 +768,12 @@ export function defineCommand (config: CommandConfig): OpaqueCommandHandle {
         return
       }
       const { parse: parseYaml } = await import('yaml')
-      result = parseYaml(handlerResult.text) as JsonValue
+      try {
+        result = parseYaml(handlerResult.text) as JsonValue
+      } catch {
+        // Multi-doc manifests (k8s `---` separators) throw; keep the raw body so --json still exits 0.
+        result = handlerResult.text
+      }
     } else {
       result = handlerResult
     }

--- a/src/kb/handler.ts
+++ b/src/kb/handler.ts
@@ -44,7 +44,7 @@ export function createKbHandler (
     const params = deps.buildKibanaRequestParams(def, parsed)
 
     try {
-      const body = await client.request(params)
+      const body = await client.request(params, def.responseType)
       return body as HandlerResult
     } catch (err) {
       return kibanaApiError(err)

--- a/src/lib/kibana-client.ts
+++ b/src/lib/kibana-client.ts
@@ -51,13 +51,17 @@ function looksLikeSse (text: string): boolean {
 }
 
 function parseNdjson (text: string): unknown[] {
-  return text.split('\n').filter((l) => l.trim().length > 0).map((l) => JSON.parse(l))
+  return text.split(/\r?\n/).filter((l) => l.trim().length > 0).map((l) => {
+    try { return JSON.parse(l) } catch { return l }
+  })
 }
 
 function acceptFor (responseType?: KibanaResponseType): string {
-  if (responseType === 'ndjson') return 'application/x-ndjson'
-  if (responseType === 'text') return 'text/plain'
-  return 'application/json'
+  switch (responseType) {
+    case 'ndjson': return 'application/x-ndjson'
+    case 'text': return 'text/plain'
+    default: return 'application/json'
+  }
 }
 
 function decodeBody (text: string, contentType: string, responseType?: KibanaResponseType): unknown {

--- a/src/lib/kibana-client.ts
+++ b/src/lib/kibana-client.ts
@@ -15,6 +15,9 @@ import { YamlResponse, isYamlContentType } from './yaml-response.ts'
 /** HTTP methods supported by the Kibana API client. */
 export type KibanaHttpMethod = 'GET' | 'POST' | 'PUT' | 'DELETE' | 'HEAD' | 'PATCH'
 
+/** Declared success-body shape from the endpoint definition (`x-response-type`). */
+export type KibanaResponseType = 'json' | 'ndjson' | 'text'
+
 /**
  * Parameters for a single Kibana API request.
  */
@@ -45,6 +48,49 @@ const SSE_FIELD_PREFIX = /^(?:event|data|id|retry):|^:/
  */
 function looksLikeSse (text: string): boolean {
   return SSE_FIELD_PREFIX.test(text.replace(/^[\r\n]+/, ''))
+}
+
+function parseNdjson (text: string): unknown[] {
+  return text.split('\n').filter((l) => l.trim().length > 0).map((l) => JSON.parse(l))
+}
+
+function acceptFor (responseType?: KibanaResponseType): string {
+  if (responseType === 'ndjson') return 'application/x-ndjson'
+  if (responseType === 'text') return 'text/plain'
+  return 'application/json'
+}
+
+function decodeBody (text: string, contentType: string, responseType?: KibanaResponseType): unknown {
+  if (contentType.includes('ndjson') || responseType === 'ndjson') {
+    try {
+      const parsed = JSON.parse(text)
+      return Array.isArray(parsed) ? parsed : [parsed]
+    } catch {
+      return parseNdjson(text)
+    }
+  }
+
+  const maybeMaskedStream = contentType === '' || contentType.includes('application/octet-stream')
+  if (contentType.includes('text/event-stream') || (maybeMaskedStream && looksLikeSse(text))) {
+    return decodeSse(text)
+  }
+
+  if (isYamlContentType(contentType) || responseType === 'text') {
+    return isYamlContentType(contentType) ? new YamlResponse(text) : text
+  }
+
+  if (contentType.includes('json')) {
+    try {
+      return JSON.parse(text)
+    } catch {
+      return text
+    }
+  }
+  try {
+    return JSON.parse(text)
+  } catch {
+    return text
+  }
 }
 
 /**
@@ -86,14 +132,17 @@ export class KibanaClient {
   /**
    * Sends an HTTP request to the Kibana API and returns the parsed response.
    *
-   * Decoding is driven by the response `Content-Type`: `application/x-ndjson` yields an array
-   * of per-line objects, `text/event-stream` (or an SSE body masked as `application/octet-stream`,
-   * per elastic/kibana#232170) yields an array of `{ event, data }` events (`data` JSON-parsed when
-   * possible, `event` defaulting to `"message"`), and everything else is parsed as a single JSON value.
+   * Decoding is driven by the response `Content-Type`, falling back to the endpoint's declared
+   * `responseType` (`x-response-type`) when the header is missing or lies. `application/x-ndjson`
+   * (or `responseType: 'ndjson'`) yields an array of per-line objects. YAML is wrapped so the
+   * output layer can print it verbatim. `text/event-stream` (or an SSE body masked as
+   * `application/octet-stream`, per elastic/kibana#232170) yields `{ event, data }` events.
+   * Bodies advertised as JSON are parsed when they are JSON and otherwise returned as raw text
+   * instead of throwing (`Unexpected non-whitespace character after JSON`).
    *
    * @throws {Error} on non-2xx responses, including the status code and response body
    */
-  async request (params: KibanaRequestParams): Promise<unknown> {
+  async request (params: KibanaRequestParams, responseType?: KibanaResponseType): Promise<unknown> {
     let url = `${this.baseUrl}${params.path}`
 
     if (params.querystring != null && Object.keys(params.querystring).length > 0) {
@@ -107,7 +156,7 @@ export class KibanaClient {
     const method = params.method.toUpperCase()
     const headers: Record<string, string> = {
       ...clientHeaders(),
-      'Accept': 'application/json',
+      'Accept': acceptFor(responseType),
     }
     if (this.authHeader != null) {
       headers['Authorization'] = this.authHeader
@@ -164,38 +213,7 @@ export class KibanaClient {
     const text = await response.text()
     if (text.length === 0) return {}
 
-    const contentType = response.headers.get('content-type') ?? ''
-
-    if (contentType.includes('ndjson')) {
-      return text.split('\n').filter((l) => l.trim().length > 0).map((l) => JSON.parse(l))
-    }
-
-    // Server-Sent Events (agent_builder converse/async) are labeled `text/event-stream` by
-    // spec-compliant Kibana (>= 9.3.8/9.4.2/9.5.0); older builds mask the stream as
-    // `application/octet-stream` to stop a proxy gzip-compressing it (elastic/kibana#232170), so the
-    // body is sniffed only for that masked case to avoid misclassifying binary/JSON octet-stream.
-    const maybeMaskedStream = contentType === '' || contentType.includes('application/octet-stream')
-    if (contentType.includes('text/event-stream') || (maybeMaskedStream && looksLikeSse(text))) {
-      return decodeSse(text)
-    }
-
-    // YAML bodies (agent-policy / Kubernetes manifest downloads) are wrapped so the output layer
-    // can print them verbatim by default and parse them to JSON only under `--json`.
-    if (isYamlContentType(contentType)) {
-      return new YamlResponse(text)
-    }
-
-    // Other raw non-JSON payloads (script-library downloads, the OAuth callback JavaScript) are
-    // returned verbatim instead of blowing up with `is not valid JSON`. Bodies advertised as JSON
-    // are parsed strictly; otherwise fall back to the raw text when parsing fails.
-    if (contentType.includes('json')) {
-      return JSON.parse(text)
-    }
-    try {
-      return JSON.parse(text)
-    } catch {
-      return text
-    }
+    return decodeBody(text, response.headers.get('content-type') ?? '', responseType)
   }
 
   /**

--- a/test/factory.test.ts
+++ b/test/factory.test.ts
@@ -4376,4 +4376,33 @@ describe('YAML response rendering', () => {
     const out = await capture([], cmd)
     assert.equal(out, 'key: value\n')
   })
+
+  it('returns the yaml body under --json with exit 0 (#588)', async () => {
+    const cmd = defineCommand({
+      name: 'download',
+      description: 'Download',
+      handler: () => new YamlResponse(yamlBody),
+    })
+    const { stdout, exitCode } = await invokeCapturingStreams(cmd, ['--json'], [])
+    assert.equal(exitCode, 0)
+    assert.deepEqual(JSON.parse(stdout), {
+      apiVersion: 'v1',
+      kind: 'ConfigMap',
+      metadata: { name: 'agent' },
+    })
+  })
+
+  it('returns an ndjson body as a json array under --json with exit 0 (#588)', async () => {
+    const cmd = defineCommand({
+      name: 'export-list-items',
+      description: 'Export',
+      handler: () => [{ list_id: 'a', value: '1' }, { list_id: 'a', value: '2' }],
+    })
+    const { stdout, exitCode } = await invokeCapturingStreams(cmd, ['--json'], [])
+    assert.equal(exitCode, 0)
+    assert.deepEqual(JSON.parse(stdout), [
+      { list_id: 'a', value: '1' },
+      { list_id: 'a', value: '2' },
+    ])
+  })
 })

--- a/test/factory.test.ts
+++ b/test/factory.test.ts
@@ -4405,4 +4405,16 @@ describe('YAML response rendering', () => {
       { list_id: 'a', value: '2' },
     ])
   })
+
+  it('prints a multi-doc yaml body as a json string under --json with exit 0', async () => {
+    const multiDoc = '---\napiVersion: v1\nkind: ConfigMap\n---\napiVersion: apps/v1\nkind: DaemonSet\n'
+    const cmd = defineCommand({
+      name: 'download',
+      description: 'Download',
+      handler: () => new YamlResponse(multiDoc),
+    })
+    const { stdout, exitCode } = await invokeCapturingStreams(cmd, ['--json'], [])
+    assert.equal(exitCode, 0)
+    assert.equal(JSON.parse(stdout), multiDoc)
+  })
 })

--- a/test/functional/kb/definitions/security_lists_api_export_list_items.yml
+++ b/test/functional/kb/definitions/security_lists_api_export_list_items.yml
@@ -33,6 +33,5 @@ teardown:
   - do:
       security-lists-api.export_list_items:
         list_id: cli-ft-sec-lists-export-items-list
-  - is_true: 0.list_id
-  - match: {0.list_id: cli-ft-sec-lists-export-items-list}
-  - match: {0.value: "192.0.2.1"}
+  - is_true: "0"
+  - match: {0: "192.0.2.1"}

--- a/test/kb/handler.test.ts
+++ b/test/kb/handler.test.ts
@@ -112,4 +112,20 @@ describe('createKbHandler', () => {
     await handler(parsed())
     assert.deepEqual(captured, [{ method: 'POST', path: '/api/spaces/space', body: { name: 'x' } }])
   })
+
+  it('forwards definition responseType to client.request (#588)', async () => {
+    const captured: Array<string | undefined> = []
+    const def: KbApiDefinition = { ...listDef(), name: 'export-list-items', responseType: 'ndjson' }
+    const handler = createKbHandler(def, {
+      getKibanaClient: () => ({
+        request: async (_params: KibanaRequestParams, responseType?: string) => {
+          captured.push(responseType)
+          return []
+        },
+      } as unknown as KibanaClient),
+      buildKibanaRequestParams: () => ({ method: 'POST', path: '/api/lists/items/_export' }),
+    })
+    await handler(parsed())
+    assert.deepEqual(captured, ['ndjson'])
+  })
 })

--- a/test/lib/kibana-client.test.ts
+++ b/test/lib/kibana-client.test.ts
@@ -319,6 +319,58 @@ describe('KibanaClient.request non-JSON bodies', () => {
     assert.equal(result.text, yaml)
   })
 
+  it('wraps a text/yaml body in a YamlResponse (#588)', async () => {
+    const client = makeClient()
+    const yaml = 'kind: ConfigMap\n'
+    client._testSetFetch(rawFetch(yaml, 'text/yaml'))
+
+    const result = await client.request({ method: 'GET', path: '/api/fleet/kubernetes/download' })
+    assert.ok(result instanceof YamlResponse)
+    assert.equal(result.text, yaml)
+  })
+
+  it('parses application/x-ndjson into an array of objects (#588)', async () => {
+    const client = makeClient()
+    const ndjson = '{"list_id":"a","value":"1"}\n{"list_id":"a","value":"2"}\n'
+    client._testSetFetch(rawFetch(ndjson, 'application/x-ndjson'))
+
+    const result = await client.request({ method: 'POST', path: '/api/lists/items/_export' })
+    assert.deepEqual(result, [
+      { list_id: 'a', value: '1' },
+      { list_id: 'a', value: '2' },
+    ])
+  })
+
+  it('decodes ndjson when Content-Type is application/json but responseType is ndjson (#588)', async () => {
+    const client = makeClient()
+    const ndjson = '{"list_id":"a"}\n{"list_id":"b"}\n'
+    client._testSetFetch(rawFetch(ndjson, 'application/json'))
+
+    const result = await client.request({ method: 'POST', path: '/api/lists/items/_export' }, 'ndjson')
+    assert.deepEqual(result, [{ list_id: 'a' }, { list_id: 'b' }])
+  })
+
+  it('returns a yaml body advertised as application/json as raw text (#588)', async () => {
+    const client = makeClient()
+    const yaml = 'apiVersion: v1\nkind: ConfigMap\n'
+    client._testSetFetch(rawFetch(yaml, 'application/json'))
+
+    const result = await client.request({ method: 'GET', path: '/api/fleet/kubernetes/download' })
+    assert.equal(result, yaml)
+  })
+
+  it('sends Accept: application/x-ndjson when responseType is ndjson', async () => {
+    const client = makeClient()
+    let captured: Record<string, string> = {}
+    client._testSetFetch(((url: string, init: RequestInit) => {
+      captured = init.headers as Record<string, string>
+      return Promise.resolve(new Response('{"id":"1"}\n', { status: 200, headers: { 'content-type': 'application/x-ndjson' } }))
+    }) as typeof fetch)
+
+    await client.request({ method: 'POST', path: '/api/lists/items/_export' }, 'ndjson')
+    assert.equal(captured['Accept'], 'application/x-ndjson')
+  })
+
   it('returns a raw JavaScript body verbatim (oauth callback script)', async () => {
     const client = makeClient()
     const js = '(() => { window.location = "/" })()'

--- a/test/lib/kibana-client.test.ts
+++ b/test/lib/kibana-client.test.ts
@@ -341,6 +341,23 @@ describe('KibanaClient.request non-JSON bodies', () => {
     ])
   })
 
+  it('keeps non-JSON ndjson lines as strings (lists export is value per line)', async () => {
+    const client = makeClient()
+    const ndjson = '127.0.0.1\n127.0.0.2\n'
+    client._testSetFetch(rawFetch(ndjson, 'application/ndjson'))
+
+    const result = await client.request({ method: 'POST', path: '/api/lists/items/_export' }, 'ndjson')
+    assert.deepEqual(result, ['127.0.0.1', '127.0.0.2'])
+  })
+
+  it('keeps a dotted IP as a string, not a failed JSON number', async () => {
+    const client = makeClient()
+    client._testSetFetch(rawFetch('192.0.2.1\n', 'application/x-ndjson'))
+
+    const result = await client.request({ method: 'POST', path: '/api/lists/items/_export' }, 'ndjson')
+    assert.deepEqual(result, ['192.0.2.1'])
+  })
+
   it('decodes ndjson when Content-Type is application/json but responseType is ndjson (#588)', async () => {
     const client = makeClient()
     const ndjson = '{"list_id":"a"}\n{"list_id":"b"}\n'


### PR DESCRIPTION
Pass YAML and NDJSON through instead of JSON.parse. Closes #588.