### PR TITLE
ci: install entity store before kb tests

### DIFF
--- a/.buildkite/run-kb-tests-runner.sh
+++ b/.buildkite/run-kb-tests-runner.sh
@@ -163,6 +163,33 @@ if [ "$STREAMS_CODE" = "409" ] && \
   STREAMS_CODE=$(streams_post_enable)
 fi
 if [ "$STREAMS_CODE" != "200" ] && ! streams_logs_enabled; then
+  if [ "$STREAMS_CODE" = "500" ] || [ "$STREAMS_CODE" = "503" ]; then
+    echo "--- Retrying streams enable after ${STREAMS_CODE}"
+    WAIT=0
+    until [ "$WAIT" -ge 30 ]; do
+      sleep 2
+      WAIT=$((WAIT + 1))
+      STREAMS_CODE=$(streams_post_enable)
+      if [ "$STREAMS_CODE" = "200" ] || streams_logs_enabled; then
+        STREAMS_CODE=200
+        break
+      fi
+      if [ "$STREAMS_CODE" = "409" ] && \
+         ! jq -e '.message | test("lock"; "i")' /tmp/kb-streams-enable.json >/dev/null; then
+        echo "--- Clearing conflicting logs data streams"
+        curl -sS -u "elastic:${ES_PASSWORD}" \
+          -X DELETE "http://${ES_HOST}:9200/_data_stream/logs,logs.otel,logs.ecs" || true
+        echo
+        STREAMS_CODE=$(streams_post_enable)
+        if [ "$STREAMS_CODE" = "200" ] || streams_logs_enabled; then
+          STREAMS_CODE=200
+          break
+        fi
+      fi
+    done
+  fi
+fi
+if [ "$STREAMS_CODE" != "200" ] && ! streams_logs_enabled; then
   echo "FAIL: POST /api/streams/_enable returned ${STREAMS_CODE}"
   cat /tmp/kb-streams-enable.json
   echo

--- a/.buildkite/run-kb-tests-runner.sh
+++ b/.buildkite/run-kb-tests-runner.sh
@@ -175,6 +175,43 @@ if [ "$STREAMS_CODE" != "200" ] && ! streams_logs_enabled; then
 fi
 echo "Wired streams enabled"
 
+# Entity Store V2 400s until this runs. 409 means it was already installed.
+echo "--- Installing entity store"
+ENTITY_STORE_CODE=$(curl -sS -o /tmp/kb-entity-store-install.json -w "%{http_code}" \
+  -u "elastic:${ES_PASSWORD}" \
+  -H "kbn-xsrf: true" \
+  -H "elastic-api-version: 2023-10-31" \
+  -H "Content-Type: application/json" \
+  -X POST "http://${KB_HOST}:5601/api/security/entity_store/install" \
+  -d '{"entityTypes":["user","host","service","generic"]}')
+if [ "$ENTITY_STORE_CODE" != "200" ] && [ "$ENTITY_STORE_CODE" != "409" ]; then
+  echo "FAIL: POST /api/security/entity_store/install returned ${ENTITY_STORE_CODE}"
+  cat /tmp/kb-entity-store-install.json
+  exit 1
+fi
+echo "Entity store installed (${ENTITY_STORE_CODE})"
+
+echo "--- Waiting for entity store engines"
+RETRIES=0
+MAX_RETRIES=30
+until curl -sf -u "elastic:${ES_PASSWORD}" \
+      -H "kbn-xsrf: true" \
+      -H "elastic-api-version: 2023-10-31" \
+      "http://${KB_HOST}:5601/api/security/entity_store/status" \
+      | jq -e '.engines | length > 0 and all(.status == "started")' > /dev/null 2>&1; do
+  RETRIES=$((RETRIES + 1))
+  if [ "$RETRIES" -ge "$MAX_RETRIES" ]; then
+    echo "Entity store engines did not start in time"
+    curl -sS -u "elastic:${ES_PASSWORD}" \
+      -H "kbn-xsrf: true" \
+      -H "elastic-api-version: 2023-10-31" \
+      "http://${KB_HOST}:5601/api/security/entity_store/status" || true
+    exit 1
+  fi
+  sleep 2
+done
+echo "Entity store engines started"
+
 echo "--- Generating CLI config file"
 cat > /tmp/elastic-rc.yml <<EOF
 contexts:

--- a/.buildkite/run-kb-tests-runner.sh
+++ b/.buildkite/run-kb-tests-runner.sh
@@ -175,7 +175,7 @@ if [ "$STREAMS_CODE" != "200" ] && ! streams_logs_enabled; then
 fi
 echo "Wired streams enabled"
 
