### PR TITLE
fix: fail fast on empty captured setup vars

### DIFF
--- a/codegen/functional/generator.ts
+++ b/codegen/functional/generator.ts
@@ -72,6 +72,7 @@ export function generateScript (
   const skipEmptySet = opts.skipEmptySet === true
   const skipNotFound = opts.skipNotFound === true
   const actionMap = buildActionMap(definitions)
+  const reusedSetVars = collectDoStepVarRefs(testFile)
   const skippedActions: string[] = []
   const lines: string[] = []
 
@@ -86,7 +87,7 @@ export function generateScript (
   if (testFile.teardown.length > 0 || tempFileVars.length > 0) {
     const teardownBody: string[] = []
     if (testFile.teardown.length > 0) {
-      renderSteps(testFile.teardown, actionMap, clientArgs, teardownBody, skippedActions, '  ', false, skipEmptySet, skipNotFound)
+      renderSteps(testFile.teardown, actionMap, clientArgs, teardownBody, skippedActions, '  ', false, skipEmptySet, skipNotFound, reusedSetVars)
     }
     for (const v of tempFileVars) {
       teardownBody.push(`  [ -n "$${v}" ] && rm -rf -- "$(dirname -- "$${v}")"`)
@@ -118,13 +119,13 @@ export function generateScript (
 
   if (testFile.setup.length > 0) {
     lines.push('# --- Setup ---')
-    hadSkippedDo = renderSteps(testFile.setup, actionMap, clientArgs, lines, skippedActions, '', false, skipEmptySet, skipNotFound)
+    hadSkippedDo = renderSteps(testFile.setup, actionMap, clientArgs, lines, skippedActions, '', false, skipEmptySet, skipNotFound, reusedSetVars)
     lines.push('')
   }
 
   for (const section of testFile.tests) {
     lines.push(`# --- Test: ${section.name} ---`)
-    renderSteps(section.steps, actionMap, clientArgs, lines, skippedActions, '', hadSkippedDo, skipEmptySet, skipNotFound)
+    renderSteps(section.steps, actionMap, clientArgs, lines, skippedActions, '', hadSkippedDo, skipEmptySet, skipNotFound, reusedSetVars)
     lines.push('')
   }
 
@@ -277,7 +278,8 @@ function renderSteps (
   indent: string,
   initialHadSkippedDo = false,
   skipEmptySet = false,
-  skipNotFound = false
+  skipNotFound = false,
+  reusedSetVars = new Set<string>()
 ): boolean {
   // Assertions and set-steps read $RESPONSE, which is written by the most
   // recent successful `do`. If the last `do` was skipped (unmapped action,
@@ -336,7 +338,7 @@ function renderSteps (
 
     switch (step.kind) {
       case 'set':
-        renderSet(step, lines, indent, skipEmptySet)
+        renderSet(step, lines, indent, skipEmptySet, reusedSetVars)
         // If a variable was previously unset, it's now set
         for (const varName of Object.values(step.assignments)) {
           unsetVars.delete(varName.toUpperCase().replace(/[^A-Z0-9]/g, '_'))
@@ -565,7 +567,7 @@ function buildCommand (mapped: MappedAction, step: DoStep): string {
   return base
 }
 
-function renderSet (step: SetStep, lines: string[], indent: string, skipEmptySet = false): void {
+function renderSet (step: SetStep, lines: string[], indent: string, skipEmptySet = false, reusedSetVars = new Set<string>()): void {
   for (const [responsePath, varName] of Object.entries(step.assignments)) {
     const bashVar = varName.toUpperCase().replace(/[^A-Z0-9]/g, '_')
     const jqPath = toJqPath(responsePath)
@@ -584,6 +586,10 @@ function renderSet (step: SetStep, lines: string[], indent: string, skipEmptySet
       lines.push(`${indent}fi`)
     } else {
       lines.push(`${indent}${bashVar}=$(echo "$RESPONSE" | jq -r '${jqPath}')`)
+      // jq -r prints "null" for a missing path; -n alone would not fail.
+      if (reusedSetVars.has(bashVar)) {
+        lines.push(`${indent}[ -n "$${bashVar}" ] && [ "$${bashVar}" != "null" ] || { echo "FAIL: setup produced empty ${bashVar}"; exit 1; }`)
+      }
     }
   }
 }
@@ -858,6 +864,35 @@ function collectRequiredStepVarRefs (step: DoStep, mapped: MappedAction): string
     for (const [key, val] of Object.entries(step.body as Record<string, unknown>)) add(key, val)
   }
   return names
+}
+
+function collectDoStepVarRefs (file: TestFile): Set<string> {
+  const out = new Set<string>()
+  const walk = (steps: Step[]): void => {
+    for (const step of steps) {
+      if (step.kind !== 'do') continue
+      collectStringVarRefs(step.params, out)
+      if (step.body != null) collectStringVarRefs(step.body, out)
+    }
+  }
+  walk(file.setup)
+  walk(file.teardown)
+  for (const t of file.tests) walk(t.steps)
+  return out
+}
+
+function collectStringVarRefs (val: unknown, out: Set<string>): void {
+  if (typeof val === 'string' && val.startsWith('$')) {
+    out.add(val.slice(1).toUpperCase().replace(/[^A-Z0-9]/g, '_'))
+    return
+  }
+  if (Array.isArray(val)) {
+    for (const v of val) collectStringVarRefs(v, out)
+    return
+  }
+  if (val !== null && typeof val === 'object') {
+    for (const v of Object.values(val as Record<string, unknown>)) collectStringVarRefs(v, out)
+  }
 }
 
 function valueReferencesUnset (val: unknown, unsetVars: Set<string>): boolean {

--- a/codegen/functional/kb.ts
+++ b/codegen/functional/kb.ts
@@ -365,6 +365,7 @@ const skippedFilesStack = new Set<string>([
   "elastic_agents_get_fleet_agent_status_data.yml",
   "elastic_agents_get_fleet_agents_agentid.yml",
   "elastic_agents_get_fleet_agents_agentid_effective_config.yml",
+  "elastic_agents_get_fleet_agents_agentid_uploads.yml",
   "elastic_agents_get_fleet_agents_files_fileid_filename.yml",
   "elastic_agents_post_fleet_agents.yml",
   "elastic_agents_post_fleet_agents_agentid_privilege_level_change.yml",

--- a/codegen/functional/test/generator.test.ts
+++ b/codegen/functional/test/generator.test.ts
@@ -67,6 +67,14 @@ const testDefs: EsApiDefinition[] = [
     method: 'POST',
     path: '/api/lists/items/_import',
     input: { type: 'object', properties: { file: { type: 'string', 'x-found-in': 'body' } }, required: ['file'] }
+  },
+  {
+    name: 'bulk-remove',
+    namespace: 'agents',
+    description: 'Bulk remove agents',
+    method: 'POST',
+    path: '/agents/_bulk_remove',
+    input: { type: 'object', properties: { agents: { type: 'array', 'x-found-in': 'body' } }, required: ['agents'] }
   }
 ]
 
@@ -312,6 +320,79 @@ describe('generateScript', () => {
     const result = generateScript(testFile, testDefs)
     assert.equal(result.script.includes('SKIP: no id in list response'), false)
     assert.equal(result.script.includes('.[0].id // empty'), false)
+    assert.equal(result.script.includes('FAIL: setup produced empty ID'), false)
+  })
+
+  it('fails fast when a reused set capture is empty or null', () => {
+    const content = readFileSync(join(fixturesDir, 'get.yml'), 'utf-8')
+    const testFile = parseTestFile(content, 'get.yml')
+    const result = generateScript(testFile, testDefs)
+    const guard = '[ -n "$ID" ] && [ "$ID" != "null" ] || { echo "FAIL: setup produced empty ID"; exit 1; }'
+    assert.ok(result.script.includes(guard), 'must emit a fail-fast guard for reused $id')
+
+    const setLine = "ID=$(echo \"$RESPONSE\" | jq -r '._id')"
+    assert.ok(result.script.includes(setLine))
+    const snippet = `set -euo pipefail\n${setLine}\n${guard}\n`
+    const run = (response: string): { status: number, out: string } => {
+      try {
+        const out = execFileSync('bash', ['-c', snippet], {
+          encoding: 'utf8',
+          env: { ...process.env, RESPONSE: response },
+          stdio: ['ignore', 'pipe', 'pipe']
+        })
+        return { status: 0, out }
+      } catch (err) {
+        const e = err as { status?: number, stdout?: string, stderr?: string }
+        return { status: e.status ?? 1, out: `${e.stdout ?? ''}${e.stderr ?? ''}` }
+      }
+    }
+    assert.equal(run('{"_id":"abc"}').status, 0)
+    const empty = run('{}')
+    assert.equal(empty.status, 1)
+    assert.match(empty.out, /FAIL: setup produced empty ID/)
+    const nul = run('{"_id":null}')
+    assert.equal(nul.status, 1)
+    assert.match(nul.out, /FAIL: setup produced empty ID/)
+  })
+
+  it('emits the empty set guard for a var reused in a nested body', () => {
+    const testFile: TestFile = {
+      sourceFile: 'fleet.yml',
+      requires: { serverless: true, stack: true },
+      setup: [
+        { kind: 'do', action: 'count', params: { index: 'x' }, body: undefined },
+        { kind: 'set', assignments: { 'items.0.id': 'agent_id' } }
+      ],
+      teardown: [],
+      tests: [{
+        name: 'bulk',
+        steps: [
+          { kind: 'do', action: 'agents.bulk-remove', params: {}, body: { agents: ['$agent_id'] } }
+        ]
+      }]
+    }
+    const result = generateScript(testFile, testDefs)
+    assert.ok(result.script.includes('FAIL: setup produced empty AGENT_ID'))
+  })
+
+  it('does not emit a fail-fast set guard when skipEmptySet skips instead', () => {
+    const testFile: TestFile = {
+      sourceFile: 'list.yml',
+      requires: { serverless: true, stack: true },
+      setup: [],
+      teardown: [],
+      tests: [{
+        name: 'get item',
+        steps: [
+          { kind: 'do', action: 'count', params: { index: 'x' }, body: undefined },
+          { kind: 'set', assignments: { 'regions.0.id': 'id' } },
+          { kind: 'do', action: 'get', params: { index: 'x', id: '$id' }, body: undefined }
+        ]
+      }]
+    }
+    const result = generateScript(testFile, testDefs, { skipEmptySet: true })
+    assert.equal(result.script.includes('FAIL: setup produced empty ID'), false)
+    assert.ok(result.script.includes('SKIP: no id in list response'))
   })
 
   it('skipNotFound wraps do-steps to skip 404 errors', () => {

--- a/test/functional/kb/definitions/security_attack_discovery_api_post_attack_discovery_bulk.yml
+++ b/test/functional/kb/definitions/security_attack_discovery_api_post_attack_discovery_bulk.yml
@@ -2,28 +2,19 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Kibana security-attack-discovery-api: bulk update attack discovery workflow status.
-# Finds an existing attack discovery in setup (if any), then bulk-updates its
-# workflow status to "open". The response always contains a `data` array
-# (required by the response schema), so the assertion passes even when no
-# matching discovery is found.
+# CI has no attack discoveries. The bulk route still returns a `data` array
+# when ids is empty, which is what this assertion checks.
 ---
 requires:
   serverless: true
   stack: true
   serverless_project: security
 ---
-setup:
-  - do:
-      security-attack-discovery-api.attack_discovery_find:
-        per_page: 1
-  - set: {"data.0.id": discovery_id}
----
 "security-attack-discovery-api post attack discovery bulk":
   - do:
       security-attack-discovery-api.post_attack_discovery_bulk:
         body:
           update:
-            ids:
-              - $discovery_id
+            ids: []
             kibana_alert_workflow_status: open
   - is_true: data


### PR DESCRIPTION
Closes #591. Generated scripts fail when a reused set capture is empty or null. Attack discovery bulk no longer captures a missing id; agent uploads stays skipped on stack because nothing is enrolled.