### PR TITLE
test: unskip slo get definitions on stack

### DIFF
--- a/codegen/functional/kb.ts
+++ b/codegen/functional/kb.ts
@@ -422,10 +422,8 @@ const skippedFilesStack = new Set<string>([
   "streams_get_streams_name_query.yml",
   "streams_put_streams_name_query.yml",
 
-  // No SLO definitions exist in the env (404); slo_bulk_snapshot and slo_get_snapshot
-  // depend on data that is never provisioned.
+  // 9.5.3 has no GET/POST /api/observability/slos/_snapshot routes (9.6).
   "slo_bulk_snapshot_op.yml",
-  "slo_get_definitions_op.yml",
   "slo_get_snapshot_op.yml",
 
   // Feature or route gated off in this stack config (404 / not available with

--- a/src/kb/request-builder.ts
+++ b/src/kb/request-builder.ts
@@ -34,6 +34,15 @@ export const MULTIPART_ENDPOINTS = new Set([
 ])
 
 /**
+ * OAS still documents these at `/internal`; Kibana 9.5+ registers `/api`.
+ * Keyed by `"<namespace> <name>"`. Delete an entry when `@elastic/schemas`
+ * publishes the public path.
+ */
+export const PATH_OVERRIDES = new Map([
+  ['slo get-definitions-op', '/s/{spaceId}/api/observability/slos/_definitions'],
+])
+
+/**
  * Builds a `KibanaRequestParams` from an API definition and parsed CLI input.
  *
  * Routing is derived from `x-found-in` in the JSON Schema properties:
@@ -53,7 +62,12 @@ export function buildKibanaRequestParams (
   const props = ((def.input?.['properties'] ?? {}) as Record<string, Record<string, unknown>>)
 
   const required = new Set(Array.isArray(def.input?.['required']) ? def.input!['required'] as string[] : [])
-  const path = interpolatePath(def.path, props, required, input)
+  const path = interpolatePath(
+    PATH_OVERRIDES.get(`${def.namespace} ${def.name}`) ?? def.path,
+    props,
+    required,
+    input
+  )
   const querystring = buildQuerystring(props, input)
 
   const params: KibanaRequestParams = { method: def.method, path }

--- a/test/kb/request-builder.test.ts
+++ b/test/kb/request-builder.test.ts
@@ -73,6 +73,31 @@ describe('buildKibanaRequestParams', () => {
     assert.deepEqual(stale, [], 'stale multipart endpoint keys')
   })
 
+  it('every PATH_OVERRIDES entry matches a real definition', async () => {
+    const { loadAllKbApis } = await import('../../src/kb/apis.ts')
+    const { PATH_OVERRIDES } = await import('../../src/kb/request-builder.ts')
+    const real = new Set((await loadAllKbApis()).map((d) => `${d.namespace} ${d.name}`))
+    const stale = [...PATH_OVERRIDES.keys()].filter((key) => !real.has(key))
+    assert.deepEqual(stale, [], 'stale path override keys')
+  })
+
+  it('sends get-definitions-op to /api not the schema /internal path', async () => {
+    const { loadAllKbApis } = await import('../../src/kb/apis.ts')
+    const def = (await loadAllKbApis()).find((d) => d.namespace === 'slo' && d.name === 'get-definitions-op')
+    assert.ok(def != null, 'expected slo get-definitions-op')
+    assert.match(def.path, /\/internal\//)
+    const result = buildKibanaRequestParams(def, parsed({ spaceId: 'default' }))
+    assert.equal(result.path, '/s/default/api/observability/slos/_definitions')
+  })
+
+  it('encodes adversarial spaceId on the get-definitions-op override', async () => {
+    const { loadAllKbApis } = await import('../../src/kb/apis.ts')
+    const def = (await loadAllKbApis()).find((d) => d.namespace === 'slo' && d.name === 'get-definitions-op')
+    assert.ok(def != null, 'expected slo get-definitions-op')
+    const result = buildKibanaRequestParams(def, parsed({ spaceId: '../?#/' }))
+    assert.equal(result.path, '/s/' + encodeURIComponent('../?#/') + '/api/observability/slos/_definitions')
+  })
+
   it('upstream schemas still emit no multipart/binary signal (delete MULTIPART_ENDPOINTS when they do)', async () => {
     const { loadAllKbApis } = await import('../../src/kb/apis.ts')
     const signals = ['contentMediaType', 'contentEncoding', 'x-content-type', 'x-body-format']


### PR DESCRIPTION
Relates to #595. Schema still hits /internal; 9.5.3 registers /api. Snapshot ops stay skipped, those routes are 9.6.