### PR TITLE
fix: keep keychain secret off argv

### DIFF
--- a/src/config/secret-store.ts
+++ b/src/config/secret-store.ts
@@ -18,7 +18,12 @@
  * read back by the corresponding resolver.
  */
 
-import { execSync, type ExecSyncOptionsWithStringEncoding } from 'node:child_process'
+import {
+  execSync,
+  spawnSync,
+  type ExecSyncOptionsWithStringEncoding,
+  type SpawnSyncOptionsWithStringEncoding,
+} from 'node:child_process'
 
 /** Distinguishes between the supported secret-store implementations. */
 export type SecretStoreKind =
@@ -89,11 +94,36 @@ function psEncodedCommand (expression: string): string {
   return `powershell -NoProfile -NonInteractive -EncodedCommand ${utf16le.toString('base64')}`
 }
 
+function redactSecret (message: string, secret: string): string {
+  return secret.length === 0 ? message : message.split(secret).join('[redacted]')
+}
+
+/**
+ * `security -w` with no password prompts (enter + retype). If the process has
+ * a controlling TTY it reads `/dev/tty` and ignores stdin. Drop the session
+ * with `setsid` so `/dev/tty` fails, then feed both prompt lines on stdin.
+ * The secret stays off argv (`ps` / `execSync` error text).
+ */
+const SETSID_PERL = '/usr/bin/perl'
+const SETSID_SCRIPT = 'use POSIX; POSIX::setsid(); exec { $ARGV[0] } @ARGV;'
+
+function spawnOpts (timeoutMs: number, input?: string): SpawnSyncOptionsWithStringEncoding & { input?: string } {
+  const opts: SpawnSyncOptionsWithStringEncoding & { input?: string } = {
+    encoding: 'utf-8',
+    timeout: timeoutMs,
+    stdio: ['pipe', 'pipe', 'pipe'],
+    windowsHide: true,
+  }
+  if (input !== undefined) opts.input = input
+  return opts
+}
+
 // ---------------------------------------------------------------------------
 // Test seams
 // ---------------------------------------------------------------------------
 
 let _execSync: typeof execSync = execSync
+let _spawnSync: typeof spawnSync = spawnSync
 let _platform: string = process.platform
 
 /** @internal */
@@ -101,6 +131,13 @@ export function _testSetExecSync (fn: typeof execSync): () => void {
   const prev = _execSync
   _execSync = fn
   return () => { _execSync = prev }
+}
+
+/** @internal */
+export function _testSetSpawnSync (fn: typeof spawnSync): () => void {
+  const prev = _spawnSync
+  _spawnSync = fn
+  return () => { _spawnSync = prev }
 }
 
 /** @internal */
@@ -145,16 +182,28 @@ class MacOSKeychainStore extends ShellSecretStore {
   async put (service: string, account: string, secret: string): Promise<void> {
     validateServiceAccount(service, account, this.kind)
     try {
-      // -U updates an existing entry in-place instead of failing.
-      // -w with no argument reads the password from stdin, keeping the secret
-      // out of the process argument list.
-      _execSync(
-        `security add-generic-password -U -s ${shellEscape(service)} -a ${shellEscape(account)} -w`,
-        execOpts(5_000, secret)
+      const result = _spawnSync(
+        SETSID_PERL,
+        [
+          '-e', SETSID_SCRIPT,
+          'security', 'add-generic-password', '-U',
+          '-s', service,
+          '-a', account,
+          '-w',
+        ],
+        spawnOpts(5_000, `${secret}\n${secret}\n`)
       )
+      if (result.error != null) throw result.error
+      if (result.status !== 0) {
+        const detail = String(result.stderr || result.stdout || `exit ${result.status}`).trim()
+        throw new Error(detail)
+      }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err)
-      throw new Error(`Keychain write failed for service="${service}", account="${account}": ${message}`, { cause: err })
+      throw new Error(
+        `Keychain write failed for service="${service}", account="${account}": ${redactSecret(message, secret)}`,
+        { cause: err }
+      )
     }
   }
 

--- a/test/cloud/credentials.test.ts
+++ b/test/cloud/credentials.test.ts
@@ -20,6 +20,7 @@ import {
 import type { JsonValue } from '../../src/factory.ts'
 import {
   _testSetExecSync as setSecretStoreExec,
+  _testSetSpawnSync as setSecretStoreSpawn,
   _testSetPlatform as setSecretStorePlatform,
 } from '../../src/config/secret-store.ts'
 
@@ -148,6 +149,10 @@ describe('applyCredentialPolicy', () => {
         calls.push({ cmd, options })
         return ''
       }) as unknown as typeof import('node:child_process').execSync))
