### PR TITLE
ci: enable wired streams before kb tests

### DIFF
--- a/.buildkite/run-kb-tests-runner.sh
+++ b/.buildkite/run-kb-tests-runner.sh
@@ -110,6 +110,21 @@ until curl -sf -u "elastic:${ES_PASSWORD}" "http://${KB_HOST}:5601/api/status" \
 done
 echo "Kibana is ready"
 
+# Wired stream CRUD 422s until this runs. 409 means it was already enabled.
+echo "--- Enabling wired streams"
+STREAMS_CODE=$(curl -sS -o /tmp/kb-streams-enable.json -w "%{http_code}" \
+  -u "elastic:${ES_PASSWORD}" \
+  -H "kbn-xsrf: true" \
+  -H "elastic-api-version: 2023-10-31" \
+  -H "Content-Type: application/json" \
+  -X POST "http://${KB_HOST}:5601/api/streams/_enable")
+if [ "$STREAMS_CODE" != "200" ] && [ "$STREAMS_CODE" != "409" ]; then
+  echo "FAIL: POST /api/streams/_enable returned ${STREAMS_CODE}"
+  cat /tmp/kb-streams-enable.json
+  exit 1
+fi
+echo "Wired streams enabled (${STREAMS_CODE})"
+
 echo "--- Generating CLI config file"
 cat > /tmp/elastic-rc.yml <<EOF
 contexts:

--- a/codegen/functional/kb.ts
+++ b/codegen/functional/kb.ts
@@ -414,6 +414,20 @@ const skippedFilesStack = new Set<string>([
   "significantevents_post_streams_name_queries_bulk.yml",
   "significantevents_put_streams_name_queries_queryid.yml",
 
+  // 9.3 PUT /api/streams/{name} requires body.queries. Fixtures omit it
+  // (9.5 moved queries off the upsert contract). Enable itself works.
+  "streams_delete_streams_name.yml",
+  "streams_delete_streams_streamname_attachments_attachmenttype_attachmentid.yml",
+  "streams_get_streams_name.yml",
+  "streams_get_streams_name_ingest.yml",
+  "streams_get_streams_streamname_attachments.yml",
+  "streams_post_streams_name_content_export.yml",
+  "streams_post_streams_name_content_import.yml",
+  "streams_post_streams_name_fork.yml",
+  "streams_post_streams_streamname_attachments_bulk.yml",
+  "streams_put_streams_name.yml",
+  "streams_put_streams_name_ingest.yml",
+  "streams_put_streams_streamname_attachments_attachmenttype_attachmentid.yml",
   // 9.3 PUT query requires body.kql; fixtures and the CLI schema send esql.
   "streams_get_streams_name_query.yml",
   "streams_put_streams_name_query.yml",

--- a/codegen/functional/kb.ts
+++ b/codegen/functional/kb.ts
@@ -162,8 +162,8 @@ const skippedFilesServerless = new Set<string>([
   "elastic_agents_get_fleet_agent_status_data.yml",
   "elastic_agents_get_fleet_agents_agentid_effective_config.yml",
 
-  // Wired streams are not enabled in the serverless env (422: "Streams are not
-  // enabled for Wired streams"), so no stream can be created or read.
+  // Wired streams are not enabled in the serverless env (422). Stack CI
+  // provisions POST /api/streams/_enable; serverless has no equivalent yet.
   "streams_delete_streams_name.yml",
   "streams_delete_streams_streamname_attachments_attachmenttype_attachmentid.yml",
   "streams_get_streams_name.yml",
@@ -179,8 +179,8 @@ const skippedFilesServerless = new Set<string>([
   "streams_put_streams_name_query.yml",
   "streams_put_streams_streamname_attachments_attachmenttype_attachmentid.yml",
 
-  // Entity Store is not installed in the serverless env; every entity-store op
-  // 400s asking for POST /api/security/entity_store/install first.
+  // Entity Store V2 (/api/security/entity_store/*) is not on 9.3.0. Install
+  // is POST /api/security/entity_store/install on 9.5+.
   "security_entity_store_delete_security_entity_store_entities.yml",
   "security_entity_store_get_security_entity_store_resolution_group.yml",
   "security_entity_store_post_security_entity_store_entities_entitytype.yml",
@@ -387,8 +387,8 @@ const skippedFilesStack = new Set<string>([
   "elastic_agent_actions_post_fleet_agents_bulk_upgrade.yml",
   "elastic_agents_post_fleet_agents_bulk_privilege_level_change.yml",
 
-  // Entity Store is not installed in the stack env; every entity-store op 400s
-  // asking for POST /api/security/entity_store/install first.
+  // Entity Store V2 (/api/security/entity_store/*) is not on 9.3.0. Install
+  // is POST /api/security/entity_store/install on 9.5+.
   "security_entity_store_delete_security_entity_store_entities.yml",
   "security_entity_store_get_security_entity_store_resolution_group.yml",
   "security_entity_store_post_security_entity_store_entities_entitytype.yml",
@@ -398,8 +398,10 @@ const skippedFilesStack = new Set<string>([
   "security_entity_store_put_security_entity_store_entities_bulk.yml",
   "security_entity_store_put_security_entity_store_entities_entitytype.yml",
 
-  // Risk engine unavailable: Entity Store V2 is enabled (legacy risk API 400s)
-  // and the risk-engine routes 404 in this env.
+  // Legacy risk engine is not provisionable: V2 is on by default (init/enable
+  // 400). schedule_now is registered at /internal/risk_score/engine/schedule_now
+  // but the CLI hits /api/risk_score/engine/schedule_now. configure is PUT;
+  // the schema sends PATCH.
   "security_entity_analytics_api_clean_up_risk_engine.yml",
   "security_entity_analytics_api_configure_risk_engine_saved_object.yml",
   "security_entity_analytics_api_schedule_risk_engine_now.yml",
@@ -412,22 +414,9 @@ const skippedFilesStack = new Set<string>([
   "significantevents_post_streams_name_queries_bulk.yml",
   "significantevents_put_streams_name_queries_queryid.yml",
 
-  // Wired streams are not enabled in the stack env (422: "Streams are not
-  // enabled for Wired streams"), so no stream can be created or read.
-  "streams_delete_streams_name.yml",
-  "streams_delete_streams_streamname_attachments_attachmenttype_attachmentid.yml",
-  "streams_get_streams_name.yml",
-  "streams_get_streams_name_ingest.yml",
+  // 9.3 PUT query requires body.kql; fixtures and the CLI schema send esql.
   "streams_get_streams_name_query.yml",
-  "streams_get_streams_streamname_attachments.yml",
-  "streams_post_streams_name_content_export.yml",
-  "streams_post_streams_name_content_import.yml",
-  "streams_post_streams_name_fork.yml",
-  "streams_post_streams_streamname_attachments_bulk.yml",
-  "streams_put_streams_name.yml",
-  "streams_put_streams_name_ingest.yml",
   "streams_put_streams_name_query.yml",
-  "streams_put_streams_streamname_attachments_attachmenttype_attachmentid.yml",
 
   // No SLO definitions exist in the env (404); slo_bulk_snapshot and slo_get_snapshot
   // depend on data that is never provisioned.


### PR DESCRIPTION
POST /api/streams/_enable after the KB readiness gate so wired stream CRUD stops 422ing. Relates to #593.