### PR TITLE
ci: run unit tests without child process isolation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,11 @@ jobs:
     # but tsc build still peaks around 3.7 GB locally; keep headroom above
     # the 2 GB Node default for slower/smaller CI runners.
     env:
-      NODE_OPTIONS: --max-old-space-size=6144
+      # `--test-isolation=none` sidesteps a flaky node:test parent/child IPC
+      # deserialize crash (nodejs/node#64061). The flag only exists on Node 24+,
+      # so it is omitted on 22.x, which still passes under default (process)
+      # isolation.
+      NODE_OPTIONS: --max-old-space-size=6144 ${{ matrix.node-version != '22.x' && '--test-isolation=none' || '' }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7
         with:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -150,6 +150,7 @@ After every implementation change:
 9. Never add special cases or dead code in production code solely to satisfy a bad test. Fix the test instead.
 10. Test all code paths: missing input, empty input, null, wrong types, boundary values, HTTP error codes, redirects, timeouts.
 11. Run the code you wrote. For a CLI command, run it. For a request builder, trace the actual HTTP request.
+12. In CI, all tests must pass on all JS runtime versions declared in the package.json `engines` field. If you have access `mise`, `nvm`, `asdf`, etc. to validate your changes by running tests on multiple versions of Node, do that during your final pass. If you do not, make a best-effort attempt to support them all using whatever knowledge you have access to about them.
 
 ## Security Checklist
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3887,9 +3887,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-      "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "dev": true,
       "funding": [
         {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build": "node --max-old-space-size=8192 node_modules/typescript/bin/tsc -b",
     "postbuild": "node scripts/create-dist-package-jsons.mjs",
     "test": "npm run build && npm run test:unit && npm run test:license",
-    "test:unit": "node --max-old-space-size=8192 --import tsx/esm --test --test-timeout=60000 --experimental-test-coverage --test-coverage-lines=90 --test-coverage-branches=90 --test-coverage-functions=90 --test-coverage-include='src/**/*.ts' --test-coverage-include='packages/*/src/**/*.ts' --test-coverage-exclude='src/es/api-manifest.ts' --test-coverage-exclude='src/cloud/serverless-apis.ts' --test-coverage-exclude='node_modules/**'",
+    "test:unit": "node --max-old-space-size=8192 --import tsx/esm --import ./test/setup-non-interactive.ts --test --test-isolation=none --test-timeout=60000 --experimental-test-coverage --test-coverage-lines=90 --test-coverage-branches=90 --test-coverage-functions=90 --test-coverage-include='src/**/*.ts' --test-coverage-include='packages/*/src/**/*.ts' --test-coverage-exclude='src/es/api-manifest.ts' --test-coverage-exclude='src/cloud/serverless-apis.ts' --test-coverage-exclude='node_modules/**'",
     "test:lint": "eslint src packages test",
     "codegen:functional": "npx tsx codegen/functional/es.ts --tests-dir ../elasticsearch-clients-tests/tests",
     "codegen:functional:kb": "rm -rf test/functional/kb/generated && npx tsx codegen/functional/kb.ts",

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "build": "node --max-old-space-size=8192 node_modules/typescript/bin/tsc -b",
     "postbuild": "node scripts/create-dist-package-jsons.mjs",
     "test": "npm run build && npm run test:unit && npm run test:license",
-    "test:unit": "node --max-old-space-size=8192 --import tsx/esm --import ./test/setup-non-interactive.ts --test --test-isolation=none --test-timeout=60000 --experimental-test-coverage --test-coverage-lines=90 --test-coverage-branches=90 --test-coverage-functions=90 --test-coverage-include='src/**/*.ts' --test-coverage-include='packages/*/src/**/*.ts' --test-coverage-exclude='src/es/api-manifest.ts' --test-coverage-exclude='src/cloud/serverless-apis.ts' --test-coverage-exclude='node_modules/**'",
+    "test:unit": "node --max-old-space-size=8192 --import tsx/esm --import ./test/setup-non-interactive.ts --test --test-timeout=60000 --experimental-test-coverage --test-coverage-lines=90 --test-coverage-branches=90 --test-coverage-functions=90 --test-coverage-include='src/**/*.ts' --test-coverage-include='packages/*/src/**/*.ts' --test-coverage-exclude='src/es/api-manifest.ts' --test-coverage-exclude='src/cloud/serverless-apis.ts' --test-coverage-exclude='node_modules/**'",
     "test:lint": "eslint src packages test",
     "codegen:functional": "npx tsx codegen/functional/es.ts --tests-dir ../elasticsearch-clients-tests/tests",
     "codegen:functional:kb": "rm -rf test/functional/kb/generated && npx tsx codegen/functional/kb.ts",

--- a/package.json
+++ b/package.json
@@ -55,6 +55,10 @@
     "dist",
     "NOTICE.txt"
   ],
+  "engines": {
+    "node": ">=22.0.0",
+    "bun": ">=1.2.0"
+  },
   "directories": {
     "test": "test"
   },

--- a/test/config/writer.test.ts
+++ b/test/config/writer.test.ts
@@ -18,6 +18,8 @@ import {
   extractContext,
   emptyConfig,
   serializeConfig,
+  hasInlineSecrets,
+  resolveConfigPath,
   type RawConfig,
 } from '../../src/config/writer.ts'
 
@@ -201,5 +203,107 @@ describe('readRawConfig', () => {
     })
     const raw = await readRawConfig(path)
     assert.deepEqual(raw.commands, { allowed: ['cloud.*'] })
+  })
+})
+
+describe('hasInlineSecrets', () => {
+  it('returns true for an inline api_key', () => {
+    assert.equal(hasInlineSecrets(SAMPLE), true)
+  })
+
+  it('returns false when secrets use $(...) resolver expressions', () => {
+    const cfg: RawConfig = {
+      current_context: 'x',
+      contexts: { x: { elasticsearch: { auth: { api_key: '$(keychain:elastic-cli/x:es.api_key)' } } } },
+    }
+    assert.equal(hasInlineSecrets(cfg), false)
+  })
+
+  it('returns false when no auth secrets are present', () => {
+    const cfg: RawConfig = {
+      current_context: 'x',
+      contexts: { x: { elasticsearch: { url: 'http://localhost:9200' } } },
+    }
+    assert.equal(hasInlineSecrets(cfg), false)
+  })
+
+  it('ignores non-secret auth fields', () => {
+    const cfg: RawConfig = {
+      current_context: 'x',
+      contexts: { x: { elasticsearch: { auth: { username: 'elastic' } } } },
+    }
+    assert.equal(hasInlineSecrets(cfg), false)
+  })
+
+  it('skips malformed context/block/auth shapes without throwing', () => {
+    const cfg = {
+      current_context: 'x',
+      contexts: {
+        a: null,
+        b: { elasticsearch: null },
+        c: { elasticsearch: { auth: 'not-an-object' } },
+        d: { elasticsearch: { auth: { api_key: '' } } },
+      },
+    } as unknown as RawConfig
+    assert.equal(hasInlineSecrets(cfg), false)
+  })
+})
+
+describe('resolveConfigPath', () => {
+  it('prefers an explicit non-empty path', () => {
+    assert.equal(resolveConfigPath('/tmp/explicit.yml'), '/tmp/explicit.yml')
+  })
+
+  it('falls back to ELASTIC_CLI_CONFIG_FILE when no explicit path is given', () => {
+    const prev = process.env.ELASTIC_CLI_CONFIG_FILE
+    process.env.ELASTIC_CLI_CONFIG_FILE = '/tmp/from-env.yml'
+    try {
+      assert.equal(resolveConfigPath(), '/tmp/from-env.yml')
+      assert.equal(resolveConfigPath(''), '/tmp/from-env.yml')
+    } finally {
+      if (prev === undefined) delete process.env.ELASTIC_CLI_CONFIG_FILE
+      else process.env.ELASTIC_CLI_CONFIG_FILE = prev
+    }
+  })
+
+  it('defaults to ~/.elasticrc.yml when nothing else is set', () => {
+    const prev = process.env.ELASTIC_CLI_CONFIG_FILE
+    delete process.env.ELASTIC_CLI_CONFIG_FILE
+    try {
+      assert.match(resolveConfigPath(), /\.elasticrc\.yml$/)
+    } finally {
+      if (prev !== undefined) process.env.ELASTIC_CLI_CONFIG_FILE = prev
+    }
+  })
+})
+
+describe('serializeConfig — optional top-level keys', () => {
+  it('includes banner and telemetry when set and passes through extra keys', () => {
+    const cfg = {
+      current_context: 'x',
+      contexts: {},
+      banner: false,
+      telemetry: true,
+      custom_extra: { note: 'kept' },
+    } as unknown as RawConfig
+    const parsed = parseYaml(serializeConfig(cfg)) as Record<string, unknown>
+    assert.equal(parsed.banner, false)
+    assert.equal(parsed.telemetry, true)
+    assert.deepEqual(parsed.custom_extra, { note: 'kept' })
+  })
+})
+
+describe('readRawConfig — coercion', () => {
+  let dir: string
+  before(async () => { dir = await mkdtemp(join(tmpdir(), 'elastic-cli-coerce-')) })
+  after(async () => rm(dir, { recursive: true, force: true }))
+
+  it('preserves banner/telemetry booleans and defaults a non-string current_context', async () => {
+    const path = join(dir, 'coerce.yml')
+    await writeFile(path, 'current_context: 123\nbanner: false\ntelemetry: true\ncontexts: {}\n')
+    const raw = await readRawConfig(path)
+    assert.equal(raw.current_context, '')
+    assert.equal(raw.banner, false)
+    assert.equal(raw.telemetry, true)
   })
 })