-# Entity Store V2 400s until this runs. 409 means it was already installed.
+# Entity Store V2 400s until this runs. 201 is created; 409 is already installed.
 echo "--- Installing entity store"
 ENTITY_STORE_CODE=$(curl -sS -o /tmp/kb-entity-store-install.json -w "%{http_code}" \
   -u "elastic:${ES_PASSWORD}" \
@@ -184,7 +184,7 @@ ENTITY_STORE_CODE=$(curl -sS -o /tmp/kb-entity-store-install.json -w "%{http_cod
   -H "Content-Type: application/json" \
   -X POST "http://${KB_HOST}:5601/api/security/entity_store/install" \
   -d '{"entityTypes":["user","host","service","generic"]}')
-if [ "$ENTITY_STORE_CODE" != "200" ] && [ "$ENTITY_STORE_CODE" != "409" ]; then
+if [ "$ENTITY_STORE_CODE" != "200" ] && [ "$ENTITY_STORE_CODE" != "201" ] && [ "$ENTITY_STORE_CODE" != "409" ]; then
   echo "FAIL: POST /api/security/entity_store/install returned ${ENTITY_STORE_CODE}"
   cat /tmp/kb-entity-store-install.json
   exit 1

--- a/codegen/functional/kb.ts
+++ b/codegen/functional/kb.ts
@@ -404,17 +404,6 @@ const skippedFilesStack = new Set<string>([
   // registers /internal/risk_score/engine/schedule_now only.
   "security_entity_analytics_api_schedule_risk_engine_now.yml",
 
-  // Entity Store V2 (/api/security/entity_store/*) is not on 9.3.0. Install
-  // is POST /api/security/entity_store/install on 9.5+.
-  "security_entity_store_delete_security_entity_store_entities.yml",
-  "security_entity_store_get_security_entity_store_resolution_group.yml",
-  "security_entity_store_post_security_entity_store_entities_entitytype.yml",
-  "security_entity_store_post_security_entity_store_resolution_link.yml",
-  "security_entity_store_post_security_entity_store_resolution_unlink.yml",
-  "security_entity_store_put_security_entity_store.yml",
-  "security_entity_store_put_security_entity_store_entities_bulk.yml",
-  "security_entity_store_put_security_entity_store_entities_entitytype.yml",
-
   // 9.3 PUT /api/streams/{name} requires body.queries. Fixtures omit it
   // (9.5 moved queries off the upsert contract). Enable itself works.
   "streams_delete_streams_name.yml",

--- a/test/functional/kb/definitions/security_entity_store_delete_security_entity_store_entities.yml
+++ b/test/functional/kb/definitions/security_entity_store_delete_security_entity_store_entities.yml
@@ -10,20 +10,19 @@ requires:
 setup:
   - do:
       security-entity-store.post_security_entity_store_entities_entitytype:
-        entity_type: user
+        entity_type: host
         body:
-          user:
+          host:
             name: cli-ft-entity-delete
-  - set: {entity.id: entity_id}
 ---
 teardown:
   - do:
       security-entity-store.delete_security_entity_store_entities:
-        entity_id: $entity_id
+        entity_id: host:cli-ft-entity-delete
         ignore: [404]
 ---
 "security-entity-store delete security entity store entities":
   - do:
       security-entity-store.delete_security_entity_store_entities:
-        entity_id: $entity_id
+        entity_id: host:cli-ft-entity-delete
   - is_true: ""

--- a/test/functional/kb/definitions/security_entity_store_get_security_entity_store_resolution_group.yml
+++ b/test/functional/kb/definitions/security_entity_store_get_security_entity_store_resolution_group.yml
@@ -11,20 +11,19 @@ requires:
 setup:
   - do:
       security-entity-store.put_security_entity_store_entities_entitytype:
-        entity_type: user
+        entity_type: host
         body:
-          user:
+          host:
             name: cli-ft-entity-resolution-group
-  - set: {entity.id: entity_id}
 ---
 teardown:
   - do:
       security-entity-store.delete_security_entity_store_entities:
-        entity_id: $entity_id
+        entity_id: host:cli-ft-entity-resolution-group
         ignore: [404]
 ---
 "security-entity-store get security entity store resolution group":
   - do:
       security-entity-store.get_security_entity_store_resolution_group:
-        entity_id: $entity_id
+        entity_id: host:cli-ft-entity-resolution-group
   - is_true: ""

--- a/test/functional/kb/definitions/security_entity_store_get_security_entity_store_resolution_group.yml
+++ b/test/functional/kb/definitions/security_entity_store_get_security_entity_store_resolution_group.yml
@@ -10,7 +10,7 @@ requires:
 ---
 setup:
   - do:
-      security-entity-store.put_security_entity_store_entities_entitytype:
+      security-entity-store.post_security_entity_store_entities_entitytype:
         entity_type: host
         body:
           host:

--- a/test/functional/kb/definitions/security_entity_store_post_security_entity_store_entities_entitytype.yml
+++ b/test/functional/kb/definitions/security_entity_store_post_security_entity_store_entities_entitytype.yml
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Kibana security-entity-store: create an entity by entity type.
+# Host identity derives EUID host:<name>. Create returns {ok: true}, not entity.id.
 ---
 requires:
   serverless: true
@@ -10,15 +11,14 @@ requires:
 teardown:
   - do:
       security-entity-store.delete_security_entity_store_entities:
-        entity_id: $entity_id
+        entity_id: host:cli-ft-entity-create
         ignore: [404]
 ---
 "security-entity-store post security entity store entities entitytype":
   - do:
       security-entity-store.post_security_entity_store_entities_entitytype:
-        entity_type: user
+        entity_type: host
         body:
-          user:
+          host:
             name: cli-ft-entity-create
-  - set: {entity.id: entity_id}
-  - is_true: "entity.id"
+  - is_true: ok

--- a/test/functional/kb/definitions/security_entity_store_post_security_entity_store_resolution_link.yml
+++ b/test/functional/kb/definitions/security_entity_store_post_security_entity_store_resolution_link.yml
@@ -10,13 +10,13 @@ requires:
 ---
 setup:
   - do:
-      security-entity-store.put_security_entity_store_entities_entitytype:
+      security-entity-store.post_security_entity_store_entities_entitytype:
         entity_type: host
         body:
           host:
             name: cli-ft-resolution-link-source
   - do:
-      security-entity-store.put_security_entity_store_entities_entitytype:
+      security-entity-store.post_security_entity_store_entities_entitytype:
         entity_type: host
         body:
           host:

--- a/test/functional/kb/definitions/security_entity_store_post_security_entity_store_resolution_link.yml
+++ b/test/functional/kb/definitions/security_entity_store_post_security_entity_store_resolution_link.yml
@@ -11,27 +11,25 @@ requires:
 setup:
   - do:
       security-entity-store.put_security_entity_store_entities_entitytype:
-        entity_type: user
+        entity_type: host
         body:
-          user:
+          host:
             name: cli-ft-resolution-link-source
-  - set: {entity.id: entity_id_source}
   - do:
       security-entity-store.put_security_entity_store_entities_entitytype:
-        entity_type: user
+        entity_type: host
         body:
-          user:
+          host:
             name: cli-ft-resolution-link-target
-  - set: {entity.id: entity_id_target}
 ---
 teardown:
   - do:
       security-entity-store.delete_security_entity_store_entities:
-        entity_id: $entity_id_source
+        entity_id: host:cli-ft-resolution-link-source
         ignore: [404]
   - do:
       security-entity-store.delete_security_entity_store_entities:
-        entity_id: $entity_id_target
+        entity_id: host:cli-ft-resolution-link-target
         ignore: [404]
 ---
 "security-entity-store post security entity store resolution link":
@@ -39,6 +37,6 @@ teardown:
       security-entity-store.post_security_entity_store_resolution_link:
         body:
           entity_ids:
-            - $entity_id_source
-          target_id: $entity_id_target
+            - host:cli-ft-resolution-link-source
+          target_id: host:cli-ft-resolution-link-target
   - is_true: ""

--- a/test/functional/kb/definitions/security_entity_store_post_security_entity_store_resolution_unlink.yml
+++ b/test/functional/kb/definitions/security_entity_store_post_security_entity_store_resolution_unlink.yml
@@ -10,13 +10,13 @@ requires:
 ---
 setup:
   - do:
-      security-entity-store.put_security_entity_store_entities_entitytype:
+      security-entity-store.post_security_entity_store_entities_entitytype:
         entity_type: host
         body:
           host:
             name: cli-ft-resolution-unlink-source
   - do:
-      security-entity-store.put_security_entity_store_entities_entitytype:
+      security-entity-store.post_security_entity_store_entities_entitytype:
         entity_type: host
         body:
           host:

--- a/test/functional/kb/definitions/security_entity_store_post_security_entity_store_resolution_unlink.yml
+++ b/test/functional/kb/definitions/security_entity_store_post_security_entity_store_resolution_unlink.yml
@@ -11,33 +11,31 @@ requires:
 setup:
   - do:
       security-entity-store.put_security_entity_store_entities_entitytype:
-        entity_type: user
+        entity_type: host
         body:
-          user:
+          host:
             name: cli-ft-resolution-unlink-source
-  - set: {entity.id: entity_id_source}
   - do:
       security-entity-store.put_security_entity_store_entities_entitytype:
-        entity_type: user
+        entity_type: host
         body:
-          user:
+          host:
             name: cli-ft-resolution-unlink-target
-  - set: {entity.id: entity_id_target}
   - do:
       security-entity-store.post_security_entity_store_resolution_link:
         body:
           entity_ids:
-            - $entity_id_source
-          target_id: $entity_id_target
+            - host:cli-ft-resolution-unlink-source
+          target_id: host:cli-ft-resolution-unlink-target
 ---
 teardown:
   - do:
       security-entity-store.delete_security_entity_store_entities:
-        entity_id: $entity_id_source
+        entity_id: host:cli-ft-resolution-unlink-source
         ignore: [404]
   - do:
       security-entity-store.delete_security_entity_store_entities:
-        entity_id: $entity_id_target
+        entity_id: host:cli-ft-resolution-unlink-target
         ignore: [404]
 ---
 "security-entity-store post security entity store resolution unlink":
@@ -45,5 +43,5 @@ teardown:
       security-entity-store.post_security_entity_store_resolution_unlink:
         body:
           entity_ids:
-            - $entity_id_source
+            - host:cli-ft-resolution-unlink-source
   - is_true: ""

--- a/test/functional/kb/definitions/security_entity_store_put_security_entity_store_entities_bulk.yml
+++ b/test/functional/kb/definitions/security_entity_store_put_security_entity_store_entities_bulk.yml
@@ -11,16 +11,15 @@ requires:
 setup:
   - do:
       security-entity-store.post_security_entity_store_entities_entitytype:
-        entity_type: user
+        entity_type: host
         body:
-          user:
+          host:
             name: cli-ft-entity-bulk-update
-  - set: {entity.id: entity_id}
 ---
 teardown:
   - do:
       security-entity-store.delete_security_entity_store_entities:
-        entity_id: $entity_id
+        entity_id: host:cli-ft-entity-bulk-update
         ignore: [404]
 ---
 "security-entity-store put security entity store entities bulk":
@@ -28,10 +27,10 @@ teardown:
       security-entity-store.put_security_entity_store_entities_bulk:
         body:
           entities:
-            - type: user
+            - type: host
               doc:
                 entity:
-                  id: $entity_id
-                user:
+                  id: host:cli-ft-entity-bulk-update
+                host:
                   name: cli-ft-entity-bulk-update
   - is_true: ""

--- a/test/functional/kb/definitions/security_entity_store_put_security_entity_store_entities_entitytype.yml
+++ b/test/functional/kb/definitions/security_entity_store_put_security_entity_store_entities_entitytype.yml
@@ -2,11 +2,19 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Kibana security-entity-store: upsert an entity by entity type.
-# Host identity derives EUID host:<name>. Upsert returns {ok: true}, not entity.id.
+# PUT is update-only. Create with POST first. Response is {ok: true}.
 ---
 requires:
   serverless: true
   stack: true
+---
+setup:
+  - do:
+      security-entity-store.post_security_entity_store_entities_entitytype:
+        entity_type: host
+        body:
+          host:
+            name: cli-ft-entity-put
 ---
 teardown:
   - do:

--- a/test/functional/kb/definitions/security_entity_store_put_security_entity_store_entities_entitytype.yml
+++ b/test/functional/kb/definitions/security_entity_store_put_security_entity_store_entities_entitytype.yml
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 #
 # Kibana security-entity-store: upsert an entity by entity type.
+# Host identity derives EUID host:<name>. Upsert returns {ok: true}, not entity.id.
 ---
 requires:
   serverless: true
@@ -10,15 +11,14 @@ requires:
 teardown:
   - do:
       security-entity-store.delete_security_entity_store_entities:
-        entity_id: $entity_id
+        entity_id: host:cli-ft-entity-put
         ignore: [404]
 ---
 "security-entity-store put security entity store entities entitytype":
   - do:
       security-entity-store.put_security_entity_store_entities_entitytype:
-        entity_type: user
+        entity_type: host
         body:
-          user:
+          host:
             name: cli-ft-entity-put
-  - set: {entity.id: entity_id}
-  - is_true: "entity.id"
+  - is_true: ok


### PR DESCRIPTION
Relates to #593. Installs the entity store, then runs CRUD with host identity (user.name alone cannot derive an EUID; create returns {ok: true}).