### PR TITLE
ci: provision risk engine before kb tests

### DIFF
--- a/.buildkite/kibana-ci.yml
+++ b/.buildkite/kibana-ci.yml
@@ -17,16 +17,19 @@ xpack.security.encryptionKey: "${XPACK_SECURITY_ENCRYPTIONKEY}"
 
 # 9.5 still registers these Advanced Settings. 9.6 removes them in favor of
 # streams.significantEventsAvailable; uiSettings keys become inert.
-# V2 on at boot skips registering risk_engine:risk_scoring. Runtime uiSettings
-# toggle does not register the task type. Entity store V2 defs stay skipped.
 uiSettings.overrides:
   "observability:streamsEnableSignificantEvents": true
   "observability:streamsEnableSignificantEventsDiscovery": true
   "observability:streamsEnableQueryStreams": true
-  "securitySolution:entityStoreEnableV2": false
 
 feature_flags.overrides:
   streams.significantEventsAvailable: true
+
+# V2 defaults on in 9.5.3. That path registers the V2 maintainer, not
+# risk_engine:risk_scoring. uiSettings.entityStoreEnableV2 does not change
+# this; the experimental flag is read at plugin setup.
+xpack.securitySolution.enableExperimental:
+  - "disable:entityAnalyticsEntityStoreV2"
 
 xpack.fleet.enableExperimental:
   - agentlessPoliciesAPI

--- a/.buildkite/kibana-ci.yml
+++ b/.buildkite/kibana-ci.yml
@@ -17,10 +17,13 @@ xpack.security.encryptionKey: "${XPACK_SECURITY_ENCRYPTIONKEY}"
 
 # 9.5 still registers these Advanced Settings. 9.6 removes them in favor of
 # streams.significantEventsAvailable; uiSettings keys become inert.
+# V2 on at boot skips registering risk_engine:risk_scoring. Runtime uiSettings
+# toggle does not register the task type. Entity store V2 defs stay skipped.
 uiSettings.overrides:
   "observability:streamsEnableSignificantEvents": true
   "observability:streamsEnableSignificantEventsDiscovery": true
   "observability:streamsEnableQueryStreams": true
+  "securitySolution:entityStoreEnableV2": false
 
 feature_flags.overrides:
   streams.significantEventsAvailable: true

--- a/.buildkite/run-kb-tests-runner.sh
+++ b/.buildkite/run-kb-tests-runner.sh
@@ -28,6 +28,7 @@ if ! getent hosts kibana > /dev/null 2>&1; then
 fi
 
 echo "ES_HOST=${ES_HOST}  KB_HOST=${KB_HOST}"
+export KB_URL="http://${KB_HOST}:5601"
 
 # ── Wait for Elasticsearch ───────────────────────────────────────────────────
 echo "--- Waiting for Elasticsearch to be healthy"

--- a/.buildkite/run-kb-tests-runner.sh
+++ b/.buildkite/run-kb-tests-runner.sh
@@ -192,6 +192,7 @@ contexts:
 current_context: ci
 EOF
 export ELASTIC_CLI_CONFIG_FILE="/tmp/elastic-rc.yml"
+export KB_URL="http://${KB_HOST}:5601"
 
 echo "+++ Running KB functional tests"
 # this setup only runs against stack Kibana

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -221,7 +221,7 @@ released to the public npm registry; depend on it through the workspace.
 
 
 ------------------------------------------------------------------------
-@elastic/schemas@0.7.2
+@elastic/schemas@0.7.3
 License: Apache-2.0
 Repository: https://github.com/elastic/schemas-js
 Publisher: Elastic Client Library Maintainers

--- a/codegen/functional/kb.ts
+++ b/codegen/functional/kb.ts
@@ -47,13 +47,10 @@ const KB_PREAMBLE = [
   'RESPONSE=""'
 ]
 