--- a/test/docs/read.test.ts
+++ b/test/docs/read.test.ts
@@ -79,4 +79,38 @@ describe('createReadCommand', () => {
     assert.equal(process.exitCode, 1)
     process.exitCode = 0 // reset
   })
+
+  it('returns missing_input error when no path is given', async () => {
+    let err = ''
+    const cmd = createReadCommand({
+      resolveDocsPath: async (input) => input,
+      docsRead: async () => '# unused',
+      stdout: { write: () => true },
+    })
+    cmd.exitOverride()
+    cmd.configureOutput({ writeErr: (s) => { err += s } })
+    const restoreStdin = _testSetStdinReader(() => '')
+    try {
+      await cmd.parseAsync([], { from: 'user' })
+    } catch { /* exitOverride on error result */ } finally { restoreStdin() }
+    assert.match(err, /path is required/)
+    process.exitCode = 0
+  })
+
+  it('surfaces a non-Error thrown value via String(err)', async () => {
+    let err = ''
+    const cmd = createReadCommand({
+      resolveDocsPath: async (input) => input,
+      docsRead: async () => { throw 'plain string failure' },
+      stdout: { write: () => true },
+    })
+    cmd.exitOverride()
+    cmd.configureOutput({ writeErr: (s) => { err += s } })
+    const restoreStdin = _testSetStdinReader(() => '')
+    try {
+      await cmd.parseAsync(['--path', '/bad-path'], { from: 'user' })
+    } catch { /* exitOverride on error result */ } finally { restoreStdin() }
+    assert.match(err, /plain string failure/)
+    process.exitCode = 0
+  })
 })