+      restores.push(setSecretStoreSpawn(((file: string, args?: readonly string[], options?: unknown) => {
+        calls.push({ cmd: [file, ...(args ?? [])].join(' '), options })
+        return { status: 0, stdout: '', stderr: '', error: undefined, pid: 0, output: [null, '', ''], signal: null }
+      }) as unknown as typeof import('node:child_process').spawnSync))
     } else {
       restores.push(setSecretStorePlatform('linux'))
       restores.push(setSecretStoreExec(((cmd: string, options?: unknown) => {

--- a/test/config/secret-store.test.ts
+++ b/test/config/secret-store.test.ts
@@ -5,10 +5,12 @@
 
 import { describe, it, afterEach } from 'node:test'
 import assert from 'node:assert/strict'
-import type { execSync as ExecSyncFn } from 'node:child_process'
+import { spawnSync, type execSync as ExecSyncFn, type spawnSync as SpawnSyncFn } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
 import {
   getSecretStore,
   _testSetExecSync,
+  _testSetSpawnSync,
   _testSetPlatform,
   _testStores,
 } from '../../src/config/secret-store.ts'
@@ -33,6 +35,36 @@ function makeExec (
     }
     return ''
   }) as unknown as typeof ExecSyncFn
+  return { fn, calls }
+}
+
+interface SpawnCall { file: string; args: string[]; options: Record<string, unknown> | undefined }
+function makeSpawn (
+  handlers: Array<{ match: string; result?: Partial<{ status: number | null; stderr: string; stdout: string; error: Error }> }>
+): { fn: typeof SpawnSyncFn; calls: SpawnCall[] } {
+  const calls: SpawnCall[] = []
+  const fn = ((file: string, args?: string[], options?: Record<string, unknown>) => {
+    const argv = args ?? []
+    calls.push({ file, args: argv, options })
+    const joined = [file, ...argv].join(' ')
+    for (const h of handlers) {
+      if (joined.includes(h.match)) {
+        if (h.result?.error != null) {
+          return { status: null, stderr: '', stdout: '', error: h.result.error, pid: 0, output: [null, '', ''], signal: null }
+        }
+        return {
+          status: h.result?.status ?? 0,
+          stderr: h.result?.stderr ?? '',
+          stdout: h.result?.stdout ?? '',
+          error: undefined,
+          pid: 0,
+          output: [null, h.result?.stdout ?? '', h.result?.stderr ?? ''],
+          signal: null,
+        }
+      }
+    }
+    return { status: 0, stderr: '', stdout: '', error: undefined, pid: 0, output: [null, '', ''], signal: null }
+  }) as unknown as typeof SpawnSyncFn
   return { fn, calls }
 }
 
@@ -92,20 +124,22 @@ describe('MacOSKeychainStore', () => {
     while (restores.length > 0) restores.pop()!()
   })
 
-  it('put invokes `security add-generic-password -U` with shell-escaped values and passes secret via stdin', async () => {
-    const { fn, calls } = makeExec([{ match: 'security ', result: '' }])
-    restores.push(_testSetExecSync(fn))
+  it('put feeds the password on stdin after dropping the controlling TTY', async () => {
+    const { fn, calls } = makeSpawn([{ match: 'add-generic-password' }])
+    restores.push(_testSetSpawnSync(fn))
     const store = new _testStores.MacOSKeychainStore()
     await store.put('elastic-cli', 'prod:es.api_key', "it's secret")
-    const put = calls.find(c => c.cmd.includes('add-generic-password'))!
+    const put = calls.find(c => c.args.includes('add-generic-password'))!
     assert.ok(put)
-    assert.match(put.cmd, /-U /)
-    assert.match(put.cmd, /-s 'elastic-cli'/)
-    assert.match(put.cmd, /-a 'prod:es.api_key'/)
-    // Secret must NOT appear in the command string (would be visible in `ps`)
-    assert.ok(!put.cmd.includes("it's secret"), 'secret must not be in argv')
-    // Secret IS passed via stdin
-    assert.equal((put.options as { input?: string }).input, "it's secret")
+    assert.equal(put.file, '/usr/bin/perl')
+    assert.ok(put.args.includes('security'))
+    assert.ok(put.args.includes('-U'))
+    assert.deepEqual(
+      put.args.slice(put.args.indexOf('-s'), put.args.indexOf('-s') + 5),
+      ['-s', 'elastic-cli', '-a', 'prod:es.api_key', '-w']
+    )
+    assert.ok(!put.args.includes("it's secret"), 'secret must not be in argv')
+    assert.equal((put.options as { input?: string }).input, "it's secret\nit's secret\n")
   })
 
   it('delete swallows errors (idempotent)', async () => {
@@ -146,16 +180,75 @@ describe('MacOSKeychainStore', () => {
     await assert.rejects(() => store.put('svc', 'ac\u0000count', 'x'), /non-printable/)
   })
 
-  it('wraps underlying errors with context', async () => {
-    const { fn } = makeExec([
-      { match: 'security ', result: new Error('permission denied') },
+  it('wraps underlying errors with context and redacts the secret', async () => {
+    const { fn } = makeSpawn([
+      { match: 'add-generic-password', result: { status: 1, stderr: 'permission denied for hunter2' } },
     ])
-    restores.push(_testSetExecSync(fn))
+    restores.push(_testSetSpawnSync(fn))
     const store = new _testStores.MacOSKeychainStore()
     await assert.rejects(
-      () => store.put('svc', 'acct', 'x'),
-      /Keychain write failed for service="svc", account="acct".*permission denied/
+      () => store.put('svc', 'acct', 'hunter2'),
+      /Keychain write failed for service="svc", account="acct".*permission denied for \[redacted\]/
     )
+  })
+
+  it('put stores the password when a TTY is present', {
+    skip: process.platform !== 'darwin',
+  }, () => {
+    const account = `cli-tty-${process.pid}-${Date.now()}`
+    const secret = 'tty-secret-620'
+    const storePath = fileURLToPath(new URL('../../src/config/secret-store.ts', import.meta.url))
+    const childArgv = [
+      process.execPath,
+      '--import', 'tsx',
+      '--input-type=module',
+      '-e',
+      `
+        import { _testStores } from ${JSON.stringify(storePath)}
+        const store = new _testStores.MacOSKeychainStore()
+        await store.put('elastic-cli', ${JSON.stringify(account)}, ${JSON.stringify(secret)})
+      `,
+    ]
+    const py = `
+import os, pty, select, sys
+pid, fd = pty.fork()
+if pid == 0:
+    os.execvpe(${JSON.stringify(childArgv[0])}, ${JSON.stringify(childArgv)}, os.environ)
+status = None
+while True:
+    r, _, _ = select.select([fd], [], [], 0.1)
+    if r:
+        try:
+            data = os.read(fd, 4096)
+        except OSError:
+            break
+        if not data:
+            break
+        sys.stdout.buffer.write(data)
+        sys.stdout.buffer.flush()
+    wpid, st = os.waitpid(pid, os.WNOHANG)
+    if wpid != 0:
+        status = st
+        break
+if status is None:
+    status = os.waitpid(pid, 0)[1]
+os.close(fd)
+sys.exit(os.waitstatus_to_exitcode(status))
+`
+    const child = spawnSync('python3', ['-c', py], { encoding: 'utf-8', timeout: 15_000 })
+    try {
+      assert.equal(child.status, 0, `${child.stderr}\n${child.stdout}`)
+      assert.doesNotMatch(child.stdout + child.stderr, /password data for new item/)
+      const stored = spawnSync(
+        'security',
+        ['find-generic-password', '-s', 'elastic-cli', '-a', account, '-w'],
+        { encoding: 'utf-8' }
+      )
+      assert.equal(stored.status, 0, stored.stderr)
+      assert.equal(stored.stdout.replace(/\n$/, ''), secret)
+    } finally {
+      spawnSync('security', ['delete-generic-password', '-s', 'elastic-cli', '-a', account])
+    }
   })
 })
 


### PR DESCRIPTION
Drop the controlling TTY with setsid, then feed the password twice on stdin. Secret stays off argv. Relates to #620 and #515.