### PR TITLE
fix(deps): update csv-parse to 7.0.2 (CVE-2026-85063) and allowlist gitleaks false positive

### DIFF
--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -9,3 +9,9 @@ regexes = [
   # Dummy Kibana encryption key in run-kb-tests.sh
   '''xP9mfMqnRrNHmSmzPoBtLQvLFzYdHxKj''',
 ]
+commits = [
+  # risk-engine-provision.sh on the ci/provision-risk-engine branch used the well-known
+  # "elastic:changeme" CI default before a follow-up commit switched to env-var-only form.
+  # gitleaks flags this historical commit when scanning the full repository history.
+  "050c857c2c1090bedd0c7a3c5df316edb000b099",
+]

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -862,7 +862,7 @@ THE SOFTWARE.
 
 
 ------------------------------------------------------------------------
-csv-parse@7.0.1
+csv-parse@7.0.2
 License: MIT
 Repository: https://github.com/adaltas/node-csv
 Publisher: David Worms <david@adaltas.com> (https://www.adaltas.com)

--- a/package-lock.json
+++ b/package-lock.json
@@ -22,7 +22,7 @@
         "cli-table3": "^0.6.5",
         "commander": "^15.0.0",
         "cross-spawn": "^7.0.6",
-        "csv-parse": "^7.0.0",
+        "csv-parse": "^7.0.2",
         "marked": "^18.0.0",
         "marked-terminal": "^7.3.0",
         "yaml": "^2.8.3"
@@ -2728,7 +2728,9 @@
       }
     },
     "node_modules/csv-parse": {
-      "version": "7.0.1",
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-7.0.2.tgz",
+      "integrity": "sha512-uKZghv9UmPkMVLYy//KZ9HFAIJsl7wkhoEdIL0+rhuSY9pZQlhaeGEDPIe+/w7eh81MOql8Q/9+inAGWG6ZHYA==",
       "license": "MIT"
     },
     "node_modules/dateformat": {

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "cli-table3": "^0.6.5",
     "commander": "^15.0.0",
     "cross-spawn": "^7.0.6",
-    "csv-parse": "^7.0.0",
+    "csv-parse": "^7.0.2",
     "marked": "^18.0.0",
     "marked-terminal": "^7.3.0",
     "yaml": "^2.8.3"


### PR DESCRIPTION
## What

Adds a gitleaks commit allowlist entry for commit `050c857c` on the `ci/provision-risk-engine` branch to fix the failing MegaLinter check on `main`.

## Why

MegaLinter/gitleaks scans the full repository commit history (452 commits, including commits from open PR branches). It flags commit `050c857c` on `ci/provision-risk-engine` because `risk-engine-provision.sh` in that commit used the well-known CI default credential placeholder `elastic:${ES_PASSWORD:-changeme}` in two `curl -u` calls.

A subsequent commit on that same branch already switched both curl calls to the env-var-only form (`"${KB_USER}:${ES_PASSWORD}"`), so the branch HEAD is clean. The flagged commit is a false positive — a known dummy credential used ubiquitously in Elastic CI test scripts.

## Impact

The failing gitleaks check causes the `CI Result` gate to fail on every push to `main` (confirmed across the two most recent merges: #611 and #612). This PR restores green CI on `main`.

## Change

- `.gitleaks.toml`: adds `commits = [...]` section with `050c857c` and an explanatory comment, following the [gitleaks recommended approach](https://github.com/gitleaks/gitleaks?tab=readme-ov-file#configuration) for historical false positives.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01DAY5FexfUtdP6mh9zfgBx9

---
_Generated by [Claude Code](https://claude.ai/code/session_01DAY5FexfUtdP6mh9zfgBx9)_