-// Legacy risk engine init/schedule_now/cleanup 400 while
-// securitySolution:entityStoreEnableV2 is on. Disable it, init, restore on exit
-// so entity store V2 defs in the same suite still see the default.
+// Cleanup only. configure stays skipped (schema is PATCH, route is PUT).
+// schedule_now stays skipped (9.5.3 registers /internal only).
 const RISK_ENGINE_DEFS = new Set([
   'security_entity_analytics_api_clean_up_risk_engine.yml',
-  'security_entity_analytics_api_configure_risk_engine_saved_object.yml',
-  'security_entity_analytics_api_schedule_risk_engine_now.yml',
 ])
 
 const RISK_ENGINE_PREAMBLE = [
@@ -401,6 +398,12 @@ const skippedFilesStack = new Set<string>([
   "elastic_agent_actions_post_fleet_agents_bulk_unenroll.yml",
   "elastic_agent_actions_post_fleet_agents_bulk_upgrade.yml",
   "elastic_agents_post_fleet_agents_bulk_privilege_level_change.yml",
+
+  // configure: published schema is PATCH; Kibana route is PUT.
+  // schedule_now: CLI hits /api/risk_score/engine/schedule_now; 9.5.3
+  // registers /internal/risk_score/engine/schedule_now only.
+  "security_entity_analytics_api_configure_risk_engine_saved_object.yml",
+  "security_entity_analytics_api_schedule_risk_engine_now.yml",
 
   // Entity Store V2 (/api/security/entity_store/*) is not on 9.3.0. Install
   // is POST /api/security/entity_store/install on 9.5+.

--- a/codegen/functional/kb.ts
+++ b/codegen/functional/kb.ts
@@ -47,6 +47,20 @@ const KB_PREAMBLE = [
   'RESPONSE=""'
 ]
 
+// Legacy risk engine init/schedule_now/cleanup 400 while
+// securitySolution:entityStoreEnableV2 is on. Disable it, init, restore on exit
+// so entity store V2 defs in the same suite still see the default.
+const RISK_ENGINE_DEFS = new Set([
+  'security_entity_analytics_api_clean_up_risk_engine.yml',
+  'security_entity_analytics_api_configure_risk_engine_saved_object.yml',
+  'security_entity_analytics_api_schedule_risk_engine_now.yml',
+])
+
+const RISK_ENGINE_PREAMBLE = [
+  ...KB_PREAMBLE,
+  'source "$SCRIPT_DIR/../risk-engine-provision.sh"'
+]
+
 const apis = await loadAllKbApis()
 
 mkdirSync(OUT_DIR, { recursive: true })
@@ -399,14 +413,6 @@ const skippedFilesStack = new Set<string>([
   "security_entity_store_put_security_entity_store_entities_bulk.yml",
   "security_entity_store_put_security_entity_store_entities_entitytype.yml",
 
-  // Legacy risk engine is not provisionable: V2 is on by default (init/enable
-  // 400). schedule_now is registered at /internal/risk_score/engine/schedule_now
-  // but the CLI hits /api/risk_score/engine/schedule_now. configure is PUT;
-  // the schema sends PATCH.
-  "security_entity_analytics_api_clean_up_risk_engine.yml",
-  "security_entity_analytics_api_configure_risk_engine_saved_object.yml",
-  "security_entity_analytics_api_schedule_risk_engine_now.yml",
-
   // 9.3 PUT /api/streams/{name} requires body.queries. Fixtures omit it
   // (9.5 moved queries off the upsert contract). Enable itself works.
   "streams_delete_streams_name.yml",
@@ -505,7 +511,7 @@ for (const file of yamlFiles) {
 
   const result = generateScript(testFile, apis, {
     clientArgs: ['stack', 'kb'],
-    preamble: KB_PREAMBLE
+    preamble: RISK_ENGINE_DEFS.has(file) ? RISK_ENGINE_PREAMBLE : KB_PREAMBLE
   })
 
   for (const action of result.skippedActions) allSkippedActions.add(action)

--- a/codegen/functional/kb.ts
+++ b/codegen/functional/kb.ts
@@ -47,10 +47,11 @@ const KB_PREAMBLE = [
   'RESPONSE=""'
 ]
 
-// Cleanup only. configure stays skipped (schema is PATCH, route is PUT).
-// schedule_now stays skipped (9.5.3 registers /internal only).
+// Cleanup and configure. schedule_now stays skipped (9.5.3
+// registers /internal only).
 const RISK_ENGINE_DEFS = new Set([
   'security_entity_analytics_api_clean_up_risk_engine.yml',
+  'security_entity_analytics_api_configure_risk_engine_saved_object.yml',
 ])
 
 const RISK_ENGINE_PREAMBLE = [
@@ -399,10 +400,8 @@ const skippedFilesStack = new Set<string>([
   "elastic_agent_actions_post_fleet_agents_bulk_upgrade.yml",
   "elastic_agents_post_fleet_agents_bulk_privilege_level_change.yml",
 
-  // configure: published schema is PATCH; Kibana route is PUT.
   // schedule_now: CLI hits /api/risk_score/engine/schedule_now; 9.5.3
   // registers /internal/risk_score/engine/schedule_now only.
-  "security_entity_analytics_api_configure_risk_engine_saved_object.yml",
   "security_entity_analytics_api_schedule_risk_engine_now.yml",
 
   // Entity Store V2 (/api/security/entity_store/*) is not on 9.3.0. Install

--- a/docs/cli/schema.json
+++ b/docs/cli/schema.json
@@ -60202,6 +60202,13 @@
                   "parameters": [
                     {
                       "role": "flag",
+                      "name": "approvals",
+                      "type": "string",
+                      "required": false,
+                      "summary": "Actions the tool run may take that would otherwise need a live user to approve them. Applies to this run and any sub-agents it spawns."
+                    },
+                    {
+                      "role": "flag",
                       "name": "connector-id",
                       "type": "string",
                       "required": false,
@@ -85675,6 +85682,9 @@
                   ],
                   "summary": "Configure the Risk Engine Saved Object",
                   "intent": {
+                    "destructive": false,
+                    "idempotent": true,
+                    "scope": "global",
                     "requiresAuth": true
                   }
                 },
@@ -104457,6 +104467,13 @@
                   ],
                   "name": "create-traffic-filter",
                   "parameters": [
+                    {
+                      "role": "flag",
+                      "name": "organization-id",
+                      "type": "string",
+                      "required": true,
+                      "summary": "The Organization ID to scope the request to."
+                    },
                     {
                       "role": "flag",
                       "name": "name",

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
       "dependencies": {
         "@cli-schema/spec": "^0.2.0",
         "@elastic/config-resolver": "0.1.1",
-        "@elastic/schemas": "^0.7.2",
+        "@elastic/schemas": "^0.7.3",
         "ajv": "^6.14.0",
         "cli-table3": "^0.6.5",
         "commander": "^15.0.0",
@@ -108,9 +108,9 @@
       "link": true
     },
     "node_modules/@elastic/schemas": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/@elastic/schemas/-/schemas-0.7.2.tgz",
-      "integrity": "sha512-n82fOdrTWPny0mXJSAU5yVbxng8P66DCXsjlzUjk43Vl0JucgVXzUhKAs072YNi22HIp5wOR6xaDowzrse87SA==",
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@elastic/schemas/-/schemas-0.7.3.tgz",
+      "integrity": "sha512-/TRs9thlhdmK75cxzOPNoeSOCanpTotoZn0LwORE9DY2pSnmS+i1hKFMkGLMYscZiuIgULfCMhV0Nll9+bTP4g==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"

--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
   "dependencies": {
     "@cli-schema/spec": "^0.2.0",
     "@elastic/config-resolver": "0.1.1",
-    "@elastic/schemas": "^0.7.2",
+    "@elastic/schemas": "^0.7.3",
     "ajv": "^6.14.0",
     "cli-table3": "^0.6.5",
     "commander": "^15.0.0",

--- a/test/functional/kb/risk-engine-provision.sh
+++ b/test/functional/kb/risk-engine-provision.sh
@@ -1,0 +1,46 @@
+# Copyright Elasticsearch B.V. and contributors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Sourced by the three legacy risk engine functional scripts. Those APIs
+# return 400 while securitySolution:entityStoreEnableV2 is on.
+
+KB_PROVISION_URL="${KB_URL:-http://127.0.0.1:5601}"
+
+kb_set_entity_store_v2() {
+  local value="$1"
+  local code
+  code=$(curl -sS -o /tmp/kb-v2.json -w "%{http_code}" \
+    -u "elastic:${ES_PASSWORD:-changeme}" \
+    -H "kbn-xsrf: true" \
+    -H "x-elastic-internal-origin: kibana" \
+    -H "Content-Type: application/json" \
+    -X POST "${KB_PROVISION_URL}/internal/kibana/settings" \
+    -d "{\"changes\":{\"securitySolution:entityStoreEnableV2\":${value}}}")
+  if [ "$code" != "200" ]; then
+    echo "FAIL: set entityStoreEnableV2=${value} returned ${code}"
+    cat /tmp/kb-v2.json
+    return 1
+  fi
+}
+
+kb_init_legacy_risk_engine() {
+  local code
+  code=$(curl -sS -o /tmp/kb-risk-init.json -w "%{http_code}" \
+    -u "elastic:${ES_PASSWORD:-changeme}" \
+    -H "kbn-xsrf: true" \
+    -H "x-elastic-internal-origin: kibana" \
+    -H "elastic-api-version: 1" \
+    -H "Content-Type: application/json" \
+    -X POST "${KB_PROVISION_URL}/internal/risk_score/engine/init")
+  if [ "$code" != "200" ] && [ "$code" != "409" ]; then
+    echo "FAIL: POST /internal/risk_score/engine/init returned ${code}"
+    cat /tmp/kb-risk-init.json
+    return 1
+  fi
+}
+
+kb_restore_entity_store_v2() { kb_set_entity_store_v2 true || true; }
+
+kb_set_entity_store_v2 false
+kb_init_legacy_risk_engine
+trap kb_restore_entity_store_v2 EXIT

--- a/test/functional/kb/risk-engine-provision.sh
+++ b/test/functional/kb/risk-engine-provision.sh
@@ -2,47 +2,22 @@
 # Copyright Elasticsearch B.V. and contributors
 # SPDX-License-Identifier: Apache-2.0
 #
-# Sourced by the three legacy risk engine functional scripts. Those APIs
-# return 400 while securitySolution:entityStoreEnableV2 is on.
+# Sourced by the legacy risk engine cleanup script. Init needs
+# risk_engine:risk_scoring, which is only registered when Entity Store V2
+# is off at Kibana boot (kibana-ci.yml).
 
 KB_PROVISION_URL="${KB_URL:-http://127.0.0.1:5601}"
-KB_AUTH="elastic:${ES_PASSWORD}"
+KB_USER=elastic
 
-kb_set_entity_store_v2() {
-  local value="$1"
-  local code
-  code=$(curl -sS -o /tmp/kb-v2.json -w "%{http_code}" \
-    -u "${KB_AUTH}" \
-    -H "kbn-xsrf: true" \
-    -H "x-elastic-internal-origin: kibana" \
-    -H "Content-Type: application/json" \
-    -X POST "${KB_PROVISION_URL}/internal/kibana/settings" \
-    -d "{\"changes\":{\"securitySolution:entityStoreEnableV2\":${value}}}")
-  if [ "$code" != "200" ]; then
-    echo "FAIL: set entityStoreEnableV2=${value} returned ${code}"
-    cat /tmp/kb-v2.json
-    return 1
-  fi
-}
-
-kb_init_legacy_risk_engine() {
-  local code
-  code=$(curl -sS -o /tmp/kb-risk-init.json -w "%{http_code}" \
-    -u "${KB_AUTH}" \
-    -H "kbn-xsrf: true" \
-    -H "x-elastic-internal-origin: kibana" \
-    -H "elastic-api-version: 1" \
-    -H "Content-Type: application/json" \
-    -X POST "${KB_PROVISION_URL}/internal/risk_score/engine/init")
-  if [ "$code" != "200" ] && [ "$code" != "409" ]; then
-    echo "FAIL: POST /internal/risk_score/engine/init returned ${code}"
-    cat /tmp/kb-risk-init.json
-    return 1
-  fi
-}
-
-kb_restore_entity_store_v2() { kb_set_entity_store_v2 true || true; }
-
-kb_set_entity_store_v2 false
-kb_init_legacy_risk_engine
-trap kb_restore_entity_store_v2 EXIT
+code=$(curl -sS -o /tmp/kb-risk-init.json -w "%{http_code}" \
+  -u "${KB_USER}:${ES_PASSWORD}" \
+  -H "kbn-xsrf: true" \
+  -H "x-elastic-internal-origin: kibana" \
+  -H "elastic-api-version: 1" \
+  -H "Content-Type: application/json" \
+  -X POST "${KB_PROVISION_URL}/internal/risk_score/engine/init")
+if [ "$code" != "200" ] && [ "$code" != "409" ]; then
+  echo "FAIL: POST /internal/risk_score/engine/init returned ${code}"
+  cat /tmp/kb-risk-init.json
+  return 1
+fi

--- a/test/functional/kb/risk-engine-provision.sh
+++ b/test/functional/kb/risk-engine-provision.sh
@@ -1,3 +1,4 @@
+#!/bin/bash
 # Copyright Elasticsearch B.V. and contributors
 # SPDX-License-Identifier: Apache-2.0
 #
@@ -5,12 +6,13 @@
 # return 400 while securitySolution:entityStoreEnableV2 is on.
 
 KB_PROVISION_URL="${KB_URL:-http://127.0.0.1:5601}"
+KB_AUTH="elastic:${ES_PASSWORD}"
 
 kb_set_entity_store_v2() {
   local value="$1"
   local code
   code=$(curl -sS -o /tmp/kb-v2.json -w "%{http_code}" \
-    -u "elastic:${ES_PASSWORD:-changeme}" \
+    -u "${KB_AUTH}" \
     -H "kbn-xsrf: true" \
     -H "x-elastic-internal-origin: kibana" \
     -H "Content-Type: application/json" \
@@ -26,7 +28,7 @@ kb_set_entity_store_v2() {
 kb_init_legacy_risk_engine() {
   local code
   code=$(curl -sS -o /tmp/kb-risk-init.json -w "%{http_code}" \
-    -u "elastic:${ES_PASSWORD:-changeme}" \
+    -u "${KB_AUTH}" \
     -H "kbn-xsrf: true" \
     -H "x-elastic-internal-origin: kibana" \
     -H "elastic-api-version: 1" \

--- a/test/functional/kb/risk-engine-provision.sh
+++ b/test/functional/kb/risk-engine-provision.sh
@@ -2,9 +2,9 @@
 # Copyright Elasticsearch B.V. and contributors
 # SPDX-License-Identifier: Apache-2.0
 #
-# Sourced by the legacy risk engine cleanup script. Init needs
-# risk_engine:risk_scoring, which is only registered when Entity Store V2
-# is off at Kibana boot (kibana-ci.yml).
+# Sourced by the legacy risk engine cleanup and configure scripts. Init
+# needs risk_engine:risk_scoring, registered when
+# entityAnalyticsEntityStoreV2 is disabled at boot (kibana-ci.yml).
 
 KB_PROVISION_URL="${KB_URL:-http://127.0.0.1:5601}"
 KB_USER=elastic


### PR DESCRIPTION
Relates to #593. Bumps `@elastic/schemas` to 0.7.3 so configure sends PUT. schedule_now stays skipped on 9.5.3 (public path is still `/internal`).