--- a/test/lib/sanitize.test.ts
+++ b/test/lib/sanitize.test.ts
@@ -376,3 +376,55 @@ describe('sanitizeRepositoryName', () => {
     assert.equal(r.sanitized, 'myrepo')
   })
 })
+
+// ---------------------------------------------------------------------------
+// Empty-after-sanitization vs empty-input branches
+//
+// Exercises both arms of the shared `s.length === 0 && value.length > 0`
+// guard: a non-empty input reduced to nothing (flags the change) and an
+// already-empty input (no change flagged).
+// ---------------------------------------------------------------------------
+
+describe('empty results across sanitizers', () => {
+  it('does not flag an already-empty index name', () => {
+    const r = sanitizeIndexName('')
+    assert.equal(r.sanitized, '')
+    assert.deepEqual(r.changes, [])
+  })
+
+  it('flags a snapshot name reduced to empty', () => {
+    const r = sanitizeSnapshotName('***')
+    assert.equal(r.sanitized, '')
+    assert.ok(r.changes.some(c => /empty/i.test(c)))
+  })
+
+  it('does not flag an already-empty snapshot name', () => {
+    const r = sanitizeSnapshotName('')
+    assert.equal(r.sanitized, '')
+    assert.deepEqual(r.changes, [])
+  })
+
+  it('flags a data stream type reduced to empty', () => {
+    const r = sanitizeDataStreamType('***')
+    assert.equal(r.sanitized, '')
+    assert.ok(r.changes.some(c => /empty/i.test(c)))
+  })
+
+  it('does not flag an already-empty data stream namespace', () => {
+    const r = sanitizeDataStreamNamespace('')
+    assert.equal(r.sanitized, '')
+    assert.deepEqual(r.changes, [])
+  })
+
+  it('flags a repository name reduced to empty', () => {
+    const r = sanitizeRepositoryName('///')
+    assert.equal(r.sanitized, '')
+    assert.ok(r.changes.some(c => /empty/i.test(c)))
+  })
+
+  it('does not flag an already-empty repository name', () => {
+    const r = sanitizeRepositoryName('')
+    assert.equal(r.sanitized, '')
+    assert.deepEqual(r.changes, [])
+  })
+})

--- a/test/setup-non-interactive.ts
+++ b/test/setup-non-interactive.ts
@@ -1,0 +1,23 @@
+/*
+ * Copyright Elasticsearch B.V. and contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * Global test setup: force the confirmation guard onto its non-TTY,
+ * fail-closed path for the whole run.
+ *
+ * With `--test-isolation=none` every test file shares one process and
+ * inherits the real terminal's stdin. A destructive command test that does
+ * not override the TTY seam would otherwise reach `promptConfirm()`, open a
+ * readline on the interactive stdin, and block forever waiting for `y/N`
+ * (e.g. `extension remove`). Under the previous per-file process isolation
+ * each child had a non-TTY stdin, so this never surfaced.
+ *
+ * Tests that need the interactive path still override the seam locally via
+ * `_testSetIsTTY(true)` and restore to this `false` default afterwards.
+ */
+
+import { _testSetIsTTY } from '../src/factory.ts'
+
+_testSetIsTTY(false)


### PR DESCRIPTION
Adjusts `test:unit` npm script to run unit tests without using child process isolation. Increases the potential for tests' state changes to collide with each other, but reduces the chances of flakiness when run in GitHub actions.

Also increases test coverage to stay above our minimum threshold.
